### PR TITLE
FFmpeg filter fix

### DIFF
--- a/ui/src/app/services/config/config.spec.ts
+++ b/ui/src/app/services/config/config.spec.ts
@@ -14,27 +14,191 @@
  * limitations under the License.
  */
 
-import {TestBed} from '@angular/core/testing';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import '@angular/compiler';
+import {EnvironmentInjector, signal} from '@angular/core';
+import {DOCUMENT} from '@angular/common';
 import {Auth} from '@angular/fire/auth';
-import {Firestore} from '@angular/fire/firestore';
+import {Firestore, getDoc, deleteDoc} from '@angular/fire/firestore';
+import {Router} from '@angular/router';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {ConfigService} from './config';
-import '../../testing/mocks/match-media.mock';
+import {ConfigService, toDecimals} from './config';
+import {of} from 'rxjs';
 
-describe('Config', () => {
+const mockGet = vi.fn();
+const mockInjector = {get: mockGet};
+
+// Mock @angular/core to bypass runInInjectionContext and provide inject
+vi.mock('@angular/core', async importOriginal => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    runInInjectionContext: vi.fn((injector: any, fn: () => any) => fn()),
+    inject: vi.fn((token: any) => mockGet(token)),
+    resource: vi.fn((options: any) => {
+      const s = signal(options?.defaultValue ?? {});
+      return {
+        value: s,
+        set: (val: any) => s.set(val),
+        update: (fn: any) => s.update(fn),
+      };
+    }),
+    effect: vi.fn(() => {
+      return {
+        destroy: vi.fn(),
+      };
+    }),
+  };
+});
+
+// Mock @angular/core/rxjs-interop
+vi.mock('@angular/core/rxjs-interop', async () => {
+  return {
+    toObservable: vi.fn((s: any) => of(s())),
+  };
+});
+
+// Mock Firebase Firestore
+vi.mock('@angular/fire/firestore', async importOriginal => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    doc: vi.fn(),
+    getDoc: vi.fn(),
+    setDoc: vi.fn(),
+    deleteDoc: vi.fn(),
+    collection: vi.fn(),
+    query: vi.fn(),
+    where: vi.fn(),
+    getDocs: vi.fn(),
+  };
+});
+
+describe('ConfigService', () => {
   let service: ConfigService;
+  let firestoreMock: any;
+  let routerMock: any;
+  let authMock: any;
+  let documentMock: any;
+  let localStorageMock: any;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        {provide: Firestore, useValue: vi.mockObject(Firestore)},
-        {provide: Auth, useValue: vi.mockObject(Auth)},
-      ],
+    firestoreMock = {};
+    routerMock = {
+      navigate: vi.fn(),
+    };
+    authMock = {
+      currentUser: {email: 'test@example.com'},
+    };
+    documentMock = {
+      documentElement: {
+        classList: {
+          add: vi.fn(),
+          remove: vi.fn(),
+        },
+      },
+      defaultView: {
+        matchMedia: vi.fn().mockReturnValue({
+          matches: false,
+          addEventListener: vi.fn(),
+        }),
+      },
+      querySelector: vi.fn(),
+    };
+
+    localStorageMock = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+    };
+    (globalThis as any).localStorage = localStorageMock;
+
+    mockGet.mockImplementation((token: any) => {
+      if (token === Firestore) return firestoreMock;
+      if (token === Router) return routerMock;
+      if (token === Auth) return authMock;
+      if (token === DOCUMENT) return documentMock;
+      if (token === EnvironmentInjector) return mockInjector;
+      return null;
     });
-    service = TestBed.inject(ConfigService);
+
+    vi.clearAllMocks();
+
+    vi.mocked(getDoc).mockResolvedValue({
+      exists: () => true,
+      data: () => ({aspectRatio: '16:9', resolution: '720p'}),
+    } as any);
+
+    service = new ConfigService();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('toDecimals', () => {
+    it('should truncate decimals', () => {
+      expect(toDecimals(1.2345, 2)).toBe(1.23);
+      expect(toDecimals(1.2345, 0)).toBe(1);
+    });
+  });
+
+  describe('sceneIdCounter', () => {
+    it('should return 1 when storyboard is empty', () => {
+      service.projectConfig.value.set({storyboard: []} as any);
+      expect(service.sceneIdCounter()).toBe(1);
+    });
+
+    it('should return max + 1 when storyboard has scenes', () => {
+      service.projectConfig.value.set({
+        storyboard: [{id: '1'}, {id: '3'}, {id: '2'}],
+      } as any);
+      expect(service.sceneIdCounter()).toBe(4);
+    });
+  });
+
+  describe('Type Guards', () => {
+    it('should identify generated scene', () => {
+      expect(service.isGeneratedScene({type: 'generated'} as any)).toBe(true);
+      expect(service.isGeneratedScene({type: 'video'} as any)).toBe(false);
+      expect(service.isGeneratedScene(null)).toBe(false);
+    });
+
+    it('should identify provided video scene', () => {
+      expect(service.isProvidedVideoScene({type: 'video'} as any)).toBe(true);
+      expect(service.isProvidedVideoScene({type: 'generated'} as any)).toBe(
+        false,
+      );
+      expect(service.isProvidedVideoScene(null)).toBe(false);
+    });
+  });
+
+  describe('State Mutations', () => {
+    it('should reset project config', () => {
+      service.loadProjectConfig('some-id');
+      service.resetProjectConfig();
+      expect(service.projectConfig.value().id).toBe('');
+      expect(service.shouldSave).toBe(false);
+    });
+
+    it('should update project config', () => {
+      service.updateProjectConfig({name: 'New Name'});
+      expect(service.projectConfig.value().name).toBe('New Name');
+      expect(service.shouldSave).toBe(true);
+    });
+
+    it('should set new project', () => {
+      service.setNewProject('uuid-123');
+      expect(service.projectConfig.value().id).toBe('uuid-123');
+      expect(service.projectConfig.value().name).toBe('Untitled Project');
+      expect(service.shouldSave).toBe(false);
+    });
+  });
+
+  describe('Firestore Operations', () => {
+    it('should delete project', async () => {
+      vi.mocked(deleteDoc).mockResolvedValue(undefined);
+      await service.deleteProject('proj-id');
+      expect(deleteDoc).toHaveBeenCalled();
+    });
   });
 });

--- a/ui/src/app/services/remix-engine/remix-engine.spec.ts
+++ b/ui/src/app/services/remix-engine/remix-engine.spec.ts
@@ -21,8 +21,7 @@ import {EnvironmentInjector} from '@angular/core';
 import * as storage from '@angular/fire/storage';
 import {Storage} from '@angular/fire/storage';
 import {MatSnackBar} from '@angular/material/snack-bar';
-import {of, take, filter, repeat, defer} from 'rxjs';
-import {TestScheduler} from 'rxjs/testing';
+import {of} from 'rxjs';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {ClientMediaService} from '../client-media/client-media';
 import {ConfigService} from '../config/config';
@@ -217,43 +216,73 @@ describe('RemixEngineService', () => {
       expect(httpClientMock.get).toHaveBeenCalled();
     });
 
