### PR TITLE
Image conversion

### DIFF
--- a/ui/src/app/services/client-media/client-media.spec.ts
+++ b/ui/src/app/services/client-media/client-media.spec.ts
@@ -16,16 +16,16 @@
 
 import {TestBed} from '@angular/core/testing';
 import {beforeEach, describe, expect, it} from 'vitest';
-import {GenerateThumbnailService} from './generate-thumbnail';
+import {ClientMediaService} from './client-media';
 
-describe('GenerateThumbnailService', () => {
-  let service: GenerateThumbnailService;
+describe('ClientMediaService', () => {
+  let service: ClientMediaService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [GenerateThumbnailService],
+      providers: [ClientMediaService],
     });
-    service = TestBed.inject(GenerateThumbnailService);
+    service = TestBed.inject(ClientMediaService);
   });
 
   it('should be created', () => {

--- a/ui/src/app/services/client-media/client-media.ts
+++ b/ui/src/app/services/client-media/client-media.ts
@@ -17,13 +17,15 @@
 import {Injectable} from '@angular/core';
 
 /**
- * Service for generating thumbnails from video URLs on the frontend.
+ * Service for transforming media using canvas, e.g. for generating thumbnails.
  */
 @Injectable({
   providedIn: 'root',
 })
-export class GenerateThumbnailService {
+export class ClientMediaService {
   constructor() {}
+
+  private readonly defaultMimeType = 'image/jpeg';
 
   private canvasFromMedia(
     src: HTMLImageElement | HTMLVideoElement,
@@ -86,16 +88,17 @@ export class GenerateThumbnailService {
    * @param options.maxHeight Optional maximum height for the thumbnail.
    * @returns A Promise that resolves with the data URL of the thumbnail image.
    */
-  generateThumbnailFromVideo(
+  convertVideo(
     videoSource: string | File | Blob,
     options: {
       seekTimeSeconds: number;
+      mimeType?: string;
+      quality?: number;
       maxWidth?: number;
       maxHeight?: number;
       blur?: number;
     } = {seekTimeSeconds: 1},
   ): Promise<Blob> {
-    const {seekTimeSeconds} = options;
     return new Promise((resolve, reject) => {
       const video = document.createElement('video');
       video.crossOrigin = 'anonymous';
@@ -111,18 +114,22 @@ export class GenerateThumbnailService {
       video.muted = true;
 
       video.onloadedmetadata = () => {
-        video.currentTime = seekTimeSeconds;
+        video.currentTime = options.seekTimeSeconds;
       };
 
       video.onseeked = () => {
         try {
           const canvas = this.canvasFromMedia(video, options);
-          canvas.toBlob(blob => {
-            if (!blob) {
-              throw new Error('Failed to generate thumbnail');
-            }
-            resolve(blob);
-          });
+          canvas.toBlob(
+            blob => {
+              if (!blob) {
+                throw new Error('Failed to generate thumbnail');
+              }
+              resolve(blob);
+            },
+            options.mimeType || this.defaultMimeType,
+            options.quality,
+          );
         } catch (error) {
           reject(error);
         } finally {
@@ -145,13 +152,15 @@ export class GenerateThumbnailService {
     });
   }
 
-  generateThumbnailFromImage(
+  convertImage(
     imageSrc: string | File | Blob,
     options: {
-      maxWidth: number;
-      maxHeight: number;
+      mimeType?: string;
+      quality?: number;
+      maxWidth?: number;
+      maxHeight?: number;
       blur?: number;
-    },
+    } = {},
   ): Promise<Blob> {
     return new Promise<Blob>((resolve, reject) => {
       const imageElement = document.createElement('img');
@@ -167,13 +176,22 @@ export class GenerateThumbnailService {
 
       imageElement.onload = () => {
         try {
-          const canvas = this.canvasFromMedia(imageElement, options);
-          canvas.toBlob(blob => {
-            if (!blob) {
-              throw new Error('Failed to generate thumbnail');
-            }
-            resolve(blob);
+          const canvas = this.canvasFromMedia(imageElement, {
+            maxWidth: options.maxWidth,
+            maxHeight: options.maxHeight,
+            blur: options.blur,
           });
+
+          canvas.toBlob(
+            blob => {
+              if (!blob) {
+                throw new Error('Failed to convert image');
+              }
+              resolve(blob);
+            },
+            options.mimeType || this.defaultMimeType,
+            options.quality,
+          );
         } catch (error) {
           reject(error);
         } finally {
@@ -208,12 +226,17 @@ export class GenerateThumbnailService {
 
   toFile(
     blob: Blob,
-    options: {mimeType: string; fileName: string} = {
-      mimeType: 'image/jpeg',
-      fileName: 'thumbnail.jpg',
-    },
+    options: {mimeType?: string; fileName?: string} = {},
   ): File {
-    return new File([blob], options.fileName, {type: options.mimeType});
+    const mimeType = options.mimeType || blob.type || this.defaultMimeType;
+    let fileName = options.fileName;
+
+    if (!fileName) {
+      const extension = mimeType.split('/')[1];
+      fileName = `thumbnail.${extension}`;
+    }
+
+    return new File([blob], fileName, {type: mimeType});
   }
 
   generateLowQualityThumbnail(
@@ -221,14 +244,14 @@ export class GenerateThumbnailService {
     type: 'video' | 'image',
   ) {
     if (type === 'video') {
-      return this.generateThumbnailFromVideo(src, {
+      return this.convertVideo(src, {
         seekTimeSeconds: 1,
         maxWidth: 20,
         maxHeight: 20,
         blur: 2,
       });
     } else if (type === 'image') {
-      return this.generateThumbnailFromImage(src, {
+      return this.convertImage(src, {
         maxWidth: 20,
         maxHeight: 20,
         blur: 2,
@@ -243,14 +266,14 @@ export class GenerateThumbnailService {
     type: 'video' | 'image',
   ) {
     if (type === 'video') {
-      return this.generateThumbnailFromVideo(src, {
+      return this.convertVideo(src, {
         seekTimeSeconds: 1,
         maxWidth: 500,
         maxHeight: 500,
       });
     }
     if (type === 'image') {
-      return this.generateThumbnailFromImage(src, {
+      return this.convertImage(src, {
         maxWidth: 500,
         maxHeight: 500,
       });

--- a/ui/src/app/services/client-media/client-media.ts
+++ b/ui/src/app/services/client-media/client-media.ts
@@ -78,17 +78,7 @@ export class ClientMediaService {
     return canvas;
   }
 
-  /**
-   * Generates a thumbnail from a video URL with optional size constraints.
-   *
-   * @param videoUrl The URL of the video.
-   * @param options Optional parameters for the thumbnail generation.
-   * @param options.seekTimeSeconds The time in seconds to extract the frame from. Defaults to 1.
-   * @param options.maxWidth Optional maximum width for the thumbnail.
-   * @param options.maxHeight Optional maximum height for the thumbnail.
-   * @returns A Promise that resolves with the data URL of the thumbnail image.
-   */
-  convertVideo(
+  convertVideoToImage(
     videoSource: string | File | Blob,
     options: {
       seekTimeSeconds: number;
@@ -244,7 +234,7 @@ export class ClientMediaService {
     type: 'video' | 'image',
   ) {
     if (type === 'video') {
-      return this.convertVideo(src, {
+      return this.convertVideoToImage(src, {
         seekTimeSeconds: 1,
         maxWidth: 20,
         maxHeight: 20,
@@ -266,7 +256,7 @@ export class ClientMediaService {
     type: 'video' | 'image',
   ) {
     if (type === 'video') {
-      return this.convertVideo(src, {
+      return this.convertVideoToImage(src, {
         seekTimeSeconds: 1,
         maxWidth: 500,
         maxHeight: 500,

--- a/ui/src/app/services/remix-engine/remix-engine.ts
+++ b/ui/src/app/services/remix-engine/remix-engine.ts
@@ -32,6 +32,7 @@ import {
 } from '@angular/fire/storage';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {filter, firstValueFrom, Observable, repeat, retry, tap} from 'rxjs';
+import {ClientMediaService} from '../client-media/client-media';
 import {
   ASPECT_RATIO_DEVIATION_THRESHOLD,
   AudioTrack,
@@ -46,7 +47,6 @@ import {
   Resolution,
   VisualOverlay,
 } from '../config/config';
-import {GenerateThumbnailService} from '../generate-thumbnail/generate-thumbnail';
 import {
   CombineVideoArrangement as CombineScenesArrangement,
   CombineScenesWorkflowParameters,
@@ -76,7 +76,7 @@ export class RemixEngineService {
   private httpClient = inject(HttpClient);
   private injector = inject(EnvironmentInjector);
   private storage = inject(Storage);
-  private thumbnailService = inject(GenerateThumbnailService);
+  private clientMediaService = inject(ClientMediaService);
 
   private startWorkflow(
     workflowDefinition: object,
@@ -571,16 +571,16 @@ export class RemixEngineService {
             return getDownloadURL(reference);
           });
 
-          const lowQualityThumbnail = await this.thumbnailService
+          const lowQualityThumbnail = await this.clientMediaService
             .generateLowQualityThumbnail(url, 'video')
-            .then(blob => this.thumbnailService.toBase64(blob))
+            .then(blob => this.clientMediaService.toBase64(blob))
             .catch(e => {
               console.log(e);
               return undefined;
             });
-          const highQualityThumbnail = await this.thumbnailService
+          const highQualityThumbnail = await this.clientMediaService
             .generateHighQualityThumbnail(url, 'video')
-            .then(blob => this.thumbnailService.toFile(blob))
+            .then(blob => this.clientMediaService.toFile(blob))
             .then(file => this.uploadThumbnail(file))
             .catch(e => {
               console.log(e);

--- a/ui/src/app/setup/setup.html
+++ b/ui/src/app/setup/setup.html
@@ -177,7 +177,7 @@
                         #fileInput
                         type="file"
                         multiple
-                        accept="image/*"
+                        accept=".avif,.jpg,.jpeg,.png,.webp"
                         class="hidden-file-input"
                         (change)="onFileSelected($event, product.id)"
                       />

--- a/ui/src/app/setup/setup.ts
+++ b/ui/src/app/setup/setup.ts
@@ -41,6 +41,7 @@ import {MatSliderModule} from '@angular/material/slider';
 import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {ActivatedRoute, Router, RouterLink} from '@angular/router';
+import {ClientMediaService} from '../services/client-media/client-media';
 import {
   ASPECT_RATIO_DEVIATION_THRESHOLD,
   AspectRatio,
@@ -95,6 +96,7 @@ export class Setup {
   private readonly route = inject(ActivatedRoute);
   private readonly snackBar = inject(MatSnackBar);
   readonly config = inject(ConfigService);
+  readonly clientMediaService = inject(ClientMediaService);
   readonly templatesService = inject(TemplatesService);
   readonly auth = inject(Auth);
 
@@ -288,6 +290,19 @@ export class Setup {
     void Promise.all(
       fileArray.map(async file => {
         if (file.type.startsWith('image/')) {
+          if (!['image/jpeg', 'image/png', 'image/jpg'].includes(file.type)) {
+            const newFileName =
+              file.name.split('.').slice(0, -1).join('.') + '.jpeg';
+            file = new File(
+              [
+                await this.clientMediaService.convertImage(file, {
+                  mimeType: 'image/jpeg',
+                }),
+              ],
+              newFileName,
+              {type: 'image/jpeg'},
+            );
+          }
           const {path, url} = await this.remixEngineService.uploadMedia(file);
           return {
             path,

--- a/ui/src/app/storyboard/storyboard.html
+++ b/ui/src/app/storyboard/storyboard.html
@@ -697,7 +697,7 @@
                           <input
                             #fileInput
                             type="file"
-                            accept="image/*"
+                            accept=".avif,.jpg,.jpeg,.png,.webp"
                             class="hidden-file-input"
                             (change)="onFileSelected($event)"
                           />

--- a/ui/src/app/storyboard/storyboard.ts
+++ b/ui/src/app/storyboard/storyboard.ts
@@ -46,13 +46,13 @@ import {MatSlideToggleModule} from '@angular/material/slide-toggle';
 import {MatSliderModule} from '@angular/material/slider';
 import {MatTabsModule} from '@angular/material/tabs';
 import {MatTooltipModule} from '@angular/material/tooltip';
+import {ClientMediaService} from '../services/client-media/client-media';
 import {
   ConfigService,
   GeneratedScene,
   ProvidedVideoScene,
   toDecimals,
 } from '../services/config/config';
-import {GenerateThumbnailService} from '../services/generate-thumbnail/generate-thumbnail';
 import {RemixEngineService} from '../services/remix-engine/remix-engine';
 import {
   AddSceneDialog,
@@ -96,7 +96,7 @@ export class Storyboard {
   config = inject(ConfigService);
   protected remixEngineService = inject(RemixEngineService);
   private dialog = inject(MatDialog);
-  private generateThumbnailService = inject(GenerateThumbnailService);
+  private clientMediaService = inject(ClientMediaService);
 
   videoElement = viewChild<ElementRef<HTMLVideoElement>>('mainVideo');
   timelineTrack = viewChild<ElementRef<HTMLElement>>('timelineTrack');
@@ -518,12 +518,12 @@ export class Storyboard {
             path: uploadResult.path,
           };
           scene.durationSeconds = duration;
-          scene.lowQualityThumbnail = await this.generateThumbnailService
+          scene.lowQualityThumbnail = await this.clientMediaService
             .generateLowQualityThumbnail(result.file, 'video')
-            .then(blob => this.generateThumbnailService.toBase64(blob));
-          scene.highQualityThumbnail = await this.generateThumbnailService
+            .then(blob => this.clientMediaService.toBase64(blob));
+          scene.highQualityThumbnail = await this.clientMediaService
             .generateHighQualityThumbnail(result.file, 'video')
-            .then(blob => this.generateThumbnailService.toFile(blob))
+            .then(blob => this.clientMediaService.toFile(blob))
             .then(file => this.remixEngineService.uploadThumbnail(file));
           this.updateScenes(scene);
         }
@@ -648,6 +648,22 @@ export class Storyboard {
     console.log('Upload triggered for file:', file.name);
     const sceneId = this.selectedSceneId();
     if (this.config.isGeneratedScene(this.selectedScene()) && sceneId) {
+      if (
+        file.type.startsWith('image/') &&
+        !['image/jpeg', 'image/png', 'image/jpg'].includes(file.type)
+      ) {
+        const newFileName =
+          file.name.split('.').slice(0, -1).join('.') + '.jpeg';
+        file = new File(
+          [
+            await this.clientMediaService.convertImage(file, {
+              mimeType: 'image/jpeg',
+            }),
+          ],
+          newFileName,
+          {type: 'image/jpeg'},
+        );
+      }
       const {path, url} = await this.remixEngineService.uploadMedia(file);
       const scene = this.config.projectConfig
         .value()
@@ -657,21 +673,21 @@ export class Storyboard {
         try {
           const [lowQualityThumbnail, highQualityThumbnail] = await Promise.all(
             [
-              this.generateThumbnailService.generateLowQualityThumbnail(
+              this.clientMediaService.generateLowQualityThumbnail(
                 file,
                 'image',
               ),
-              this.generateThumbnailService.generateHighQualityThumbnail(
+              this.clientMediaService.generateHighQualityThumbnail(
                 file,
                 'image',
               ),
             ],
           );
           scene.lowQualityThumbnail =
-            await this.generateThumbnailService.toBase64(lowQualityThumbnail);
+            await this.clientMediaService.toBase64(lowQualityThumbnail);
           scene.highQualityThumbnail =
             await this.remixEngineService.uploadThumbnail(
-              this.generateThumbnailService.toFile(highQualityThumbnail),
+              this.clientMediaService.toFile(highQualityThumbnail),
             );
         } catch (error) {
           console.log(error);


### PR DESCRIPTION
Modify old "ThumbnailService" to also cover cases for image conversion, and rename to "ClientMediaService". Additionally, block users from uploading image types other than JPEG, PNG, AVIF or WEBP.