### PR TITLE
feat: homepage - add floating theme and mode picker and made headline

### DIFF
--- a/ui/src/app/homepage/homepage.html
+++ b/ui/src/app/homepage/homepage.html
@@ -127,4 +127,48 @@
       }
     </div>
   </div>
+
+  <div class="floating-theme-controls">
+    <button mat-icon-button [matMenuTriggerFor]="themeMenu" title="Theme Picker">
+      <mat-icon>palette</mat-icon>
+    </button>
+
+    <mat-menu #themeMenu="matMenu" yPosition="above" class="theme-picker-panel">
+      <div class="color-picker-container">
+        <button
+          class="color-swatch theme-azure"
+          (click)="primaryColor.set('theme-azure')"
+          title="Azure"
+        ></button>
+        <button
+          class="color-swatch theme-magenta"
+          (click)="primaryColor.set('theme-magenta')"
+          title="Magenta"
+        ></button>
+        <button
+          class="color-swatch theme-green"
+          (click)="primaryColor.set('theme-green')"
+          title="Green"
+        ></button>
+        <button
+          class="color-swatch theme-orange"
+          (click)="primaryColor.set('theme-orange')"
+          title="Orange"
+        ></button>
+        <button
+          class="color-swatch theme-violet"
+          (click)="primaryColor.set('theme-violet')"
+          title="Violet"
+        ></button>
+      </div>
+    </mat-menu>
+
+    <button
+      mat-icon-button
+      (click)="theme.set(theme() === 'light-mode' ? 'dark-mode' : 'light-mode')"
+      [title]="theme() === 'light-mode' ? 'Switch to Dark Mode' : 'Switch to Light Mode'"
+    >
+      <mat-icon>{{ theme() === 'light-mode' ? 'dark_mode' : 'light_mode' }}</mat-icon>
+    </button>
+  </div>
 </div>

--- a/ui/src/app/homepage/homepage.scss
+++ b/ui/src/app/homepage/homepage.scss
@@ -31,18 +31,21 @@
     font-size: 64px;
     font-weight: 900;
     margin: 0;
-    background: linear-gradient(
-      135deg,
-      var(--mat-sys-primary) 0%,
-      var(--mat-sys-secondary) 100%
-    );
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
     letter-spacing: -0.02em;
     padding: 10px 0;
     line-height: 1.2;
     margin-bottom: 4px;
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+    background-image: linear-gradient(
+      90deg,
+      #89b4f8 0%,
+      #4285f4 35%,
+      #6c5ce7 70%,
+      #4752c4 100%
+    );
   }
 
   .subtitle {
@@ -409,4 +412,48 @@
   width: 16px;
   height: 16px;
   color: #9e9e9e;
+}
+
+.floating-theme-controls {
+  position: fixed;
+  bottom: 24px;
+  left: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 100;
+  background: var(--mat-sys-surface-container);
+  padding: 8px;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+
+  button {
+    color: var(--mat-sys-on-surface-variant);
+    &:hover {
+      color: var(--mat-sys-primary);
+    }
+  }
+}
+
+.color-picker-container {
+  display: flex;
+  gap: 8px;
+  padding: 12px;
+  justify-content: center;
+  border-radius: 8px;
+}
+
+.color-swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  background-color: var(--mat-sys-primary);
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: scale(1.2);
+  }
 }

--- a/ui/src/app/homepage/homepage.ts
+++ b/ui/src/app/homepage/homepage.ts
@@ -27,6 +27,7 @@ import {MatButtonModule} from '@angular/material/button';
 import {MatCardModule} from '@angular/material/card';
 import {MatDialog, MatDialogModule} from '@angular/material/dialog';
 import {MatIconModule} from '@angular/material/icon';
+import {MatMenuModule} from '@angular/material/menu';
 import {MatSlideToggleModule} from '@angular/material/slide-toggle';
 import {RouterModule} from '@angular/router';
 import {
@@ -49,6 +50,7 @@ import {ConfirmProjectDeleteDialog} from '../shared/confirm-project-delete-dialo
     MatSlideToggleModule,
     DatePipe,
     MatDialogModule,
+    MatMenuModule,
   ],
   templateUrl: './homepage.html',
   styleUrl: './homepage.scss',
@@ -59,6 +61,8 @@ export class Homepage {
   private auth = inject(Auth);
   private dialog = inject(MatDialog);
   projects = signal<ProjectConfig[]>([]);
+  theme = this.config.theme;
+  primaryColor = this.config.primaryColor;
   myProjectsOnly = signal<boolean>(true);
   userEmail = computed(() => this.auth.currentUser?.email ?? null);
 


### PR DESCRIPTION
Reused the theme and mode picker from the nav bar and added it to the homepage as floating element
Updated the gradient on the headline to match the NB 2 page (https://gemini.google/de/overview/image-generation/?hl=de-DE)