-    it('should poll until sink output is defined', () => {
-      const testScheduler = new TestScheduler((actual: any, expected: any) => {
-        expect(actual).toEqual(expected);
+    it('should poll until sink output is defined', async () => {
+      vi.useFakeTimers();
+      const mockResponse1 = {sink: {output: undefined}};
+      const mockResponse2 = {sink: {output: {'0': {video: []}}}};
+
+      let callCount = 0;
+      httpClientMock.get.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return of(mockResponse1);
+        } else {
+          return of(mockResponse2);
+        }
       });
 
-      testScheduler.run(({expectObservable, cold}: any) => {
-        const mockResponse1 = {sink: {output: undefined}};
-        const mockResponse2 = {sink: {output: {'0': {video: []}}}};
+      const pollPromise = service.pollWorkflow(
+        'mock-execution-id',
+        'mock-project-id',
+      );
 
-        httpClientMock.get
-          .mockReturnValueOnce(cold('(a|)', {a: mockResponse1}))
-          .mockReturnValueOnce(cold('b', {b: mockResponse2}));
+      // Advance timers by 1ms to let timer(0, ...) emit
+      await vi.advanceTimersByTimeAsync(1);
 
-        // Recreate the pipe in the test to test it with marbles
-        const poll$ = defer(() =>
-          (service as any).getWorkflowStatus('mock-execution-id'),
-        ).pipe(
-          repeat({delay: 10}),
-          take(5),
-          filter((response: any) => response.sink?.output !== undefined),
-          take(1),
-        );
+      // First poll should happen immediately
+      expect(callCount).toBe(1);
 
-        expectObservable(poll$).toBe('----------(b|)', {b: mockResponse2});
-      });
-    });
+      // Advance timers by 15ms to trigger the next poll (interval is 10ms)
+      await vi.advanceTimersByTimeAsync(15);
+
+      const result = await pollPromise;
+
+      expect(result).toEqual(mockResponse2);
+      expect(callCount).toBe(2);
+
+      vi.useRealTimers();
+    }, 10000);
 
     it('should throw ProjectChangedError if project changes', async () => {
+      vi.useFakeTimers();
       const mockResponse = {sink: {output: undefined}};
-      httpClientMock.get.mockReturnValue(of(mockResponse));
+      httpClientMock.get.mockImplementation(() => {
+        console.log('Test 2: Mock HTTP GET called');
+        return of(mockResponse);
+      });
       configServiceMock.projectConfig.value.mockReturnValue({
         id: 'different-project-id',
       });
 
-      await expect(
-        service.pollWorkflow('mock-execution-id', 'mock-project-id'),
-      ).rejects.toThrow('Project changed');
+      const pollPromise = service.pollWorkflow(
+        'mock-execution-id',
+        'mock-project-id',
+      );
+      pollPromise.catch(() => {}); // Prevent unhandled rejection warning
+
+      // Advance timers by 1ms to let timer(0, ...) emit
+      await vi.advanceTimersByTimeAsync(1);
+
+      let thrownError: any;
+      try {
+        await pollPromise;
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError).toBeTruthy();
+      expect(thrownError.message).toContain('Project changed');
+      vi.useRealTimers();
     });
   });
 
@@ -282,7 +311,7 @@ describe('RemixEngineService', () => {
         mockWorkflowStatus as any,
       );
 
-      (storage.getDownloadURL as any).mockResolvedValue('http://mock-url');
+      vi.mocked(storage.getDownloadURL).mockResolvedValue('http://mock-url');
 
       clientMediaServiceMock.generateLowQualityThumbnail.mockResolvedValue(
         new Blob(),
@@ -304,7 +333,7 @@ describe('RemixEngineService', () => {
         durationSeconds: 5,
         model: 'model-1',
         generateAudio: false,
-        resolution: 'LANDSCAPE' as any,
+        resolution: '720p',
       });
 
       expect(configServiceMock.updateProjectConfig).toHaveBeenCalledWith({
@@ -319,7 +348,7 @@ describe('RemixEngineService', () => {
                 prompt: 'prompt 1',
                 model: 'model-1',
                 generateAudio: false,
-                resolution: 'LANDSCAPE',
+                resolution: '720p',
                 video: {url: 'http://mock-url', path: 'mock-path/video.mp4'},
                 lowQualityThumbnail: 'mock-base64',
                 highQualityThumbnail: {
@@ -348,7 +377,7 @@ describe('RemixEngineService', () => {
         durationSeconds: 5,
         model: 'model-1',
         generateAudio: false,
-        resolution: 'LANDSCAPE' as any,
+        resolution: '720p',
       });
 
       expect(service.startVideoGenerationWorkflow).not.toHaveBeenCalled();
@@ -365,7 +394,7 @@ describe('RemixEngineService', () => {
         durationSeconds: 5,
         model: 'model-1',
         generateAudio: false,
-        resolution: 'LANDSCAPE' as any,
+        resolution: '720p',
       });
 
       expect(matSnackBarMock.open).toHaveBeenCalledWith(
@@ -399,7 +428,7 @@ describe('RemixEngineService', () => {
         durationSeconds: 5,
         model: 'model-1',
         generateAudio: false,
-        resolution: 'LANDSCAPE' as any,
+        resolution: '720p',
       });
 
       expect(matSnackBarMock.open).toHaveBeenCalledWith(
@@ -427,7 +456,7 @@ describe('RemixEngineService', () => {
         durationSeconds: 5,
         model: 'model-1',
         generateAudio: false,
-        resolution: 'LANDSCAPE' as any,
+        resolution: '720p',
       });
 
       expect(matSnackBarMock.open).toHaveBeenCalledWith(
@@ -459,7 +488,7 @@ describe('RemixEngineService', () => {
         mockWorkflowStatus as any,
       );
 
-      (storage.getDownloadURL as any).mockResolvedValue('http://mock-url');
+      vi.mocked(storage.getDownloadURL).mockResolvedValue('http://mock-url');
 
       clientMediaServiceMock.generateLowQualityThumbnail.mockRejectedValue(
         new Error('Thumbnail failed'),
@@ -479,7 +508,7 @@ describe('RemixEngineService', () => {
         durationSeconds: 5,
         model: 'model-1',
         generateAudio: false,
-        resolution: 'LANDSCAPE' as any,
+        resolution: '720p',
       });
 
       expect(configServiceMock.updateProjectConfig).toHaveBeenCalledWith(
@@ -534,8 +563,8 @@ describe('RemixEngineService', () => {
       const mockBlob = new Blob([JSON.stringify(mockStoryboardJson)], {
         type: 'application/json',
       });
-      (storage.getBlob as any).mockResolvedValue(mockBlob);
-      (storage.getDownloadURL as any).mockResolvedValue('http://mock-url');
+      vi.mocked(storage.getBlob).mockResolvedValue(mockBlob);
+      vi.mocked(storage.getDownloadURL).mockResolvedValue('http://mock-url');
 
       const result = await service.generateStoryboard(
         mockProducts as any,
@@ -683,7 +712,7 @@ describe('RemixEngineService', () => {
       const mockBlob = new Blob([JSON.stringify(mockStoryboardJson)], {
         type: 'application/json',
       });
-      (storage.getBlob as any).mockResolvedValue(mockBlob);
+      vi.mocked(storage.getBlob).mockResolvedValue(mockBlob);
 
       await service.generateStoryboard(
         mockProducts as any,
@@ -732,7 +761,7 @@ describe('RemixEngineService', () => {
         mockWorkflowStatus as any,
       );
 
-      (storage.getDownloadURL as any).mockResolvedValue(
+      vi.mocked(storage.getDownloadURL).mockResolvedValue(
         'http://mock-video-url',
       );
 
@@ -754,7 +783,7 @@ describe('RemixEngineService', () => {
             prompt: 'prompt 1',
             model: 'model-1',
             generateAudio: false,
-            resolution: 'LANDSCAPE' as any,
+            resolution: '720p',
           },
         ],
         selectedCandidateIndex: 0,
@@ -781,7 +810,7 @@ describe('RemixEngineService', () => {
       vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
         workflowStatusMock as any,
       );
-      (storage.getDownloadURL as any).mockResolvedValue(
+      vi.mocked(storage.getDownloadURL).mockResolvedValue(
         'http://mock-video-url',
       );
 
@@ -814,7 +843,7 @@ describe('RemixEngineService', () => {
             prompt: 'prompt 1',
             model: 'model-1',
             generateAudio: false,
-            resolution: 'LANDSCAPE' as any,
+            resolution: '720p',
           },
         ],
         selectedCandidateIndex: 0,
@@ -841,7 +870,7 @@ describe('RemixEngineService', () => {
       vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
         workflowStatusMock as any,
       );
-      (storage.getDownloadURL as any).mockResolvedValue(
+      vi.mocked(storage.getDownloadURL).mockResolvedValue(
         'http://mock-video-url',
       );
 
@@ -874,7 +903,7 @@ describe('RemixEngineService', () => {
             prompt: 'prompt 1',
             model: 'model-1',
             generateAudio: false,
-            resolution: 'LANDSCAPE' as any,
+            resolution: '720p',
           },
         ],
         selectedCandidateIndex: 0,
@@ -901,7 +930,7 @@ describe('RemixEngineService', () => {
       vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
         workflowStatusMock as any,
       );
-      (storage.getDownloadURL as any).mockResolvedValue(
+      vi.mocked(storage.getDownloadURL).mockResolvedValue(
         'http://mock-video-url',
       );
 
@@ -933,7 +962,7 @@ describe('RemixEngineService', () => {
             prompt: 'prompt 1',
             model: 'model-1',
             generateAudio: false,
-            resolution: 'LANDSCAPE' as any,
+            resolution: '720p',
           },
         ],
         selectedCandidateIndex: 0,
@@ -951,7 +980,7 @@ describe('RemixEngineService', () => {
             prompt: 'prompt 2',
             model: 'model-1',
             generateAudio: false,
-            resolution: 'LANDSCAPE' as any,
+            resolution: '720p',
           },
         ],
         selectedCandidateIndex: 0,
@@ -978,7 +1007,7 @@ describe('RemixEngineService', () => {
       vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
         workflowStatusMock as any,
       );
-      (storage.getDownloadURL as any).mockResolvedValue(
+      vi.mocked(storage.getDownloadURL).mockResolvedValue(
         'http://mock-video-url',
       );
 
@@ -1012,7 +1041,7 @@ describe('RemixEngineService', () => {
             prompt: 'prompt 1',
             model: 'model-1',
             generateAudio: false,
-            resolution: 'LANDSCAPE' as any,
+            resolution: '720p',
           },
         ],
         selectedCandidateIndex: 0,
@@ -1030,7 +1059,7 @@ describe('RemixEngineService', () => {
             prompt: 'prompt 2',
             model: 'model-1',
             generateAudio: false,
-            resolution: 'LANDSCAPE' as any,
+            resolution: '720p',
           },
         ],
         selectedCandidateIndex: 0,
@@ -1057,7 +1086,7 @@ describe('RemixEngineService', () => {
       vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
         workflowStatusMock as any,
       );
-      (storage.getDownloadURL as any).mockResolvedValue(
+      vi.mocked(storage.getDownloadURL).mockResolvedValue(
         'http://mock-video-url',
       );
 

--- a/ui/src/app/services/remix-engine/remix-engine.spec.ts
+++ b/ui/src/app/services/remix-engine/remix-engine.spec.ts
@@ -14,36 +14,820 @@
  * limitations under the License.
  */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import '@angular/compiler';
 import {HttpClient} from '@angular/common/http';
-import {TestBed} from '@angular/core/testing';
-import {Firestore} from '@angular/fire/firestore';
+import {EnvironmentInjector} from '@angular/core';
+import * as storage from '@angular/fire/storage';
 import {Storage} from '@angular/fire/storage';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {of, take, filter, repeat, defer} from 'rxjs';
+import {TestScheduler} from 'rxjs/testing';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {ClientMediaService} from '../client-media/client-media';
 import {ConfigService} from '../config/config';
 import {RemixEngineService} from './remix-engine';
 
+// Mock poll interval to be short for tests
+vi.mock('./remix-engine.interface', async importOriginal => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    WORKFLOW_STATUS_POLL_INTERVAL_MS: 10,
+  };
+});
+
+// Mock Firebase Storage
+vi.mock('@angular/fire/storage', async importOriginal => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    ref: vi.fn(),
+    uploadString: vi.fn(),
+    uploadBytes: vi.fn(),
+    getDownloadURL: vi.fn(),
+    getBlob: vi.fn(),
+  };
+});
+
+const mockGet = vi.fn();
+const mockInjector = {get: mockGet};
+
+// Mock @angular/core to bypass runInInjectionContext and provide inject
+vi.mock('@angular/core', async importOriginal => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    runInInjectionContext: vi.fn((injector: any, fn: () => any) => fn()),
+    inject: vi.fn((token: any) => mockGet(token)),
+  };
+});
+
 describe('RemixEngineService', () => {
   let service: RemixEngineService;
+  let httpClientMock: any;
+  let configServiceMock: any;
+  let storageMock: any;
+  let clientMediaServiceMock: any;
+  let matSnackBarMock: any;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        {provide: Firestore, useValue: {}},
-        {provide: Storage, useValue: {}},
-        {provide: HttpClient, useValue: {}},
-        {
-          provide: ConfigService,
-          useValue: {
-            globalConfig: {value: vi.fn()},
-            projectConfig: {value: vi.fn()},
-          },
-        },
-      ],
+    (globalThis as any).window = {location: {origin: 'http://localhost'}};
+    httpClientMock = {
+      post: vi.fn(),
+      get: vi.fn(),
+    };
+
+    configServiceMock = {
+      globalConfig: {
+        value: vi.fn().mockReturnValue({
+          gatewayBaseUrl: 'http://mock-gateway',
+          gatewayApiKey: 'mock-key',
+          gcpProject: 'mock-project',
+          gcpLocation: 'mock-location',
+          gcsBucket: 'mock-bucket',
+          tasksQueuePrefix: 'mock-queue',
+          veoLocation: 'mock-veo-loc',
+          geminiModel: 'mock-gemini',
+          geminiLocation: 'mock-gemini-loc',
+          outpainterModel: 'mock-outpaint',
+          outpainterLocation: 'mock-outpaint-loc',
+          duration: 5,
+          veoModel: 'mock-veo',
+          numberOfCandidates: 3,
+          generateAudio: true,
+        }),
+      },
+      projectConfig: {
+        value: vi.fn().mockReturnValue({
+          id: 'mock-project-id',
+          resolution: '720p',
+          aspectRatio: '16:9',
+          numberOfCandidates: 3,
+          candidateDurationSeconds: 5,
+          generateAudio: true,
+          model: 'mock-veo',
+          storyboard: [],
+        }),
+      },
+      isGeneratedScene: vi.fn().mockReturnValue(true),
+      isProvidedVideoScene: vi.fn().mockReturnValue(false),
+      updateProjectConfig: vi.fn(),
+      addRenderRun: vi.fn(),
+    };
+
+    storageMock = {};
+
+    clientMediaServiceMock = {
+      generateLowQualityThumbnail: vi.fn(),
+      generateHighQualityThumbnail: vi.fn(),
+      toBase64: vi.fn(),
+      toFile: vi.fn(),
+    };
+
+    matSnackBarMock = {
+      open: vi.fn(),
+    };
+
+    mockGet.mockImplementation((token: any) => {
+      if (token === HttpClient) return httpClientMock;
+      if (token === ConfigService) return configServiceMock;
+      if (token === Storage) return storageMock;
+      if (token === ClientMediaService) return clientMediaServiceMock;
+      if (token === MatSnackBar) return matSnackBarMock;
+      if (token === EnvironmentInjector) return mockInjector;
+      return null;
     });
-    service = TestBed.inject(RemixEngineService);
+
+    service = new RemixEngineService();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('uploadText', () => {
+    it('should upload text and return path', async () => {
+      const mockSnapshot = {metadata: {fullPath: 'mock-path'}};
+      vi.mocked(storage.uploadString).mockResolvedValue(mockSnapshot as any);
+      vi.mocked(storage.ref).mockReturnValue({} as any);
+
+      // Mock generateHash to return a fixed value for testing
+      vi.spyOn(service, 'generateHash').mockResolvedValue('mock-hash');
+
+      const path = await service.uploadText('test content', 'testfile');
+
+      expect(path).toBe('mock-path');
+      expect(storage.uploadString).toHaveBeenCalled();
+    });
+  });
+
+  describe('generateHash', () => {
+    it('should generate hash for string', async () => {
+      const hash = await service.generateHash('test content');
+      expect(hash).toBeTruthy();
+      expect(typeof hash).toBe('string');
+    });
+  });
+
+  describe('startVideoGenerationWorkflow', () => {
+    it('should call startWorkflow and return observable', async () => {
+      const scene = {id: '1', prompt: 'test prompt', type: 'generated'};
+      httpClientMock.post.mockReturnValue(
+        of({executionId: 'mock-execution-id'}),
+      );
+      vi.spyOn(service, 'uploadText').mockResolvedValue('mock-prompt-path');
+
+      const result = await service.startVideoGenerationWorkflow(
+        scene as any,
+        false,
+      );
+
+      expect(result).toBeTruthy();
+      expect(httpClientMock.post).toHaveBeenCalled();
+    });
+
+    it('should handle error and return undefined', async () => {
+      const scene = {id: '1', prompt: 'test prompt', type: 'generated'};
+      vi.spyOn(service, 'uploadText').mockRejectedValue(
+        new Error('Upload failed'),
+      );
+
+      const result = await service.startVideoGenerationWorkflow(
+        scene as any,
+        false,
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('pollWorkflow', () => {
+    it('should return response when sink output is defined', async () => {
+      const mockResponse = {sink: {output: {'0': {video: []}}}};
+      httpClientMock.get.mockReturnValue(of(mockResponse));
+
+      const result = await service.pollWorkflow(
+        'mock-execution-id',
+        'mock-project-id',
+      );
+
+      expect(result).toEqual(mockResponse);
+      expect(httpClientMock.get).toHaveBeenCalled();
+    });
+
+    it('should poll until sink output is defined', () => {
+      const testScheduler = new TestScheduler((actual: any, expected: any) => {
+        expect(actual).toEqual(expected);
+      });
+
+      testScheduler.run(({expectObservable, cold}: any) => {
+        const mockResponse1 = {sink: {output: undefined}};
+        const mockResponse2 = {sink: {output: {'0': {video: []}}}};
+
+        httpClientMock.get
+          .mockReturnValueOnce(cold('(a|)', {a: mockResponse1}))
+          .mockReturnValueOnce(cold('b', {b: mockResponse2}));
+
+        // Recreate the pipe in the test to test it with marbles
+        const poll$ = defer(() =>
+          (service as any).getWorkflowStatus('mock-execution-id'),
+        ).pipe(
+          repeat({delay: 10}),
+          take(5),
+          filter((response: any) => response.sink?.output !== undefined),
+          take(1),
+        );
+
+        expectObservable(poll$).toBe('----------(b|)', {b: mockResponse2});
+      });
+    });
+
+    it('should throw ProjectChangedError if project changes', async () => {
+      const mockResponse = {sink: {output: undefined}};
+      httpClientMock.get.mockReturnValue(of(mockResponse));
+      configServiceMock.projectConfig.value.mockReturnValue({
+        id: 'different-project-id',
+      });
+
+      await expect(
+        service.pollWorkflow('mock-execution-id', 'mock-project-id'),
+      ).rejects.toThrow('Project changed');
+    });
+  });
+
+  describe('generateCandidates', () => {
+    it('should generate candidates and update project config', async () => {
+      const mockScene = {id: 'scene-1', prompt: 'prompt 1', candidates: []};
+      const mockProject = {id: 'project-1', storyboard: [mockScene]};
+
+      configServiceMock.projectConfig.value.mockReturnValue(mockProject);
+      configServiceMock.isGeneratedScene.mockReturnValue(true);
+
+      vi.spyOn(service, 'startVideoGenerationWorkflow').mockResolvedValue(
+        of({executionId: 'mock-execution-id'}) as any,
+      );
+
+      const mockWorkflowStatus = {
+        sink: {
+          output: {
+            '0': {
+              video: [{file: 'mock-path/video.mp4'}],
+            },
+          },
+        },
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        mockWorkflowStatus as any,
+      );
+
+      (storage.getDownloadURL as any).mockResolvedValue('http://mock-url');
+
+      clientMediaServiceMock.generateLowQualityThumbnail.mockResolvedValue(
+        new Blob(),
+      );
+      clientMediaServiceMock.toBase64.mockResolvedValue('mock-base64');
+      clientMediaServiceMock.generateHighQualityThumbnail.mockResolvedValue(
+        new Blob(),
+      );
+      clientMediaServiceMock.toFile.mockResolvedValue(
+        new File([], 'mock-file'),
+      );
+
+      vi.spyOn(service, 'uploadThumbnail').mockResolvedValue({
+        path: 'mock-thumb-path',
+        url: 'mock-thumb-url',
+      });
+
+      await service.generateCandidates(mockScene as any, {
+        durationSeconds: 5,
+        model: 'model-1',
+        generateAudio: false,
+        resolution: 'LANDSCAPE' as any,
+      });
+
+      expect(configServiceMock.updateProjectConfig).toHaveBeenCalled();
+    });
+  });
+
+  describe('generateStoryboard', () => {
+    it('should generate storyboard and return mapped scenes', async () => {
+      const mockProducts = [{id: 'prod-1', images: [{file: 'img1'}]}];
+
+      vi.spyOn(service, 'startStoryboardWorkflow').mockResolvedValue(
+        of({executionId: 'mock-execution-id'}) as any,
+      );
+
+      const mockWorkflowStatus = {
+        sink: {
+          output: {
+            '0': {
+              storyboard: [{file: 'mock-path/storyboard.json'}],
+              outpainted_images: [
+                {
+                  product_id: 'prod-1',
+                  image_id: 'img1',
+                  file: 'mock-path/outpainted.jpg',
+                },
+              ],
+            },
+          },
+        },
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        mockWorkflowStatus as any,
+      );
+
+      const mockStoryboardJson = {
+        storyboard: [
+          {product_id: 'prod-1', image_id: 'img1', prompt: 'prompt 1'},
+        ],
+      };
+      const mockBlob = new Blob([JSON.stringify(mockStoryboardJson)], {
+        type: 'application/json',
+      });
+      (storage.getBlob as any).mockResolvedValue(mockBlob);
+      (storage.getDownloadURL as any).mockResolvedValue('http://mock-url');
+
+      const result = await service.generateStoryboard(
+        mockProducts as any,
+        'mock briefing',
+        'none',
+      );
+
+      expect(result).toBeTruthy();
+      expect(result!.length).toBe(1);
+      expect(result![0].type).toBe('generated');
+    });
+  });
+
+  describe('combineScenes', () => {
+    it('should combine scenes and add render run', async () => {
+      const mockProject = {
+        id: 'project-1',
+        storyboard: [],
+        audioTracks: [],
+        visualOverlays: [],
+      };
+      configServiceMock.projectConfig.value.mockReturnValue(mockProject);
+
+      vi.spyOn(service as any, 'getCombineScenesArrangements').mockReturnValue({
+        scenes: [],
+        audio: [],
+        overlays: [],
+      });
+
+      vi.spyOn(service, 'startCombineScenesWorkflow').mockResolvedValue(
+        of({executionId: 'mock-execution-id'}) as any,
+      );
+
+      const mockWorkflowStatus = {
+        sink: {
+          output: {
+            '0': {
+              video: [{file: 'mock-path/final_video.mp4'}],
+            },
+          },
+        },
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        mockWorkflowStatus as any,
+      );
+
+      (storage.getDownloadURL as any).mockResolvedValue(
+        'http://mock-video-url',
+      );
+
+      await service.combineScenes();
+
+      expect(configServiceMock.addRenderRun).toHaveBeenCalled();
+    });
+
+    it('should calculate scene duration correctly with trim', async () => {
+      const mockScene = {
+        id: 'scene-1',
+        type: 'generated',
+        candidates: [
+          {
+            video: {path: 'mock-path/video.mp4'},
+            durationSeconds: 10,
+            trim: {start: 2, end: 5},
+            runNumber: 1,
+            prompt: 'prompt 1',
+            model: 'model-1',
+            generateAudio: false,
+            resolution: 'LANDSCAPE' as any,
+          },
+        ],
+        selectedCandidateIndex: 0,
+      };
+      const mockProject = {
+        id: 'project-1',
+        storyboard: [mockScene],
+        audioTracks: [],
+        visualOverlays: [],
+      };
+      configServiceMock.projectConfig.value.mockReturnValue(mockProject);
+      configServiceMock.isGeneratedScene.mockReturnValue(true);
+
+      httpClientMock.post.mockReturnValue(
+        of({executionId: 'mock-execution-id'}),
+      );
+      vi.spyOn(service, 'uploadText').mockResolvedValue(
+        'mock-arrangement-path',
+      );
+
+      const workflowStatusMock = {
+        sink: {output: {'0': {video: [{file: 'final.mp4'}]}}},
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        workflowStatusMock as any,
+      );
+      (storage.getDownloadURL as any).mockResolvedValue(
+        'http://mock-video-url',
+      );
+
+      let capturedArrangement: any;
+      vi.spyOn(service, 'startCombineScenesWorkflow').mockImplementation(
+        async (arr: any) => {
+          capturedArrangement = arr;
+          return of({executionId: 'mock-execution-id'}) as any;
+        },
+      );
+
+      await service.combineScenes();
+
+      expect(capturedArrangement).toBeTruthy();
+      expect(capturedArrangement.length).toBe(1);
+      expect(capturedArrangement[0].skip_time).toBe(2);
+      expect(capturedArrangement[0].duration).toBe(3);
+    });
+
+    it('should calculate scene duration correctly with trim start only', async () => {
+      const mockScene = {
+        id: 'scene-1',
+        type: 'generated',
+        candidates: [
+          {
+            video: {path: 'mock-path/video.mp4'},
+            durationSeconds: 10,
+            trim: {start: 2},
+            runNumber: 1,
+            prompt: 'prompt 1',
+            model: 'model-1',
+            generateAudio: false,
+            resolution: 'LANDSCAPE' as any,
+          },
+        ],
+        selectedCandidateIndex: 0,
+      };
+      const mockProject = {
+        id: 'project-1',
+        storyboard: [mockScene],
+        audioTracks: [],
+        visualOverlays: [],
+      };
+      configServiceMock.projectConfig.value.mockReturnValue(mockProject);
+      configServiceMock.isGeneratedScene.mockReturnValue(true);
+
+      httpClientMock.post.mockReturnValue(
+        of({executionId: 'mock-execution-id'}),
+      );
+      vi.spyOn(service, 'uploadText').mockResolvedValue(
+        'mock-arrangement-path',
+      );
+
+      const workflowStatusMock = {
+        sink: {output: {'0': {video: [{file: 'final.mp4'}]}}},
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        workflowStatusMock as any,
+      );
+      (storage.getDownloadURL as any).mockResolvedValue(
+        'http://mock-video-url',
+      );
+
+      let capturedArrangement: any;
+      vi.spyOn(service, 'startCombineScenesWorkflow').mockImplementation(
+        async (arr: any) => {
+          capturedArrangement = arr;
+          return of({executionId: 'mock-execution-id'}) as any;
+        },
+      );
+
+      await service.combineScenes();
+
+      expect(capturedArrangement).toBeTruthy();
+      expect(capturedArrangement.length).toBe(1);
+      expect(capturedArrangement[0].skip_time).toBe(2);
+      expect(capturedArrangement[0].duration).toBe(8);
+    });
+
+    it('should calculate scene duration correctly with trim end only', async () => {
+      const mockScene = {
+        id: 'scene-1',
+        type: 'generated',
+        candidates: [
+          {
+            video: {path: 'mock-path/video.mp4'},
+            durationSeconds: 10,
+            trim: {end: 5},
+            runNumber: 1,
+            prompt: 'prompt 1',
+            model: 'model-1',
+            generateAudio: false,
+            resolution: 'LANDSCAPE' as any,
+          },
+        ],
+        selectedCandidateIndex: 0,
+      };
+      const mockProject = {
+        id: 'project-1',
+        storyboard: [mockScene],
+        audioTracks: [],
+        visualOverlays: [],
+      };
+      configServiceMock.projectConfig.value.mockReturnValue(mockProject);
+      configServiceMock.isGeneratedScene.mockReturnValue(true);
+
+      httpClientMock.post.mockReturnValue(
+        of({executionId: 'mock-execution-id'}),
+      );
+      vi.spyOn(service, 'uploadText').mockResolvedValue(
+        'mock-arrangement-path',
+      );
+
+      const workflowStatusMock = {
+        sink: {output: {'0': {video: [{file: 'final.mp4'}]}}},
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        workflowStatusMock as any,
+      );
+      (storage.getDownloadURL as any).mockResolvedValue(
+        'http://mock-video-url',
+      );
+
+      let capturedArrangement: any;
+      vi.spyOn(service, 'startCombineScenesWorkflow').mockImplementation(
+        async (arr: any) => {
+          capturedArrangement = arr;
+          return of({executionId: 'mock-execution-id'}) as any;
+        },
+      );
+
+      await service.combineScenes();
+
+      expect(capturedArrangement).toBeTruthy();
+      expect(capturedArrangement.length).toBe(1);
+      expect(capturedArrangement[0].skip_time).toBe(0);
+      expect(capturedArrangement[0].duration).toBe(5);
+    });
+
+    it('should include transition in arrangement between two scenes', async () => {
+      const mockScene1 = {
+        id: 'scene-1',
+        type: 'generated',
+        candidates: [
+          {
+            video: {path: 'mock-path/video1.mp4'},
+            durationSeconds: 10,
+            runNumber: 1,
+            prompt: 'prompt 1',
+            model: 'model-1',
+            generateAudio: false,
+            resolution: 'LANDSCAPE' as any,
+          },
+        ],
+        selectedCandidateIndex: 0,
+        transition: 'fade',
+        transitionOverlap: 1,
+      };
+      const mockScene2 = {
+        id: 'scene-2',
+        type: 'generated',
+        candidates: [
+          {
+            video: {path: 'mock-path/video2.mp4'},
+            durationSeconds: 10,
+            runNumber: 1,
+            prompt: 'prompt 2',
+            model: 'model-1',
+            generateAudio: false,
+            resolution: 'LANDSCAPE' as any,
+          },
+        ],
+        selectedCandidateIndex: 0,
+      };
+      const mockProject = {
+        id: 'project-1',
+        storyboard: [mockScene1, mockScene2],
+        audioTracks: [],
+        visualOverlays: [],
+      };
+      configServiceMock.projectConfig.value.mockReturnValue(mockProject);
+      configServiceMock.isGeneratedScene.mockReturnValue(true);
+
+      httpClientMock.post.mockReturnValue(
+        of({executionId: 'mock-execution-id'}),
+      );
+      vi.spyOn(service, 'uploadText').mockResolvedValue(
+        'mock-arrangement-path',
+      );
+
+      const workflowStatusMock = {
+        sink: {output: {'0': {video: [{file: 'final.mp4'}]}}},
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        workflowStatusMock as any,
+      );
+      (storage.getDownloadURL as any).mockResolvedValue(
+        'http://mock-video-url',
+      );
+
+      let capturedArrangement: any;
+      vi.spyOn(service, 'startCombineScenesWorkflow').mockImplementation(
+        async (arr: any) => {
+          capturedArrangement = arr;
+          return of({executionId: 'mock-execution-id'}) as any;
+        },
+      );
+
+      await service.combineScenes();
+
+      expect(capturedArrangement).toBeTruthy();
+      expect(capturedArrangement.length).toBe(2);
+      expect(capturedArrangement[0].transition).toBe('fade');
+      expect(capturedArrangement[0].transition_overlap).toBe(1);
+      expect(capturedArrangement[1].file_path).toBe('mock-path/video2.mp4');
+    });
+
+    it('should calculate duration correctly with trim and transition between two scenes', async () => {
+      const mockScene1 = {
+        id: 'scene-1',
+        type: 'generated',
+        candidates: [
+          {
+            video: {path: 'mock-path/video1.mp4'},
+            durationSeconds: 10,
+            trim: {start: 2, end: 5},
+            runNumber: 1,
+            prompt: 'prompt 1',
+            model: 'model-1',
+            generateAudio: false,
+            resolution: 'LANDSCAPE' as any,
+          },
+        ],
+        selectedCandidateIndex: 0,
+        transition: 'fade',
+        transitionOverlap: 1,
+      };
+      const mockScene2 = {
+        id: 'scene-2',
+        type: 'generated',
+        candidates: [
+          {
+            video: {path: 'mock-path/video2.mp4'},
+            durationSeconds: 10,
+            runNumber: 1,
+            prompt: 'prompt 2',
+            model: 'model-1',
+            generateAudio: false,
+            resolution: 'LANDSCAPE' as any,
+          },
+        ],
+        selectedCandidateIndex: 0,
+      };
+      const mockProject = {
+        id: 'project-1',
+        storyboard: [mockScene1, mockScene2],
+        audioTracks: [],
+        visualOverlays: [],
+      };
+      configServiceMock.projectConfig.value.mockReturnValue(mockProject);
+      configServiceMock.isGeneratedScene.mockReturnValue(true);
+
+      httpClientMock.post.mockReturnValue(
+        of({executionId: 'mock-execution-id'}),
+      );
+      vi.spyOn(service, 'uploadText').mockResolvedValue(
+        'mock-arrangement-path',
+      );
+
+      const workflowStatusMock = {
+        sink: {output: {'0': {video: [{file: 'final.mp4'}]}}},
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        workflowStatusMock as any,
+      );
+      (storage.getDownloadURL as any).mockResolvedValue(
+        'http://mock-video-url',
+      );
+
+      let capturedArrangement: any;
+      vi.spyOn(service, 'startCombineScenesWorkflow').mockImplementation(
+        async (arr: any) => {
+          capturedArrangement = arr;
+          return of({executionId: 'mock-execution-id'}) as any;
+        },
+      );
+
+      await service.combineScenes();
+
+      expect(capturedArrangement).toBeTruthy();
+      expect(capturedArrangement.length).toBe(2);
+      expect(capturedArrangement[0].skip_time).toBe(2);
+      expect(capturedArrangement[0].duration).toBe(3);
+      expect(capturedArrangement[0].transition).toBe('fade');
+      expect(capturedArrangement[0].transition_overlap).toBe(1);
+      expect(capturedArrangement[1].file_path).toBe('mock-path/video2.mp4');
+    });
+  });
+
+  describe('startStoryboardWorkflow', () => {
+    it('should call startWorkflow and return observable', async () => {
+      const products = [
+        {id: 1, images: [{path: 'img1'}], description: 'prod1'},
+      ];
+      httpClientMock.post.mockReturnValue(
+        of({executionId: 'mock-execution-id'}),
+      );
+      vi.spyOn(service, 'uploadText').mockResolvedValue('mock-briefing-path');
+
+      const result = await service.startStoryboardWorkflow(
+        products as any,
+        'mock briefing',
+        'none',
+      );
+
+      expect(result).toBeTruthy();
+      expect(httpClientMock.post).toHaveBeenCalled();
+    });
+
+    it('should handle error and return undefined', async () => {
+      const products = [
+        {id: 1, images: [{path: 'img1'}], description: 'prod1'},
+      ];
+      vi.spyOn(service, 'uploadText').mockRejectedValue(
+        new Error('Upload failed'),
+      );
+
+      const result = await service.startStoryboardWorkflow(
+        products as any,
+        'mock briefing',
+        'none',
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('startCombineScenesWorkflow', () => {
+    it('should call startWorkflow and return observable', async () => {
+      const arrangement = [
+        {
+          file_type: 'video',
+          file_path: 'path',
+          start_time: 0,
+          skip_time: 0,
+          duration: 5,
+        },
+      ];
+      httpClientMock.post.mockReturnValue(
+        of({executionId: 'mock-execution-id'}),
+      );
+      vi.spyOn(service, 'uploadText').mockResolvedValue(
+        'mock-arrangement-path',
+      );
+
+      const result = await service.startCombineScenesWorkflow(
+        arrangement as any,
+        false,
+      );
+
+      expect(result).toBeTruthy();
+      expect(httpClientMock.post).toHaveBeenCalled();
+    });
+
+    it('should handle error and return undefined', async () => {
+      const arrangement = [
+        {
+          file_type: 'video',
+          file_path: 'path',
+          start_time: 0,
+          skip_time: 0,
+          duration: 5,
+        },
+      ];
+      vi.spyOn(service, 'uploadText').mockRejectedValue(
+        new Error('Upload failed'),
+      );
+
+      const result = await service.startCombineScenesWorkflow(
+        arrangement as any,
+        false,
+      );
+
+      expect(result).toBeUndefined();
+    });
   });
 });

--- a/ui/src/app/services/remix-engine/remix-engine.spec.ts
+++ b/ui/src/app/services/remix-engine/remix-engine.spec.ts
@@ -165,8 +165,9 @@ describe('RemixEngineService', () => {
   describe('generateHash', () => {
     it('should generate hash for string', async () => {
       const hash = await service.generateHash('test content');
-      expect(hash).toBeTruthy();
-      expect(typeof hash).toBe('string');
+      expect(hash).toBe(
+        '6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72',
+      );
     });
   });
 
@@ -306,7 +307,194 @@ describe('RemixEngineService', () => {
         resolution: 'LANDSCAPE' as any,
       });
 
-      expect(configServiceMock.updateProjectConfig).toHaveBeenCalled();
+      expect(configServiceMock.updateProjectConfig).toHaveBeenCalledWith({
+        storyboard: [
+          {
+            id: 'scene-1',
+            prompt: 'prompt 1',
+            candidates: [
+              {
+                runNumber: 1,
+                durationSeconds: 5,
+                prompt: 'prompt 1',
+                model: 'model-1',
+                generateAudio: false,
+                resolution: 'LANDSCAPE',
+                video: {url: 'http://mock-url', path: 'mock-path/video.mp4'},
+                lowQualityThumbnail: 'mock-base64',
+                highQualityThumbnail: {
+                  path: 'mock-thumb-path',
+                  url: 'mock-thumb-url',
+                },
+              },
+            ],
+            selectedCandidateIndex: 0,
+          },
+        ],
+      });
+    });
+
+    it('should return early if already generating candidates for the scene', async () => {
+      const mockScene = {id: 'scene-1', prompt: 'prompt 1', candidates: []};
+      service.generatingSceneIds.update(ids => {
+        const newIds = new Set(ids);
+        newIds.add('scene-1');
+        return newIds;
+      });
+
+      vi.spyOn(service, 'startVideoGenerationWorkflow');
+
+      await service.generateCandidates(mockScene as any, {
+        durationSeconds: 5,
+        model: 'model-1',
+        generateAudio: false,
+        resolution: 'LANDSCAPE' as any,
+      });
+
+      expect(service.startVideoGenerationWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('should handle workflow start failure and show error snackbar', async () => {
+      const mockScene = {id: 'scene-1', prompt: 'prompt 1', candidates: []};
+
+      vi.spyOn(service, 'startVideoGenerationWorkflow').mockResolvedValue(
+        undefined,
+      );
+
+      await service.generateCandidates(mockScene as any, {
+        durationSeconds: 5,
+        model: 'model-1',
+        generateAudio: false,
+        resolution: 'LANDSCAPE' as any,
+      });
+
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Failed to generate video(s). Failed to start workflow',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+    });
+
+    it('should handle workflow execution error and show error snackbar', async () => {
+      const mockScene = {id: 'scene-1', prompt: 'prompt 1', candidates: []};
+
+      vi.spyOn(service, 'startVideoGenerationWorkflow').mockResolvedValue(
+        of({executionId: 'mock-execution-id'}) as any,
+      );
+
+      const mockWorkflowStatus = {
+        sink: {
+          output: {
+            '0': {
+              video: [{_error: 'Mock workflow error'}],
+            },
+          },
+        },
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        mockWorkflowStatus as any,
+      );
+
+      await service.generateCandidates(mockScene as any, {
+        durationSeconds: 5,
+        model: 'model-1',
+        generateAudio: false,
+        resolution: 'LANDSCAPE' as any,
+      });
+
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Failed to generate video(s). Mock workflow error',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+    });
+
+    it('should handle workflow completed without output and show error snackbar', async () => {
+      const mockScene = {id: 'scene-1', prompt: 'prompt 1', candidates: []};
+
+      vi.spyOn(service, 'startVideoGenerationWorkflow').mockResolvedValue(
+        of({executionId: 'mock-execution-id'}) as any,
+      );
+
+      const mockWorkflowStatus = {
+        sink: undefined,
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        mockWorkflowStatus as any,
+      );
+
+      await service.generateCandidates(mockScene as any, {
+        durationSeconds: 5,
+        model: 'model-1',
+        generateAudio: false,
+        resolution: 'LANDSCAPE' as any,
+      });
+
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Failed to generate video(s). Workflow completed without output',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+    });
+
+    it('should handle thumbnail generation failure gracefully', async () => {
+      const mockScene = {id: 'scene-1', prompt: 'prompt 1', candidates: []};
+      const mockProject = {id: 'project-1', storyboard: [mockScene]};
+      configServiceMock.projectConfig.value.mockReturnValue(mockProject);
+
+      vi.spyOn(service, 'startVideoGenerationWorkflow').mockResolvedValue(
+        of({executionId: 'mock-execution-id'}) as any,
+      );
+
+      const mockWorkflowStatus = {
+        sink: {
+          output: {
+            '0': {
+              video: [{file: 'mock-path/video.mp4'}],
+            },
+          },
+        },
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        mockWorkflowStatus as any,
+      );
+
+      (storage.getDownloadURL as any).mockResolvedValue('http://mock-url');
+
+      clientMediaServiceMock.generateLowQualityThumbnail.mockRejectedValue(
+        new Error('Thumbnail failed'),
+      );
+      clientMediaServiceMock.generateHighQualityThumbnail.mockResolvedValue(
+        new Blob(),
+      );
+      clientMediaServiceMock.toFile.mockResolvedValue(
+        new File([], 'mock-file'),
+      );
+      vi.spyOn(service, 'uploadThumbnail').mockResolvedValue({
+        path: 'mock-thumb-path',
+        url: 'mock-thumb-url',
+      });
+
+      await service.generateCandidates(mockScene as any, {
+        durationSeconds: 5,
+        model: 'model-1',
+        generateAudio: false,
+        resolution: 'LANDSCAPE' as any,
+      });
+
+      expect(configServiceMock.updateProjectConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          storyboard: [
+            expect.objectContaining({
+              candidates: [
+                expect.objectContaining({
+                  lowQualityThumbnail: undefined,
+                }),
+              ],
+            }),
+          ],
+        }),
+      );
     });
   });
 
@@ -358,6 +546,156 @@ describe('RemixEngineService', () => {
       expect(result).toBeTruthy();
       expect(result!.length).toBe(1);
       expect(result![0].type).toBe('generated');
+    });
+
+    it('should handle workflow start failure and show error snackbar', async () => {
+      const mockProducts = [{id: 'prod-1', images: [{file: 'img1'}]}];
+
+      vi.spyOn(service, 'startStoryboardWorkflow').mockResolvedValue(undefined);
+
+      await service.generateStoryboard(
+        mockProducts as any,
+        'mock briefing',
+        'none',
+      );
+
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Failed to generate storyboard. Failed to start workflow',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+    });
+
+    it('should handle workflow execution error and show error snackbar', async () => {
+      const mockProducts = [{id: 'prod-1', images: [{file: 'img1'}]}];
+
+      vi.spyOn(service, 'startStoryboardWorkflow').mockResolvedValue(
+        of({executionId: 'mock-execution-id'}) as any,
+      );
+
+      const mockWorkflowStatus = {
+        sink: {
+          output: {
+            '0': {
+              storyboard: [{_error: 'Mock storyboard error'}],
+            },
+          },
+        },
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        mockWorkflowStatus as any,
+      );
+
+      await service.generateStoryboard(
+        mockProducts as any,
+        'mock briefing',
+        'none',
+      );
+
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Failed to generate storyboard. Mock storyboard error',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+    });
+
+    it('should handle workflow completed without output and show error snackbar', async () => {
+      const mockProducts = [{id: 'prod-1', images: [{file: 'img1'}]}];
+
+      vi.spyOn(service, 'startStoryboardWorkflow').mockResolvedValue(
+        of({executionId: 'mock-execution-id'}) as any,
+      );
+
+      const mockWorkflowStatus = {
+        sink: undefined,
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        mockWorkflowStatus as any,
+      );
+
+      await service.generateStoryboard(
+        mockProducts as any,
+        'mock briefing',
+        'none',
+      );
+
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Failed to generate storyboard. Workflow completed without output',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+    });
+
+    it('should handle storyboard JSON file not found and show error snackbar', async () => {
+      const mockProducts = [{id: 'prod-1', images: [{file: 'img1'}]}];
+
+      vi.spyOn(service, 'startStoryboardWorkflow').mockResolvedValue(
+        of({executionId: 'mock-execution-id'}) as any,
+      );
+
+      const mockWorkflowStatus = {
+        sink: {
+          output: {
+            '0': {
+              storyboard: [{}],
+            },
+          },
+        },
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        mockWorkflowStatus as any,
+      );
+
+      await service.generateStoryboard(
+        mockProducts as any,
+        'mock briefing',
+        'none',
+      );
+
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Failed to generate storyboard. Storyboard JSON file not found',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+    });
+
+    it('should handle invalid storyboard JSON structure and show error snackbar', async () => {
+      const mockProducts = [{id: 'prod-1', images: [{file: 'img1'}]}];
+
+      vi.spyOn(service, 'startStoryboardWorkflow').mockResolvedValue(
+        of({executionId: 'mock-execution-id'}) as any,
+      );
+
+      const mockWorkflowStatus = {
+        sink: {
+          output: {
+            '0': {
+              storyboard: [{file: 'mock-path/storyboard.json'}],
+            },
+          },
+        },
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        mockWorkflowStatus as any,
+      );
+
+      const mockStoryboardJson = {};
+      const mockBlob = new Blob([JSON.stringify(mockStoryboardJson)], {
+        type: 'application/json',
+      });
+      (storage.getBlob as any).mockResolvedValue(mockBlob);
+
+      await service.generateStoryboard(
+        mockProducts as any,
+        'mock briefing',
+        'none',
+      );
+
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Failed to generate storyboard. Storyboard JSON file is missing storyboard',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
     });
   });
 
@@ -741,6 +1079,107 @@ describe('RemixEngineService', () => {
       expect(capturedArrangement[0].transition_overlap).toBe(1);
       expect(capturedArrangement[1].file_path).toBe('mock-path/video2.mp4');
     });
+
+    it('should handle workflow start failure and show error snackbar and add failed render run', async () => {
+      const mockProject = {
+        id: 'project-1',
+        storyboard: [],
+        audioTracks: [],
+        visualOverlays: [],
+      };
+      configServiceMock.projectConfig.value.mockReturnValue(mockProject);
+
+      vi.spyOn(service, 'startCombineScenesWorkflow').mockResolvedValue(
+        undefined,
+      );
+
+      await service.combineScenes();
+
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Failed to start workflow',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+      expect(configServiceMock.addRenderRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errorMessage: 'Failed to start workflow',
+        }),
+      );
+    });
+
+    it('should handle workflow execution error and show error snackbar and add failed render run', async () => {
+      const mockProject = {
+        id: 'project-1',
+        storyboard: [],
+        audioTracks: [],
+        visualOverlays: [],
+      };
+      configServiceMock.projectConfig.value.mockReturnValue(mockProject);
+
+      vi.spyOn(service, 'startCombineScenesWorkflow').mockResolvedValue(
+        of({executionId: 'mock-execution-id'}) as any,
+      );
+
+      const mockWorkflowStatus = {
+        sink: {
+          output: {
+            '0': {
+              video: [{_error: 'Mock combine error'}],
+            },
+          },
+        },
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        mockWorkflowStatus as any,
+      );
+
+      await service.combineScenes();
+
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Mock combine error',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+      expect(configServiceMock.addRenderRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errorMessage: 'Mock combine error',
+        }),
+      );
+    });
+
+    it('should handle workflow completed without output and show error snackbar and add failed render run', async () => {
+      const mockProject = {
+        id: 'project-1',
+        storyboard: [],
+        audioTracks: [],
+        visualOverlays: [],
+      };
+      configServiceMock.projectConfig.value.mockReturnValue(mockProject);
+
+      vi.spyOn(service, 'startCombineScenesWorkflow').mockResolvedValue(
+        of({executionId: 'mock-execution-id'}) as any,
+      );
+
+      const mockWorkflowStatus = {
+        sink: undefined,
+      };
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue(
+        mockWorkflowStatus as any,
+      );
+
+      await service.combineScenes();
+
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Workflow completed without output',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+      expect(configServiceMock.addRenderRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errorMessage: 'Workflow completed without output',
+        }),
+      );
+    });
   });
 
   describe('startStoryboardWorkflow', () => {
@@ -779,6 +1218,39 @@ describe('RemixEngineService', () => {
 
       expect(result).toBeUndefined();
     });
+
+    it('should not upload briefing if it is empty', async () => {
+      const products = [
+        {id: 1, images: [{path: 'img1'}], description: 'prod1'},
+      ];
+      httpClientMock.post.mockReturnValue(
+        of({executionId: 'mock-execution-id'}),
+      );
+      vi.spyOn(service, 'uploadText');
+
+      await service.startStoryboardWorkflow(products as any, '', 'none');
+
+      expect(service.uploadText).not.toHaveBeenCalled();
+      expect(httpClientMock.post).toHaveBeenCalled();
+    });
+
+    it('should propagate error if startWorkflow fails', async () => {
+      const products = [
+        {id: 1, images: [{path: 'img1'}], description: 'prod1'},
+      ];
+      vi.spyOn(service, 'uploadText').mockResolvedValue('mock-briefing-path');
+      vi.spyOn(service as any, 'startWorkflow').mockRejectedValue(
+        new Error('Workflow start failed'),
+      );
+
+      await expect(
+        service.startStoryboardWorkflow(
+          products as any,
+          'mock briefing',
+          'none',
+        ),
+      ).rejects.toThrow('Workflow start failed');
+    });
   });
 
   describe('startCombineScenesWorkflow', () => {
@@ -808,6 +1280,82 @@ describe('RemixEngineService', () => {
       expect(httpClientMock.post).toHaveBeenCalled();
     });
 
+    it('should map 1080p resolution correctly', async () => {
+      const arrangement = [
+        {
+          file_type: 'video',
+          file_path: 'path',
+          start_time: 0,
+          skip_time: 0,
+          duration: 5,
+        },
+      ];
+      const mockProject = {
+        id: 'project-1',
+        resolution: '1080p',
+        aspectRatio: '16:9',
+      };
+      configServiceMock.projectConfig.value.mockReturnValue(mockProject);
+
+      httpClientMock.post.mockReturnValue(
+        of({executionId: 'mock-execution-id'}),
+      );
+      vi.spyOn(service, 'uploadText').mockResolvedValue(
+        'mock-arrangement-path',
+      );
+
+      let capturedParams: any;
+      vi.spyOn(
+        service as any,
+        'getCombineScenesWorkflowDefinition',
+      ).mockImplementation((params: any) => {
+        capturedParams = params;
+        return {};
+      });
+
+      await service.startCombineScenesWorkflow(arrangement as any, false);
+
+      expect(capturedParams.resolution).toBe('1920:1080');
+    });
+
+    it('should map 4k resolution correctly', async () => {
+      const arrangement = [
+        {
+          file_type: 'video',
+          file_path: 'path',
+          start_time: 0,
+          skip_time: 0,
+          duration: 5,
+        },
+      ];
+      const mockProject = {
+        id: 'project-1',
+        resolution: '4k',
+        aspectRatio: '16:9',
+      };
+      configServiceMock.projectConfig.value.mockReturnValue(mockProject);
+
+      httpClientMock.post.mockReturnValue(
+        of({executionId: 'mock-execution-id'}),
+      );
+      vi.spyOn(service, 'uploadText').mockResolvedValue(
+        'mock-arrangement-path',
+      );
+
+      let capturedParams: any;
+      vi.spyOn(
+        service as any,
+        'getCombineScenesWorkflowDefinition',
+      ).mockImplementation((params: any) => {
+        capturedParams = params;
+        return {};
+      });
+
+      await service.startCombineScenesWorkflow(arrangement as any, false);
+
+      expect(capturedParams.resolution).toBe('3840:2160');
+    });
+
     it('should handle error and return undefined', async () => {
       const arrangement = [
         {
@@ -828,6 +1376,28 @@ describe('RemixEngineService', () => {
       );
 
       expect(result).toBeUndefined();
+    });
+
+    it('should propagate error if startWorkflow fails', async () => {
+      const arrangement = [
+        {
+          file_type: 'video',
+          file_path: 'path',
+          start_time: 0,
+          skip_time: 0,
+          duration: 5,
+        },
+      ];
+      vi.spyOn(service, 'uploadText').mockResolvedValue(
+        'mock-arrangement-path',
+      );
+      vi.spyOn(service as any, 'startWorkflow').mockRejectedValue(
+        new Error('Workflow start failed'),
+      );
+
+      await expect(
+        service.startCombineScenesWorkflow(arrangement as any, false),
+      ).rejects.toThrow('Workflow start failed');
     });
   });
 });

--- a/ui/src/app/services/remix-engine/remix-engine.ts
+++ b/ui/src/app/services/remix-engine/remix-engine.ts
@@ -886,7 +886,6 @@ export class RemixEngineService {
     for (const scene of validScenes) {
       let gcsVideoPath;
       let skipTime = 0;
-      const duration = this.getSceneVideoDuration(scene, skipTime);
       if (this.configService.isProvidedVideoScene(scene)) {
         gcsVideoPath = scene.video?.path;
         skipTime = scene.trim?.start ?? 0;
@@ -895,6 +894,7 @@ export class RemixEngineService {
         gcsVideoPath = candidate.video?.path;
         skipTime = candidate.trim?.start ?? 0;
       }
+      const duration = this.getSceneVideoDuration(scene, skipTime);
       if (!gcsVideoPath) {
         console.log(`No video for scene ${scene.id}`);
         continue;

--- a/ui/src/app/services/remix-engine/remix-engine.ts
+++ b/ui/src/app/services/remix-engine/remix-engine.ts
@@ -31,7 +31,16 @@ import {
   uploadString,
 } from '@angular/fire/storage';
 import {MatSnackBar} from '@angular/material/snack-bar';
-import {filter, firstValueFrom, Observable, repeat, retry, tap} from 'rxjs';
+import {
+  filter,
+  firstValueFrom,
+  Observable,
+  retry,
+  tap,
+  timer,
+  switchMap,
+  take,
+} from 'rxjs';
 import {ClientMediaService} from '../client-media/client-media';
 import {
   ASPECT_RATIO_DEVIATION_THRESHOLD,
@@ -100,7 +109,8 @@ export class RemixEngineService {
     projectId: string,
   ): Promise<WorkflowStatusResponse> {
     return await firstValueFrom(
-      this.getWorkflowStatus(workflowId).pipe(
+      timer(0, WORKFLOW_STATUS_POLL_INTERVAL_MS).pipe(
+        switchMap(() => this.getWorkflowStatus(workflowId)),
         retry({delay: WORKFLOW_STATUS_POLL_INTERVAL_MS}),
         tap(() => {
           if (this.configService.projectConfig.value().id !== projectId) {
@@ -108,7 +118,7 @@ export class RemixEngineService {
           }
         }),
         filter(response => response.sink?.output !== undefined),
-        repeat({delay: WORKFLOW_STATUS_POLL_INTERVAL_MS}),
+        take(1),
       ),
     );
   }


### PR DESCRIPTION
Small fix in remix-engine.ts to ensure candidate durations are correctly calculated when a candidate includes a trim.

Also added thorough unit tests for remix-engine.ts.