### PR TITLE
deploy: harden prereqs, IAM retry, phase markers, manual-step UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,34 @@ The following APIs are used by Scene Machine:
 
 _Please note that most of the APIs are enabled automatically when you run the deployment script. Cloud Storage and Cloud Logging are normally enabled by default. If your organization disables these APIs, you will need to enable them manually._
 
+### Permissions required for the deploying user
+
+`roles/owner` on the target project is sufficient and is the simplest option.
+
+If your organization's policies require narrower scopes, the deploying user needs at minimum the following predefined roles. **Do not rely on `roles/editor` as a catch-all** — Google has narrowed the basic roles, and `editor` no longer includes Firestore native-mode DB creation, App Engine app creation, custom role creation, or project-level IAM bindings.
+
+| Role | Why it's needed |
+|---|---|
+| `roles/serviceusage.serviceUsageAdmin` | Enable APIs (`gcloud services enable`) and create service identities (Vertex AI service agent) |
+| `roles/storage.admin` | Create the GCS bucket, set CORS, upload example assets |
+| `roles/datastore.owner` | Create the two Firestore native-mode databases |
+| `roles/firebase.admin` | Initialise the Firebase project, create the Web App, deploy Firestore/Storage rules |
+| `roles/appengine.appCreator` | One-time `gcloud app create` (project-level App Engine app) |
+| `roles/appengine.appAdmin` | Deploy the UI to App Engine (used by `deploy-ui.sh`) |
+| `roles/run.admin` | Deploy the backend to Cloud Run |
+| `roles/artifactregistry.admin` | Create the Docker repository for the backend image |
+| `roles/apigateway.admin` | Create the API Gateway, its config, and its managed service |
+| `roles/cloudtasks.admin` | Create the three task queues (Veo, Gemini, Other) |
+| `roles/serviceusage.apiKeysAdmin` | Create the API key used by the gateway |
+| `roles/iam.serviceAccountAdmin` | Service-account-level IAM bindings (e.g. Cloud Tasks → Cloud Run actAs) |
+| `roles/iam.serviceAccountUser` | Allow the deploy to act as service accounts during Cloud Run deploy |
+| `roles/iam.roleAdmin` | Create the custom `SceneMachineUser` role used for end-user authorization |
+| `roles/resourcemanager.projectIamAdmin` | Project-level IAM bindings (used throughout for the default Compute Engine SA and the Vertex AI service agent) |
+
+The two distinct `setIamPolicy` permissions matter: `projectIamAdmin` covers project-level bindings, `serviceAccountAdmin` covers service-account-level bindings. Both come up.
+
+End users of the deployed app only need the custom `projects/$PROJECT/roles/SceneMachineUser` role — see [Adding Users](#adding-users).
+
 ## Deployment
 
 [< Technical Requirements](#technical-requirements) • [Top](#readme-top) • [Adding Users >](#adding-users)

--- a/README.md
+++ b/README.md
@@ -97,27 +97,20 @@ _Please note that most of the APIs are enabled automatically when you run the de
 
 `roles/owner` on the target project is sufficient and is the simplest option.
 
-If your organization's policies require narrower scopes, the deploying user needs at minimum the following predefined roles. **Do not rely on `roles/editor` as a catch-all** — Google has narrowed the basic roles, and `editor` no longer includes Firestore native-mode DB creation, App Engine app creation, custom role creation, or project-level IAM bindings.
+If your organization's policies require narrower scopes, the tested minimum set is `roles/editor` plus five add-ons. `roles/editor` still covers most of the deploy work (API enable, GCS bucket, Cloud Run, Artifact Registry, API Gateway, Cloud Tasks, API keys, Firebase init, "act as" service accounts). Google narrowed the basic roles for a handful of specific operations, which is what the add-ons cover.
 
 | Role | Why it's needed |
 |---|---|
-| `roles/serviceusage.serviceUsageAdmin` | Enable APIs (`gcloud services enable`) and create service identities (Vertex AI service agent) |
-| `roles/storage.admin` | Create the GCS bucket, set CORS, upload example assets |
-| `roles/datastore.owner` | Create the two Firestore native-mode databases |
-| `roles/firebase.admin` | Initialise the Firebase project, create the Web App, deploy Firestore/Storage rules |
-| `roles/appengine.appCreator` | One-time `gcloud app create` (project-level App Engine app) |
-| `roles/appengine.appAdmin` | Deploy the UI to App Engine (used by `deploy-ui.sh`) |
-| `roles/run.admin` | Deploy the backend to Cloud Run |
-| `roles/artifactregistry.admin` | Create the Docker repository for the backend image |
-| `roles/apigateway.admin` | Create the API Gateway, its config, and its managed service |
-| `roles/cloudtasks.admin` | Create the three task queues (Veo, Gemini, Other) |
-| `roles/serviceusage.apiKeysAdmin` | Create the API key used by the gateway |
-| `roles/iam.serviceAccountAdmin` | Service-account-level IAM bindings (e.g. Cloud Tasks → Cloud Run actAs) |
-| `roles/iam.serviceAccountUser` | Allow the deploy to act as service accounts during Cloud Run deploy |
-| `roles/iam.roleAdmin` | Create the custom `SceneMachineUser` role used for end-user authorization |
-| `roles/resourcemanager.projectIamAdmin` | Project-level IAM bindings (used throughout for the default Compute Engine SA and the Vertex AI service agent) |
+| `roles/editor` | Catch-all for the bulk of the deploy operations |
+| `roles/datastore.owner` | Firestore native-mode database creation (not in `editor`) |
+| `roles/appengine.appCreator` | One-time `gcloud app create` at the project level (separate from `appAdmin`; not in `editor`) |
+| `roles/resourcemanager.projectIamAdmin` | Project-level IAM bindings — the `add_iam_binding` calls in `deploy.sh` |
+| `roles/iam.roleAdmin` | Create the custom `SceneMachineUser` role late in `deploy.sh` |
+| `roles/iam.serviceAccountAdmin` | Service-account-level IAM bindings (e.g. Cloud Tasks → Cloud Run "actAs") — a separate `setIamPolicy` from the project-level one |
 
-The two distinct `setIamPolicy` permissions matter: `projectIamAdmin` covers project-level bindings, `serviceAccountAdmin` covers service-account-level bindings. Both come up.
+For `deploy-ui.sh`, add `roles/appengine.appAdmin` so the UI can be deployed to the existing App Engine app (note: this is distinct from `appCreator`, which only allows the initial app creation).
+
+Two distinct `setIamPolicy` permissions matter: `projectIamAdmin` covers project-level bindings; `serviceAccountAdmin` covers service-account-level bindings. `deploy.sh` uses both.
 
 End users of the deployed app only need the custom `projects/$PROJECT/roles/SceneMachineUser` role — see [Adding Users](#adding-users).
 

--- a/README.md
+++ b/README.md
@@ -182,20 +182,25 @@ _Please note that most of the APIs are enabled automatically when you run the de
     - Go to the [Firebase console](https://console.firebase.google.com/), select your project then click **Authentication > Sign-in method**.
     - Click **Add new provider**, choose **Google** then enable and save it.
 
-6.  **Link Storage Bucket to Firebase**
-    - Go to the [Firebase console](https://console.firebase.google.com/).
-    - Select your project from the list.
-    - Hover over **Databases & Storage** on the left menu and select **Storage**.
-    - Click **Get started** (if prompted) and ensure the location selected is the same as you selected for the project.
-      - _Note: No-cost locations are only available in the USA._
-    - If asked, start in production mode to ensure the data in firebase is kept private.
-    - Click on the bucket name dropdown and select **+ Add bucket** (if not automatically prompted).
-    - Select **Import existing Google Cloud Storage buckets**.
-    - Select your project bucket and confirm.
+6.  **Link Storage Bucket to Firebase** — _two sequential actions_ are required on the same Firebase Storage page.
+    - Open the [Firebase console](https://console.firebase.google.com/) → select your project → **Databases & Storage** → **Storage**.
+
+    **(a) Initialize Firebase Storage** (one-time per project):
+    - Click **Get started** and walk through the wizard. This creates the project's *default* `<project>.firebasestorage.app` bucket, which the Firebase CLI requires; without it the storage deploy fails with `Firebase Storage has not been set up on project`.
+    - Production mode is fine.
+    - _Note: No-cost locations are only available in the USA._
+
+    **(b) Register your project bucket with Firebase Storage:**
+    - After (a) finishes the bucket dropdown appears at the top of the page (it doesn't exist until a bucket exists).
+    - Click the dropdown → **+ Add bucket** → **Import existing Google Cloud Storage buckets**.
+    - Select your project bucket (the one referenced by `GCS_BUCKET` in `config.txt`) → confirm.
 
 7.  **Deploy UI**
     - Run `./deploy-ui.sh` (if you skipped it during backend deployment).
     - If requested, perform any required manual steps indicated by the script (e.g. linking buckets or configuring OAuth).
+
+> [!TIP]
+> Steps 4–6 can be completed **in parallel** with `./deploy-ui.sh` running. The script polls every 15s (or prompts you for the OAuth consent screen) and continues automatically once each manual action is done. After `./deploy.sh` finishes you can launch `./deploy-ui.sh` immediately and complete steps 4–6 in browser tabs while it waits.
 
 8.  **Set up Identity-Aware Proxy**:
     - In the [App Engine settings](https://console.cloud.google.com/appengine/settings?serviceId=default), under "Identity-Aware Proxy" select "Configure Now".
@@ -211,7 +216,15 @@ To help debug problems with the deployment scripts, you can change their top lin
 
 [< Deployment](#deployment) • [Top](#readme-top) • [Using Scene Machine >](#using-scene-machine)
 
-Each person intending to use Scene Machine needs to be given the "Scene Machine User" role in the Google Cloud project in which the tool is deployed.
+Each person intending to use Scene Machine needs to be given the "Scene Machine User" role in the Google Cloud project in which the tool is deployed. `./deploy-ui.sh`'s final summary outputs a ready-to-paste `gcloud` command for this; you can also run it directly:
+
+```bash
+gcloud projects add-iam-policy-binding $PROJECT \
+  --member="user:USER_EMAIL@example.com" \
+  --role="projects/$PROJECT/roles/SceneMachineUser"
+```
+
+Or grant it via the [IAM console](https://console.cloud.google.com/iam-admin/iam) → **+ Grant Access** → enter user email → role: **Scene Machine User** (under "Custom") → Save.
 
 ## Using Scene Machine
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The following APIs are used by Scene Machine:
 - API Gateway API ( apigateway.googleapis.com ): Used to create and manage the API Gateway that routes traffic to the backend.
 - Artifact Registry API ( artifactregistry.googleapis.com ): Used to store the Docker container images for the backend service.
 - Cloud Build API ( cloudbuild.googleapis.com ): Used to build the container images for Cloud Run.
+- Compute Engine API ( compute.googleapis.com ): Enabled to guarantee the default Compute Engine service account exists (used for IAM role bindings during deploy).
 - Cloud Tasks API ( cloudtasks.googleapis.com ): Used for managing task queues for asynchronous processing (e.g., video generation).
 - Cloud Firestore API ( firestore.googleapis.com ): Used for the database storing application state and configurations.
 - Cloud Run API ( run.googleapis.com ): Used to host and run the backend service.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
 <a id="readme-top"></a>
 _Disclaimer: This is not an officially supported Google product._
 
@@ -21,6 +22,7 @@ _Disclaimer: This is not an officially supported Google product._
 Scene Machine is a Google Cloud-based, open-source workbench that leverages generative AI models to facilitate storyboard-driven video ad creation. While its primary use case is transforming product or service images (such as in retail, food delivery, or travel) into video ads, it also serves as a robust video prototyping platform for rapidly sharing and iterating on ideas.
 
 ## TL;DR
+
 - **Production Speed:** Automates and parallelizes scene generation, reducing a lengthy asset workflow to minutes.
 - **Target Audience:** Advertisers, developers, and creative teams seeking a video generation workbench built natively on Google Cloud.
 - **Key Technology:** Harnesses [Gemini](https://deepmind.google/models/gemini/) for intelligent prompt design and the [Veo model](https://deepmind.google/models/veo/) for high-fidelity, parallel image-to-video generation. The entire workflow is orchestrated through a single intuitive web interface.
@@ -48,15 +50,19 @@ Scene Machine is a Google Cloud-based, open-source workbench that leverages gene
 Scene Machine guides users through four core stages to turn a set of static images into a video asset.
 
 ### 1. Setup (Storyboard Generation)
+
 Upload images and business context (such as target audience and brand guidelines) to have Gemini automatically generate a structured, prompt-driven storyboard. Users can optionally apply predefined Creative Templates to guide scene structure, or start with an empty storyboard to build the timeline manually.
 
 ### 2. Storyboard (Video Generation & Scene-by-Scene Iteration)
+
 The backend sends parallel video generation requests to Google's Veo model, significantly reducing the total time required. Users refine the ad by iterating on prompts and candidate variations scene-by-scene. The timeline can be expanded at any point by generating new scenes (via text-to-video or image-to-video) or by uploading existing video slates. This process is entirely non-destructive, allowing users to adjust, trim, and reorder assets without losing previously generated video scenes.
 
 ### 3. Composition (Transitions, Audio, and Brand Overlays)
+
 Once scenes are finalized, users can enhance their ad in the Composition stage by adding transitions between scenes, custom background audio tracks (music or voice-overs), and precise pixel-positioned image overlays (such as brand logos).
 
 ### 4. Output (Rendering & Export)
+
 Users compile all timeline assets by rendering the video, which is then available for review or direct MP4 download. Crucially, the history panel preserves all older rendered versions, enabling users to maintain and compare multiple creative variants (e.g., short vs. long versions) within the same project.
 
 ## Technical Requirements
@@ -86,10 +92,10 @@ The following APIs are used by Scene Machine:
 - Identity-Aware Proxy (IAP) API ( iap.googleapis.com ): Used to secure the application and manage access.
 - Firebase API ( firebase.googleapis.com ): Used for Firebase integration, project management, and rules deployment.
 - Identity Toolkit API ( identitytoolkit.googleapis.com ): Used for Firebase Authentication and managing user domains.
-- App Engine Admin API ( appengine.googleapis.com ): The UI is deployed to App Engine (see  deploy-ui.sh  line 179).
-- API Keys API ( apikeys.googleapis.com ): Used to create and manage API keys for the API Gateway (see  deploy.sh  line 229).
+- App Engine Admin API ( appengine.googleapis.com ): The UI is deployed to App Engine (see deploy-ui.sh line 179).
+- API Keys API ( apikeys.googleapis.com ): Used to create and manage API keys for the API Gateway (see deploy.sh line 229).
 - Cloud Storage API ( storage.googleapis.com ): Used for storing assets, examples, and generated content.
-- Cloud Logging API ( logging.googleapis.com ): Used for application logging (referenced in  requirements.in ).
+- Cloud Logging API ( logging.googleapis.com ): Used for application logging (referenced in requirements.in ).
 
 _Please note that most of the APIs are enabled automatically when you run the deployment script. Cloud Storage and Cloud Logging are normally enabled by default. If your organization disables these APIs, you will need to enable them manually._
 
@@ -97,20 +103,16 @@ _Please note that most of the APIs are enabled automatically when you run the de
 
 `roles/owner` on the target project is sufficient and is the simplest option.
 
-If your organization's policies require narrower scopes, the tested minimum set is `roles/editor` plus five add-ons. `roles/editor` still covers most of the deploy work (API enable, GCS bucket, Cloud Run, Artifact Registry, API Gateway, Cloud Tasks, API keys, Firebase init, "act as" service accounts). Google narrowed the basic roles for a handful of specific operations, which is what the add-ons cover.
+If your organization's policies require narrower scopes, `roles/editor` covers most of the deploy work. The following additional roles are not included in `editor`, but are required to deploy Scene Machine:
 
-| Role | Why it's needed |
-|---|---|
-| `roles/editor` | Catch-all for the bulk of the deploy operations |
-| `roles/datastore.owner` | Firestore native-mode database creation (not in `editor`) |
-| `roles/appengine.appCreator` | One-time `gcloud app create` at the project level (separate from `appAdmin`; not in `editor`) |
-| `roles/resourcemanager.projectIamAdmin` | Project-level IAM bindings — the `add_iam_binding` calls in `deploy.sh` |
-| `roles/iam.roleAdmin` | Create the custom `SceneMachineUser` role late in `deploy.sh` |
-| `roles/iam.serviceAccountAdmin` | Service-account-level IAM bindings (e.g. Cloud Tasks → Cloud Run "actAs") — a separate `setIamPolicy` from the project-level one |
-
-For `deploy-ui.sh`, add `roles/appengine.appAdmin` so the UI can be deployed to the existing App Engine app (note: this is distinct from `appCreator`, which only allows the initial app creation).
-
-Two distinct `setIamPolicy` permissions matter: `projectIamAdmin` covers project-level bindings; `serviceAccountAdmin` covers service-account-level bindings. `deploy.sh` uses both.
+| Role                                    | Why it's needed                                                           |
+| --------------------------------------- | ------------------------------------------------------------------------- |
+| `roles/datastore.owner`                 | Firestore native-mode database creation                                   |
+| `roles/appengine.appCreator`            | One-time `gcloud app create` at the project level                         |
+| `roles/appengine.appAdmin`              | Deploying the UI (`deploy-ui.sh`) to the existing App Engine app          |
+| `roles/resourcemanager.projectIamAdmin` | Project-level IAM bindings — the `add_iam_binding` calls in `deploy.sh`   |
+| `roles/iam.roleAdmin`                   | Create the custom `SceneMachineUser` role late in `deploy.sh`             |
+| `roles/iam.serviceAccountAdmin`         | Service-account-level IAM bindings (e.g. Cloud Tasks → Cloud Run "actAs") |
 
 End users of the deployed app only need the custom `projects/$PROJECT/roles/SceneMachineUser` role — see [Adding Users](#adding-users).
 
@@ -167,7 +169,7 @@ End users of the deployed app only need the custom `projects/$PROJECT/roles/Scen
     | `API_GATEWAY`          | API Gateway ID for the application endpoint.               | Defaults to `scenemachine-api-gateway`.              |
     | `TASKS_QUEUE_PREFIX`   | Prefix for Cloud Task queue names.                         | Max lengths apply. Support letters, hyphen, numbers. |
     | `BACKEND_SERVICE_NAME` | Service name for the application backend on GCP.           | Defaults to `remix-engine-backend`.                  |
-    | `CUSTOM_DOMAIN`        | Custom domain for the application user interface.          | Optional. e.g., `scene-machine.my-company.com`   |
+    | `CUSTOM_DOMAIN`        | Custom domain for the application user interface.          | Optional. e.g., `scene-machine.my-company.com`       |
     - **Important Notes for Configuration:**
       - **Naming:** Use alphanumerical names (with hyphens) for entities like databases.
       - **Storage:** If using an existing bucket, it must use a non-hierarchical namespace.
@@ -208,7 +210,7 @@ End users of the deployed app only need the custom `projects/$PROJECT/roles/Scen
     - Open the [Firebase console](https://console.firebase.google.com/) → select your project → **Databases & Storage** → **Storage**.
 
     **(a) Initialize Firebase Storage** (one-time per project):
-    - Click **Get started** and walk through the wizard. This creates the project's *default* `<project>.firebasestorage.app` bucket, which the Firebase CLI requires; without it the storage deploy fails with `Firebase Storage has not been set up on project`.
+    - Click **Get started** and walk through the wizard. This creates the project's _default_ `<project>.firebasestorage.app` bucket, which the Firebase CLI requires; without it the storage deploy fails with `Firebase Storage has not been set up on project`.
     - Production mode is fine.
     - _Note: No-cost locations are only available in the USA._
 

--- a/deploy-ui.sh
+++ b/deploy-ui.sh
@@ -75,7 +75,7 @@ add_iam_binding() {
 }
 
 set -eu
-echo "Scene Machine UI deploy — running pre-flight checks first..."
+echo
 
 # Check config
 REQUIRED_VARS=(
@@ -111,7 +111,9 @@ fi
 source ./config.txt
 
 echo
-echo "[>] Starting Scene Machine UI deployment..."
+echo "════════════════════════════════════════════════════════════════════════"
+echo "  Starting Scene Machine UI deployment..."
+echo "════════════════════════════════════════════════════════════════════════"
 
 gcloud config set project $PROJECT
 gcloud auth application-default set-quota-project $PROJECT
@@ -355,7 +357,7 @@ IAP_ENABLED=$(gcloud app describe --project=$PROJECT --format="value(iap.enabled
 
 echo
 echo "════════════════════════════════════════════════════════════════════════"
-echo "  ✓  SCENE MACHINE UI DEPLOYED"
+echo "  ✓  Scene Machine UI deployment complete."
 echo "════════════════════════════════════════════════════════════════════════"
 echo
 echo "  ──────────────────────────────────────────────────────────────────"
@@ -383,10 +385,12 @@ if [[ ! "${IAP_ENABLED:-}" =~ [tT]rue ]]; then
   step=$((step + 1))
 fi
 echo "    ${step}. Grant the 'Scene Machine User' role to each user (highly"
-echo "       recommended — without it, signed-in users hit a 403). Fastest:"
+echo "       recommended — without it, signed-in users hit a 403)."
+echo "       Fastest via command-line:"
 echo "       gcloud projects add-iam-policy-binding ${PROJECT} \\"
 echo "         --member=\"user:YOUR_EMAIL@example.com\" \\"
 echo "         --role=\"projects/${PROJECT}/roles/SceneMachineUser\""
+echo
 echo "       Or via the IAM console:"
 echo "       https://console.cloud.google.com/iam-admin/iam?project=${PROJECT}"
 echo

--- a/deploy-ui.sh
+++ b/deploy-ui.sh
@@ -75,7 +75,7 @@ add_iam_binding() {
 }
 
 set -eu
-echo "Deploying Scene Machine's user interface..."
+echo "Scene Machine UI deploy — running pre-flight checks first..."
 
 # Check config
 REQUIRED_VARS=(
@@ -109,6 +109,9 @@ if [ $MISSING -gt 0 ]; then
   exit 1
 fi
 source ./config.txt
+
+echo
+echo "[>] Starting Scene Machine UI deployment..."
 
 gcloud config set project $PROJECT
 gcloud auth application-default set-quota-project $PROJECT

--- a/deploy-ui.sh
+++ b/deploy-ui.sh
@@ -13,6 +13,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ---------------------------------------------------------------------------
+# Console output convention: lines beginning with "[▶]" mark the start of a
+# major deployment phase. If something fails, copy the "[▶]" prefix (or the
+# full prefix + echo message) from the terminal and Ctrl+F in this file to jump
+# straight to the matching section in the script.
+# ---------------------------------------------------------------------------
+
+# Wrapper for `gcloud projects add-iam-policy-binding` that (a) suppresses the
+# verbose updated-policy YAML on success, and (b) retries with exponential
+# backoff on concurrent-modification etag conflicts. Mirrors the helper in
+# deploy.sh — keep the two definitions in sync.
+add_iam_binding() {
+  # Pull the role out of the args so retry/success messages identify which
+  # binding hit the conflict (otherwise the log just says "an IAM binding").
+  local role=""
+  for arg in "$@"; do
+    case "$arg" in --role=*) role="${arg#--role=}" ;; esac
+  done
+  local label="${role:+ (for $role)}"
+
+  local attempt=1
+  local max_attempts=5
+  while true; do
+    if gcloud projects add-iam-policy-binding "$@" --quiet > /dev/null 2>&1; then
+      if [ $attempt -gt 1 ]; then
+        echo "  ✓ IAM binding${label} succeeded on attempt $attempt."
+      fi
+      return 0
+    fi
+    if [ $attempt -ge $max_attempts ]; then
+      # Final attempt: don't suppress so the real error reaches the user.
+      gcloud projects add-iam-policy-binding "$@" --quiet
+      return $?
+    fi
+    local backoff=$((2 ** attempt))
+    echo "  IAM binding${label} hit a transient conflict — retrying in ${backoff}s (attempt $attempt/$max_attempts)..."
+    sleep $backoff
+    attempt=$((attempt + 1))
+  done
+}
+
 set -eu
 echo "Deploying Scene Machine's user interface..."
 
@@ -59,6 +100,7 @@ export FIREBASE_API_KEY=$(firebase --non-interactive --project $PROJECT apps:sdk
 export FIREBASE_AUTH_DOMAIN=$(firebase --non-interactive --project $PROJECT apps:sdkconfig WEB | grep '"authDomain":' | awk -F '"' '{print $4}')
 if [ -n "${CUSTOM_DOMAIN:-}" ]; then
   export UI_HOST="${CUSTOM_DOMAIN}"
+  echo "✓ Using custom domain: ${UI_HOST}"
 else
   export UI_HOST=$(gcloud app describe --project=$PROJECT --format="value(defaultHostname)")
 fi
@@ -66,29 +108,65 @@ fi
 envsubst < ./ui/definitions/config.template.json > ./ui/definitions/config.json
 envsubst < ./ui/src/env.template.txt > ./ui/src/env.ts
 
-echo "Enabling Identity Toolkit API (needed for Auth config)"
+echo
+echo "[▶] Enabling Identity Toolkit API (needed for Auth config)..."
 gcloud services enable identitytoolkit.googleapis.com --project=$PROJECT
 
-echo "Checking if bucket ${GCS_BUCKET} is linked to Firebase Storage..."
-HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-  -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
-  -H "x-goog-user-project: ${PROJECT}" \
-  "https://firebasestorage.googleapis.com/v1beta/projects/${PROJECT}/buckets/${GCS_BUCKET}")
-# If it returned status != 200, we assume it's not linked
-if [ "$HTTP_STATUS" != "200" ]; then
+# --- Bucket linked to Firebase Storage: poll until satisfied ----------------
+# Replaces the original exit-1-and-rerun pattern. Loops every 15s until the
+# bucket is linked, so the user can complete the console steps and the script
+# picks up automatically.
+#
+# TWO sequential manual steps in the Firebase console are required:
+#   (a) "Get Started" wizard — creates the project's *default* Firebase
+#       Storage bucket (typically <project>.firebasestorage.app). Required
+#       by `firebase deploy --only storage` further below; without it that
+#       command fails with "Firebase Storage has not been set up on project".
+#   (b) "Import existing GCS buckets" — registers ${GCS_BUCKET} (the bucket
+#       deploy.sh created earlier) with Firebase Storage so it can be the
+#       deploy target. The polling check below specifically verifies (b).
+echo
+echo "[▶] Checking if bucket ${GCS_BUCKET} is linked to Firebase Storage..."
+BUCKET_WAIT_ATTEMPTS=0
+BUCKET_WAIT_MAX=120   # 120 × 15s = 30 min total
+while true; do
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+    -H "x-goog-user-project: ${PROJECT}" \
+    "https://firebasestorage.googleapis.com/v1beta/projects/${PROJECT}/buckets/${GCS_BUCKET}")
+  if [ "$HTTP_STATUS" = "200" ]; then
+    echo "✓ Bucket ${GCS_BUCKET} is linked to Firebase Storage."
+    break
+  fi
+  BUCKET_WAIT_ATTEMPTS=$((BUCKET_WAIT_ATTEMPTS + 1))
+  if [ $BUCKET_WAIT_ATTEMPTS -ge $BUCKET_WAIT_MAX ]; then
+    echo "ERROR: bucket ${GCS_BUCKET} still not linked after 30 minutes — aborting."
+    echo "Complete the two manual steps above, then re-run $0."
+    exit 1
+  fi
   echo "============================================================"
-  echo "MANUAL STEP REQUIRED: Bucket ${GCS_BUCKET} is not linked to Firebase Storage."
-  echo "To continue deployment, please import it in the Firebase Console:"
-  echo "1. Go to https://console.firebase.google.com/project/${PROJECT}/storage"
-  echo "2. Click 'Get started' or click on the 'bucket name dropdown > + Add bucket'."
-  echo "3. Select 'Import existing Google Cloud Storage buckets'."
-  echo "4. Select ${GCS_BUCKET} and confirm."
-  echo "After doing this run '$0' again"
+  echo "WAITING: bucket ${GCS_BUCKET} is not yet linked to Firebase Storage."
+  echo "Two sequential steps in the Firebase Console are required:"
+  echo "  Open: https://console.firebase.google.com/project/${PROJECT}/storage"
+  echo
+  echo "  Step 1 — Initialize Firebase Storage (only needed once per project):"
+  echo "    Click 'Get started' and walk through the wizard."
+  echo "    This creates a default <project>.firebasestorage.app bucket."
+  echo "    Production mode is fine."
+  echo
+  echo "  Step 2 — Register ${GCS_BUCKET} with Firebase Storage:"
+  echo "    On the same page (after Step 1 — the bucket dropdown only"
+  echo "    appears once a bucket exists), click the dropdown →"
+  echo "    '+ Add bucket' → 'Import existing Google Cloud Storage"
+  echo "    buckets' → select ${GCS_BUCKET} → confirm."
+  echo
+  echo "Re-checking in 15 seconds (attempt ${BUCKET_WAIT_ATTEMPTS}/${BUCKET_WAIT_MAX}; Ctrl-C to abort)..."
   echo "============================================================"
-  exit 1
-fi
+  sleep 15
+done
 
-echo "Deploying rules for UI Firestore DB"
+echo
+echo "[▶] Deploying rules for UI Firestore DB and Storage..."
 (
   cd firebase
   export CURRENT_FIRESTORE_DB=$FIRESTORE_DB_UI
@@ -106,7 +184,8 @@ echo "Deploying rules for UI Firestore DB"
 rm firebase/firebase.json
 rm firebase/.firebaserc
 
-echo "Adding default Scene Machine configurations to Firestore"
+echo
+echo "[▶] Adding default Scene Machine configurations to Firestore..."
 curl -X PATCH \
 "https://firestore.googleapis.com/v1/projects/${PROJECT}/databases/${FIRESTORE_DB_UI}/documents/config/global" \
   -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
@@ -125,54 +204,83 @@ for template in creative_templates/*.json; do
     -d @"$template"
 done
 
-echo "Granting Storage Admin role to App Engine default service account..."
-gcloud projects add-iam-policy-binding $PROJECT \
+echo
+echo "[▶] Granting Storage Admin role to App Engine default service account..."
+add_iam_binding $PROJECT \
     --member="serviceAccount:${PROJECT}@appspot.gserviceaccount.com" \
     --role="roles/storage.admin" \
-    --condition=None \
-    --quiet
+    --condition=None
 
-echo "Granting Artifact Registry Writer role to App Engine default service account..."
-gcloud projects add-iam-policy-binding $PROJECT \
+echo
+echo "[▶] Granting Artifact Registry Writer role to App Engine default service account..."
+add_iam_binding $PROJECT \
     --member="serviceAccount:${PROJECT}@appspot.gserviceaccount.com" \
     --role="roles/artifactregistry.writer" \
-    --condition=None \
-    --quiet
+    --condition=None
 
-echo "Checking if OAuth consent screen is configured..."
-# Attempt to list brands. If empty or failures, we assume not configured or API disabled.
-BRANDS=$(gcloud iap oauth-brands list --project=$PROJECT --format="value(name)" 2>/dev/null)
-if [[ -z "$BRANDS" ]]; then
-  echo "============================================================"
-  echo "MANUAL STEP REQUIRED: OAuth consent screen is not configured for project ${PROJECT}."
-  echo "To continue deployment, please configure the OAuth consent screen at:"
-  echo "https://console.cloud.google.com/apis/credentials/consent?project=${PROJECT}"
-  echo "After doing this run '$0' again"
-  echo "============================================================"
+# --- OAuth consent screen: manual gate ---------------------------------------
+# `gcloud iap oauth-brands list` (the original verification) was permanently
+# shut down on 2026-03-19 and required project-in-org regardless, so we cannot
+# verify configuration via API on standalone projects. Gate on explicit user
+# confirmation instead: the script blocks until the user answers 'y'.
+echo "============================================================"
+echo "MANUAL STEP REQUIRED: OAuth consent screen must be configured."
+echo "  https://console.cloud.google.com/auth/branding?project=${PROJECT}"
+echo
+echo "First time on this project: click 'Get started' and walk through"
+echo "the setup dialog. User Type is set under 'Audience' — pick"
+echo "'Internal' if you have a Workspace org; otherwise 'External' and"
+echo "add yourself as a test user."
+echo
+echo "If you've configured it before and don't see 'Get started', the"
+echo "screen is already initialized — just confirm below to proceed."
+echo "============================================================"
+if [ ! -t 0 ]; then
+  echo "ERROR: stdin is not a TTY — cannot prompt for OAuth-consent confirmation."
+  echo "Configure the consent screen at the URL above, then re-run $0 interactively."
   exit 1
 fi
+read -r -p "Press Enter once the OAuth consent screen is configured (Ctrl-C to abort)... "
 
-echo "Checking if Google sign-in provider is enabled..."
-CONFIG=$(curl -s -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
-  -H "x-goog-user-project: ${PROJECT}" \
-  "https://identitytoolkit.googleapis.com/admin/v2/projects/${PROJECT}/defaultSupportedIdpConfigs/google.com")
-
-if [[ "$CONFIG" == *'"enabled": true'* ]]; then
-  echo "Google sign-in provider is enabled."
-else
+# --- Google sign-in provider enabled: poll until satisfied ------------------
+# Replaces the original exit-1-and-rerun pattern. Loops every 15s until the
+# provider is enabled.
+echo
+echo "[▶] Checking if Google sign-in provider is enabled..."
+SIGNIN_WAIT_ATTEMPTS=0
+SIGNIN_WAIT_MAX=120   # 120 × 15s = 30 min total
+while true; do
+  CONFIG=$(curl -s -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+    -H "x-goog-user-project: ${PROJECT}" \
+    "https://identitytoolkit.googleapis.com/admin/v2/projects/${PROJECT}/defaultSupportedIdpConfigs/google.com")
+  if [[ "$CONFIG" == *'"enabled": true'* ]]; then
+    echo "✓ Google sign-in provider is enabled."
+    break
+  fi
+  SIGNIN_WAIT_ATTEMPTS=$((SIGNIN_WAIT_ATTEMPTS + 1))
+  if [ $SIGNIN_WAIT_ATTEMPTS -ge $SIGNIN_WAIT_MAX ]; then
+    echo "ERROR: Google sign-in provider still not enabled after 30 minutes — aborting."
+    echo "Enable it in the Firebase Console, then re-run $0:"
+    echo "  https://console.firebase.google.com/project/${PROJECT}/authentication/providers"
+    exit 1
+  fi
   echo "============================================================"
-  echo "MANUAL STEP REQUIRED: Google sign-in provider is not enabled."
-  echo "Please enable it in the Firebase Console at:"
-  echo "https://console.firebase.google.com/project/${PROJECT}/authentication/providers"
-  echo "After doing this run '$0' again"
+  echo "WAITING: Google sign-in provider is not yet enabled."
+  echo "Please enable it in the Firebase Console (script will keep checking):"
+  echo "  https://console.firebase.google.com/project/${PROJECT}/authentication/providers"
+  echo "  If the providers list isn't visible yet, click 'Get started' on the"
+  echo "  Authentication page first to reach it."
+  echo "  Then: 'Add new provider' → choose 'Google' → enable → save."
+  echo "Re-checking in 15 seconds (attempt ${SIGNIN_WAIT_ATTEMPTS}/${SIGNIN_WAIT_MAX}; Ctrl-C to abort)..."
   echo "============================================================"
-  exit 1
-fi
+  sleep 15
+done
 
 # For a local development environment, cloud deployment is not needed
 if [[ "${1:-}" != "local" ]]; then
   export NG_CLI_ANALYTICS=ci
-  echo "Deploying UI (AppEngine)"
+  echo
+  echo "[▶] Deploying UI to App Engine (Estimated time: ≈5 minutes)..."
   (
     cd ui \
       && npm ci --legacy-peer-deps \
@@ -182,10 +290,10 @@ if [[ "${1:-}" != "local" ]]; then
       cd ui \
         && gcloud app deploy --quiet --project "${PROJECT}"
     )
-  echo "Done"
 fi
 
-echo "Configuring Firebase authorized domains..."
+echo
+echo "[▶] Configuring Firebase authorized domains..."
 curl -X PATCH "https://identitytoolkit.googleapis.com/v2/projects/${PROJECT}/config?updateMask=authorizedDomains" \
   -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
   -H "Content-Type: application/json" \
@@ -193,29 +301,50 @@ curl -X PATCH "https://identitytoolkit.googleapis.com/v2/projects/${PROJECT}/con
   -o /dev/null \
   -d "{\"authorizedDomains\": [\"localhost\", \"$(gcloud app describe --format='value(defaultHostname)')\"]}"
 
-echo
-echo "Scene Machine UI is deployed, now you can open:"
+# --- Final summary: success banner + remaining manual steps ----------------
 if [[ "${1:-}" == "local" ]]; then
-  echo "http://localhost:4200/"
+  APP_URL="http://localhost:4200/"
 else
-  echo "https://$(gcloud app describe --format='value(defaultHostname)')"
+  APP_URL="https://$(gcloud app describe --project=$PROJECT --format='value(defaultHostname)')"
 fi
-
-echo
 IAP_ENABLED=$(gcloud app describe --project=$PROJECT --format="value(iap.enabled)" 2>/dev/null || echo "")
 
-if [[ ! "${IAP_ENABLED:-}" =~ [tT]rue ]]; then
-  echo "============================================================"
-  echo "MANUAL STEP REQUIRED: Set up Identity-Aware Proxy."
-  echo "* In the App Engine settings (https://console.cloud.google.com/appengine/settings?serviceId=default), under 'Identity-Aware Proxy' select 'Configure Now'."
-  echo "* Turn on Identity-Aware Proxy for 'App Engine app'."
-  echo "* In the ⋮ menu, select 'Settings', then 'Custom OAuth', then 'Auto-generate credentials'."
-  echo "============================================================"
-  echo
-fi
+echo
+echo "════════════════════════════════════════════════════════════════════════"
+echo "  ✓  SCENE MACHINE UI DEPLOYED"
+echo "════════════════════════════════════════════════════════════════════════"
+echo
+echo "  ──────────────────────────────────────────────────────────────────"
+echo "   OPEN YOUR APP:"
+echo
+echo "       ►  ${APP_URL}"
+echo
+echo "  ──────────────────────────────────────────────────────────────────"
+echo
+echo "  Highly recommended manual steps before users can sign in."
+echo "  Skipping either step will leave the app publicly inaccessible or"
+echo "  unprotected — do not deploy to real users without completing both."
+echo
 
-echo "============================================================"
-echo "MANUAL STEP REQUIRED: Grant User Access."
-echo "* Remember to grant users the 'Scene Machine User' role in IAM so they can access the app!"
-echo "============================================================"
+step=1
+if [[ ! "${IAP_ENABLED:-}" =~ [tT]rue ]]; then
+  echo "    ${step}. Enable Identity-Aware Proxy (highly recommended — gates"
+  echo "       the app behind Google sign-in)."
+  echo "       https://console.cloud.google.com/security/iap?project=${PROJECT}&serviceId=default"
+  echo "       Turn IAP ON for 'App Engine app', then click the ⋮ (three-dot"
+  echo "       menu, far right of the row) → 'Settings' → 'Custom OAuth' →"
+  echo "       'Auto-generate credentials'."
+  echo "       (No need to download the credentials.)"
+  echo
+  step=$((step + 1))
+fi
+echo "    ${step}. Grant the 'Scene Machine User' role to each user (highly"
+echo "       recommended — without it, signed-in users hit a 403). Fastest:"
+echo "       gcloud projects add-iam-policy-binding ${PROJECT} \\"
+echo "         --member=\"user:YOUR_EMAIL@example.com\" \\"
+echo "         --role=\"projects/${PROJECT}/roles/SceneMachineUser\""
+echo "       Or via the IAM console:"
+echo "       https://console.cloud.google.com/iam-admin/iam?project=${PROJECT}"
+echo
+echo "════════════════════════════════════════════════════════════════════════"
 echo

--- a/deploy-ui.sh
+++ b/deploy-ui.sh
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 # ---------------------------------------------------------------------------
-# Console output convention: lines beginning with "[▶]" mark the start of a
-# major deployment phase. If something fails, copy the "[▶]" prefix (or the
+# Console output convention: lines beginning with "[>]" mark the start of a
+# major deployment phase. If something fails, copy the "[>]" prefix (or the
 # full prefix + echo message) from the terminal and Ctrl+F in this file to jump
 # straight to the matching section in the script.
 # ---------------------------------------------------------------------------
@@ -129,7 +129,7 @@ envsubst < ./ui/definitions/config.template.json > ./ui/definitions/config.json
 envsubst < ./ui/src/env.template.txt > ./ui/src/env.ts
 
 echo
-echo "[▶] Enabling Identity Toolkit API (needed for Auth config)..."
+echo "[>] Enabling Identity Toolkit API (needed for Auth config)..."
 gcloud services enable identitytoolkit.googleapis.com --project=$PROJECT
 
 # --- Bucket linked to Firebase Storage: poll until satisfied ----------------
@@ -146,9 +146,12 @@ gcloud services enable identitytoolkit.googleapis.com --project=$PROJECT
 #       deploy.sh created earlier) with Firebase Storage so it can be the
 #       deploy target. The polling check below specifically verifies (b).
 echo
-echo "[▶] Checking if bucket ${GCS_BUCKET} is linked to Firebase Storage..."
+echo "[>] Checking if bucket ${GCS_BUCKET} is linked to Firebase Storage..."
 BUCKET_WAIT_ATTEMPTS=0
 BUCKET_WAIT_MAX=120   # 120 × 15s = 30 min total
+# Source of truth: Firebase Storage REST API. The `firebase` CLI has no
+# per-bucket linkage query, so we hit the REST endpoint directly and treat
+# HTTP 200 as "linked", anything else as "not yet".
 while true; do
   HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
     -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
@@ -186,7 +189,7 @@ while true; do
 done
 
 echo
-echo "[▶] Deploying rules for UI Firestore DB and Storage..."
+echo "[>] Deploying rules for UI Firestore DB and Storage..."
 (
   cd firebase
   export CURRENT_FIRESTORE_DB=$FIRESTORE_DB_UI
@@ -205,7 +208,7 @@ rm firebase/firebase.json
 rm firebase/.firebaserc
 
 echo
-echo "[▶] Adding default Scene Machine configurations to Firestore..."
+echo "[>] Adding default Scene Machine configurations to Firestore..."
 curl -X PATCH \
 "https://firestore.googleapis.com/v1/projects/${PROJECT}/databases/${FIRESTORE_DB_UI}/documents/config/global" \
   -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
@@ -225,14 +228,14 @@ for template in creative_templates/*.json; do
 done
 
 echo
-echo "[▶] Granting Storage Admin role to App Engine default service account..."
+echo "[>] Granting Storage Admin role to App Engine default service account..."
 add_iam_binding $PROJECT \
     --member="serviceAccount:${PROJECT}@appspot.gserviceaccount.com" \
     --role="roles/storage.admin" \
     --condition=None
 
 echo
-echo "[▶] Granting Artifact Registry Writer role to App Engine default service account..."
+echo "[>] Granting Artifact Registry Writer role to App Engine default service account..."
 add_iam_binding $PROJECT \
     --member="serviceAccount:${PROJECT}@appspot.gserviceaccount.com" \
     --role="roles/artifactregistry.writer" \
@@ -241,34 +244,52 @@ add_iam_binding $PROJECT \
 # --- OAuth consent screen: manual gate ---------------------------------------
 # `gcloud iap oauth-brands list` (the original verification) was permanently
 # shut down on 2026-03-19 and required project-in-org regardless, so we cannot
-# verify configuration via API on standalone projects. Gate on explicit user
-# confirmation instead: the script blocks until the user answers 'y'.
-echo "============================================================"
-echo "MANUAL STEP REQUIRED: OAuth consent screen must be configured."
-echo "  https://console.cloud.google.com/auth/branding?project=${PROJECT}"
+# directly verify the consent screen via API on standalone projects.
+#
+# Fast-skip on re-run: probe the Identity Toolkit Admin REST API for the
+# Google IdP config. If it returns 200, the IdP record exists — and that
+# record cannot be created without a configured OAuth consent screen, so
+# 200 implies consent is done. 404 leaves us uncertain; fall back to the
+# blocking Press-Enter prompt below.
 echo
-echo "First time on this project: click 'Get started' and walk through"
-echo "the setup dialog. User Type is set under 'Audience' — pick"
-echo "'Internal' if you have a Workspace org; otherwise 'External' and"
-echo "add yourself as a test user."
-echo
-echo "If you've configured it before and don't see 'Get started', the"
-echo "screen is already initialized — just confirm below to proceed."
-echo "============================================================"
-if [ ! -t 0 ]; then
-  echo "ERROR: stdin is not a TTY — cannot prompt for OAuth-consent confirmation."
-  echo "Configure the consent screen at the URL above, then re-run $0 interactively."
-  exit 1
+echo "[>] Checking if OAuth consent screen is already configured..."
+IDP_HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  -H "x-goog-user-project: ${PROJECT}" \
+  "https://identitytoolkit.googleapis.com/admin/v2/projects/${PROJECT}/defaultSupportedIdpConfigs/google.com")
+if [ "$IDP_HTTP_STATUS" = "200" ]; then
+  echo "✓ OAuth consent screen already configured (Google IdP record exists)."
+else
+  echo "============================================================"
+  echo "MANUAL STEP REQUIRED: OAuth consent screen must be configured."
+  echo "  https://console.cloud.google.com/auth/branding?project=${PROJECT}"
+  echo
+  echo "First time on this project: click 'Get started' and walk through"
+  echo "the setup dialog. User Type is set under 'Audience' — pick"
+  echo "'Internal' if you have a Workspace org; otherwise 'External' and"
+  echo "add yourself as a test user."
+  echo
+  echo "If you've configured it before and don't see 'Get started', the"
+  echo "screen is already initialized — just confirm below to proceed."
+  echo "============================================================"
+  if [ ! -t 0 ]; then
+    echo "ERROR: stdin is not a TTY — cannot prompt for OAuth-consent confirmation."
+    echo "Configure the consent screen at the URL above, then re-run $0 interactively."
+    exit 1
+  fi
+  read -r -p "Press Enter once the OAuth consent screen is configured (Ctrl-C to abort)... "
 fi
-read -r -p "Press Enter once the OAuth consent screen is configured (Ctrl-C to abort)... "
 
 # --- Google sign-in provider enabled: poll until satisfied ------------------
 # Replaces the original exit-1-and-rerun pattern. Loops every 15s until the
 # provider is enabled.
 echo
-echo "[▶] Checking if Google sign-in provider is enabled..."
+echo "[>] Checking if Google sign-in provider is enabled..."
 SIGNIN_WAIT_ATTEMPTS=0
 SIGNIN_WAIT_MAX=120   # 120 × 15s = 30 min total
+# Source of truth: Identity Toolkit Admin REST API. The `firebase auth:` CLI
+# has no IdP enable-state query, so we read the IdP config directly and look
+# for `"enabled": true` in the JSON body.
 while true; do
   CONFIG=$(curl -s -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
     -H "x-goog-user-project: ${PROJECT}" \
@@ -300,7 +321,7 @@ done
 if [[ "${1:-}" != "local" ]]; then
   export NG_CLI_ANALYTICS=ci
   echo
-  echo "[▶] Deploying UI to App Engine (Estimated time: ≈5 minutes)..."
+  echo "[>] Deploying UI to App Engine (Estimated time: ≈5 minutes)..."
   (
     cd ui \
       && npm ci --legacy-peer-deps \
@@ -313,7 +334,7 @@ if [[ "${1:-}" != "local" ]]; then
 fi
 
 echo
-echo "[▶] Configuring Firebase authorized domains..."
+echo "[>] Configuring Firebase authorized domains..."
 curl -X PATCH "https://identitytoolkit.googleapis.com/v2/projects/${PROJECT}/config?updateMask=authorizedDomains" \
   -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
   -H "Content-Type: application/json" \

--- a/deploy-ui.sh
+++ b/deploy-ui.sh
@@ -74,7 +74,7 @@ add_iam_binding() {
   done
 }
 
-set -eu
+set -euo pipefail
 echo
 
 # Check config
@@ -100,12 +100,12 @@ REQUIRED_VARS=(
 MISSING=0
 for var in "${REQUIRED_VARS[@]}"; do
   if ! grep -qE "^(export )?${var}=[A-Za-z0-9._\$-]+" config.txt; then
-    echo "ERROR: $var is missing, empty, or has invalid characters in config.txt"
+    echo "ERROR: $var is missing, empty, or has invalid characters in config.txt" >&2
     MISSING=$((MISSING + 1))
   fi
 done
 if [ $MISSING -gt 0 ]; then
-  echo "Validation failed. Please fix config.txt and try again."
+  echo "Validation failed. Please fix config.txt and try again." >&2
   exit 1
 fi
 source ./config.txt
@@ -121,8 +121,18 @@ gcloud auth application-default set-quota-project $PROJECT
 API_UID=$(gcloud services api-keys list --filter="displayName='Scene Machine API Key'" --format="value(uid)" --project=$PROJECT)
 export API_KEY=$(gcloud services api-keys get-key-string $API_UID --project=$PROJECT --format="value(keyString)")
 export API_GATEWAY_HOST=$(gcloud api-gateway gateways describe scenemachine-api-gateway --project=$PROJECT --location=$API_GATEWAY_REGION --format="value(defaultHostname)")
-export FIREBASE_API_KEY=$(firebase --non-interactive --project $PROJECT apps:sdkconfig WEB | grep '"apiKey":' | awk -F '"' '{print $4}')
-export FIREBASE_AUTH_DOMAIN=$(firebase --non-interactive --project $PROJECT apps:sdkconfig WEB | grep '"authDomain":' | awk -F '"' '{print $4}')
+FIREBASE_API_KEY=$(firebase --non-interactive --project $PROJECT apps:sdkconfig WEB | grep '"apiKey":' | awk -F '"' '{print $4}')
+if [ -z "$FIREBASE_API_KEY" ]; then
+  echo "ERROR: Failed to extract Firebase API key from 'firebase apps:sdkconfig WEB'. Check that the Firebase Web app exists in project $PROJECT." >&2
+  exit 1
+fi
+export FIREBASE_API_KEY
+FIREBASE_AUTH_DOMAIN=$(firebase --non-interactive --project $PROJECT apps:sdkconfig WEB | grep '"authDomain":' | awk -F '"' '{print $4}')
+if [ -z "$FIREBASE_AUTH_DOMAIN" ]; then
+  echo "ERROR: Failed to extract Firebase auth domain from 'firebase apps:sdkconfig WEB'. Check that the Firebase Web app exists in project $PROJECT." >&2
+  exit 1
+fi
+export FIREBASE_AUTH_DOMAIN
 if [ -n "${CUSTOM_DOMAIN:-}" ]; then
   export UI_HOST="${CUSTOM_DOMAIN}"
   echo "✓ Using custom domain: ${UI_HOST}"
@@ -168,8 +178,8 @@ while true; do
   fi
   BUCKET_WAIT_ATTEMPTS=$((BUCKET_WAIT_ATTEMPTS + 1))
   if [ $BUCKET_WAIT_ATTEMPTS -ge $BUCKET_WAIT_MAX ]; then
-    echo "ERROR: bucket ${GCS_BUCKET} still not linked after 30 minutes — aborting."
-    echo "Complete the two manual steps above, then re-run $0."
+    echo "ERROR: bucket ${GCS_BUCKET} still not linked after 30 minutes — aborting." >&2
+    echo "Complete the two manual steps above, then re-run $0." >&2
     exit 1
   fi
   echo "============================================================"
@@ -234,17 +244,11 @@ done
 
 echo
 echo "[>] Granting Storage Admin role to App Engine default service account..."
-add_iam_binding $PROJECT \
-    --member="serviceAccount:${PROJECT}@appspot.gserviceaccount.com" \
-    --role="roles/storage.admin" \
-    --condition=None
+add_iam_binding $PROJECT --member="serviceAccount:${PROJECT}@appspot.gserviceaccount.com" --role="roles/storage.admin" --condition=None
 
 echo
 echo "[>] Granting Artifact Registry Writer role to App Engine default service account..."
-add_iam_binding $PROJECT \
-    --member="serviceAccount:${PROJECT}@appspot.gserviceaccount.com" \
-    --role="roles/artifactregistry.writer" \
-    --condition=None
+add_iam_binding $PROJECT --member="serviceAccount:${PROJECT}@appspot.gserviceaccount.com" --role="roles/artifactregistry.writer" --condition=None
 
 # --- OAuth consent screen: manual gate ---------------------------------------
 # `gcloud iap oauth-brands list` (the original verification) was permanently
@@ -278,8 +282,8 @@ else
   echo "screen is already initialized — just confirm below to proceed."
   echo "============================================================"
   if [ ! -t 0 ]; then
-    echo "ERROR: stdin is not a TTY — cannot prompt for OAuth-consent confirmation."
-    echo "Configure the consent screen at the URL above, then re-run $0 interactively."
+    echo "ERROR: stdin is not a TTY — cannot prompt for OAuth-consent confirmation." >&2
+    echo "Configure the consent screen at the URL above, then re-run $0 interactively." >&2
     exit 1
   fi
   read -r -p "Press Enter once the OAuth consent screen is configured (Ctrl-C to abort)... "
@@ -305,9 +309,9 @@ while true; do
   fi
   SIGNIN_WAIT_ATTEMPTS=$((SIGNIN_WAIT_ATTEMPTS + 1))
   if [ $SIGNIN_WAIT_ATTEMPTS -ge $SIGNIN_WAIT_MAX ]; then
-    echo "ERROR: Google sign-in provider still not enabled after 30 minutes — aborting."
-    echo "Enable it in the Firebase Console, then re-run $0:"
-    echo "  https://console.firebase.google.com/project/${PROJECT}/authentication/providers"
+    echo "ERROR: Google sign-in provider still not enabled after 30 minutes — aborting." >&2
+    echo "Enable it in the Firebase Console, then re-run $0:" >&2
+    echo "  https://console.firebase.google.com/project/${PROJECT}/authentication/providers" >&2
     exit 1
   fi
   echo "============================================================"

--- a/deploy-ui.sh
+++ b/deploy-ui.sh
@@ -33,21 +33,41 @@ add_iam_binding() {
   done
   local label="${role:+ (for $role)}"
 
+  local stderr_file
+  stderr_file=$(mktemp)
+  trap 'rm -f "$stderr_file"' RETURN
+
   local attempt=1
-  local max_attempts=5
+  local max_attempts=6
   while true; do
-    if gcloud projects add-iam-policy-binding "$@" --quiet > /dev/null 2>&1; then
+    if gcloud projects add-iam-policy-binding "$@" --quiet >/dev/null 2>"$stderr_file"; then
       if [ $attempt -gt 1 ]; then
         echo "  ✓ IAM binding${label} succeeded on attempt $attempt."
       fi
       return 0
     fi
-    if [ $attempt -ge $max_attempts ]; then
-      # Final attempt: don't suppress so the real error reaches the user.
-      gcloud projects add-iam-policy-binding "$@" --quiet
-      return $?
+
+    # Only retry on concurrent-modification / etag races. Permission, argument,
+    # and not-found errors won't fix themselves — surface them immediately.
+    if ! grep -qiE 'concurrent|aborted|etag|stale' "$stderr_file"; then
+      echo "  ERROR: IAM binding${label} failed with a non-retryable error:" >&2
+      cat "$stderr_file" >&2
+      return 1
     fi
-    local backoff=$((2 ** attempt))
+
+    if [ $attempt -ge $max_attempts ]; then
+      echo "  ERROR: IAM binding${label} still conflicting after $max_attempts attempts:" >&2
+      cat "$stderr_file" >&2
+      return 1
+    fi
+
+    # Exponential backoff with ±25% jitter to desynchronise retries when
+    # multiple bindings race the same background modifier.
+    local base=$((2 ** attempt))
+    local jitter=$((RANDOM % (base / 2 + 1) - base / 4))
+    local backoff=$((base + jitter))
+    [ $backoff -lt 1 ] && backoff=1
+
     echo "  IAM binding${label} hit a transient conflict — retrying in ${backoff}s (attempt $attempt/$max_attempts)..."
     sleep $backoff
     attempt=$((attempt + 1))

--- a/deploy.sh
+++ b/deploy.sh
@@ -83,7 +83,7 @@ add_iam_binding() {
 }
 
 set -eu
-echo "Deploying Scene Machine... (Total runtime estimate: ≈15 minutes)"
+echo "Scene Machine backend deploy — running pre-flight checks first..."
 
 # --- Pre-flight: required tools and gcloud auth -----------------------------
 # Fail fast if a required command is missing or gcloud isn't authenticated,
@@ -194,6 +194,9 @@ case "$confirm" in
     exit 1
     ;;
 esac
+
+echo
+echo "[>] Starting Scene Machine backend deployment (estimated runtime ≈15 minutes)..."
 
 # Enable services
 # Note: compute.googleapis.com is enabled here so the default Compute Engine

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 # ---------------------------------------------------------------------------
-# Console output convention: lines beginning with "[▶]" mark the start of a
-# major deployment phase. If something fails, copy the "[▶]" prefix (or the
+# Console output convention: lines beginning with "[>]" mark the start of a
+# major deployment phase. If something fails, copy the "[>]" prefix (or the
 # full prefix + echo message) from the terminal and Ctrl+F in this file to jump
 # straight to the matching section in the script.
 # ---------------------------------------------------------------------------
@@ -89,7 +89,7 @@ echo "Deploying Scene Machine... (Total runtime estimate: ≈15 minutes)"
 # Fail fast if a required command is missing or gcloud isn't authenticated,
 # rather than 30+ seconds into a gcloud/firebase call with a confusing error.
 echo
-echo "[▶] Checking required tools..."
+echo "[>] Checking required tools..."
 MISSING_TOOLS=0
 require_tool() {
   local name="$1"
@@ -119,7 +119,7 @@ echo "✓ gcloud authenticated as: $ACTIVE_ACCOUNT"
 
 # --- Check config.txt -------------------------------------------------------
 echo
-echo "[▶] Checking config.txt..."
+echo "[>] Checking config.txt..."
 REQUIRED_VARS=(
   "API_GATEWAY"
   "API_GATEWAY_REGION"
@@ -182,7 +182,7 @@ fi
 # service account (used for role bindings below) is guaranteed to exist. Most
 # projects already have it enabled transitively; this handles fresh projects.
 echo
-echo "[▶] Enabling required Google Cloud APIs..."
+echo "[>] Enabling required Google Cloud APIs..."
 gcloud config set project $PROJECT
 gcloud auth application-default set-quota-project $PROJECT
 gcloud services enable aiplatform.googleapis.com apigateway.googleapis.com artifactregistry.googleapis.com cloudbuild.googleapis.com cloudtasks.googleapis.com compute.googleapis.com firestore.googleapis.com run.googleapis.com servicecontrol.googleapis.com iap.googleapis.com --project=$PROJECT
@@ -193,13 +193,18 @@ gcloud services enable aiplatform.googleapis.com apigateway.googleapis.com artif
 # takes ~5-15 min to propagate. Without this, the user's first Veo generation
 # fails with "Service agents are being provisioned." Triggering identity
 # creation now starts the propagation window during the rest of the deploy.
+#
+# `services identity create` is still on the `beta` surface today; try the GA
+# path first so we survive its eventual promotion (the beta command will be
+# removed at some point and would silently fail on a future toolchain).
 echo
-echo "[▶] Provisioning Vertex AI service agent..."
-gcloud beta services identity create --service=aiplatform.googleapis.com --project=$PROJECT
+echo "[>] Provisioning Vertex AI service agent..."
+gcloud services identity create --service=aiplatform.googleapis.com --project=$PROJECT 2>/dev/null \
+  || gcloud beta services identity create --service=aiplatform.googleapis.com --project=$PROJECT
 
 # Create databases
 echo
-echo "[▶] Setting up GCS bucket and Firestore databases..."
+echo "[>] Setting up GCS bucket and Firestore databases..."
 if ! gcloud storage buckets describe "gs://$GCS_BUCKET" &> /dev/null; then
     gcloud storage buckets create "gs://$GCS_BUCKET" --project=$PROJECT --location="$REGION"
 else
@@ -222,7 +227,7 @@ else
 fi
 
 echo
-echo "[▶] Setting up Firebase project and Web App..."
+echo "[>] Setting up Firebase project and Web App..."
 if gcloud services list --enabled --project=$PROJECT --filter="name:firebase.googleapis.com" | grep -q "firebase.googleapis.com"; then
   echo "Firebase is already enabled for the project."
 else
@@ -245,7 +250,7 @@ envsubst < ./firebase/.firebaserc.template > ./firebase/.firebaserc
 firebase target:apply --config firebase/firebase.json storage bucket_target $GCS_BUCKET --project $PROJECT
 
 echo
-echo "[▶] Deploying rules for Backend Firestore DB..."
+echo "[>] Deploying rules for Backend Firestore DB..."
 firebase deploy --config firebase/firebase.json --only firestore --project $PROJECT
 
 rm firebase/firebase.json
@@ -254,7 +259,7 @@ rm firebase/.firebaserc
 export FIREBASE_API_KEY=$(firebase --non-interactive --project $PROJECT apps:sdkconfig WEB | grep '"apiKey":' | awk -F '"' '{print $4}')
 
 echo
-echo "[▶] Setting up App Engine app..."
+echo "[>] Setting up App Engine app..."
 if ! gcloud app describe --project=$PROJECT &> /dev/null; then
   echo "App Engine app doesn't exist. Creating it (Estimated time: ≈3 minutes)..."
   gcloud app create --region $APP_ENGINE_REGION --project $PROJECT
@@ -277,13 +282,13 @@ SERVICE_ACCOUNT="$PROJECT_NUMBER-compute@developer.gserviceaccount.com"
 # Wait for it to exist before attempting role bindings below, rather than
 # failing inside the loop with a confusing "service account not found" error.
 echo
-echo "[▶] Waiting for default Compute Engine service account to exist..."
+echo "[>] Waiting for default Compute Engine service account to exist..."
 SA_WAIT_ATTEMPTS=0
-SA_WAIT_MAX=60   # 60 × 5s = 5 min total
+SA_WAIT_MAX=120   # 120 × 5s = 10 min total
 until gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" --project=$PROJECT &> /dev/null; do
   SA_WAIT_ATTEMPTS=$((SA_WAIT_ATTEMPTS + 1))
   if [ $SA_WAIT_ATTEMPTS -ge $SA_WAIT_MAX ]; then
-    echo "ERROR: default Compute Engine SA did not appear after 5 minutes."
+    echo "ERROR: default Compute Engine SA did not appear after 10 minutes."
     echo "Try enabling Compute Engine API manually, then re-run $0:"
     echo "  gcloud services enable compute.googleapis.com --project=$PROJECT"
     exit 1
@@ -304,7 +309,7 @@ ROLES=(
   "roles/iam.serviceAccountUser"
 )
 echo
-echo "[▶] Granting ${#ROLES[@]} roles to $SERVICE_ACCOUNT..."
+echo "[>] Granting ${#ROLES[@]} roles to $SERVICE_ACCOUNT..."
 for ROLE in "${ROLES[@]}"; do
   echo "  - $ROLE"
   add_iam_binding $PROJECT --member="serviceAccount:${SERVICE_ACCOUNT}" --role="$ROLE" --condition=None
@@ -317,7 +322,7 @@ echo "✓ Roles granted."
 # provisioned" failure (see DEPLOY_NOTES.md issue #6).
 AIPLATFORM_SA="service-${PROJECT_NUMBER}@gcp-sa-aiplatform.iam.gserviceaccount.com"
 echo
-echo "[▶] Granting roles/storage.objectUser to Vertex AI service agent..."
+echo "[>] Granting roles/storage.objectUser to Vertex AI service agent..."
 add_iam_binding $PROJECT \
   --member="serviceAccount:${AIPLATFORM_SA}" \
   --role="roles/storage.objectUser" \
@@ -337,13 +342,13 @@ fi
 generate_config
 
 echo
-echo "[▶] Deploying backend to Cloud Run (Estimated time: ~5 minutes)..."
+echo "[>] Deploying backend to Cloud Run (Estimated time: ~5 minutes)..."
 gcloud run deploy "$BACKEND_SERVICE_NAME" --source . --image $REGION-docker.pkg.dev/$PROJECT/$ARTIFACT_REPO/$BACKEND_SERVICE_NAME:latest --region $REGION --project $PROJECT --cpu=8 --memory=16G --timeout=1800 --no-allow-unauthenticated
 export CLOUD_RUN_URL=$(gcloud run services describe "$BACKEND_SERVICE_NAME" --region=$REGION --project=$PROJECT --format='value(status.url)')
 
 # Ensure queues
 echo
-echo "[▶] Setting up Cloud Tasks queues..."
+echo "[>] Setting up Cloud Tasks queues..."
 QUEUES=("Other" "Gemini" "Veo")
 for QUEUE_SUFFIX in "${QUEUES[@]}"; do
   QUEUE_NAME="${TASKS_QUEUE_PREFIX}${QUEUE_SUFFIX}"
@@ -381,12 +386,12 @@ done
 # Apply IAM bindings for the Cloud Tasks service agent.
 CLOUD_TASKS_ACCOUNT="service-${PROJECT_NUMBER}@gcp-sa-cloudtasks.iam.gserviceaccount.com"
 echo
-echo "[▶] Granting Cloud Tasks service agent permissions..."
+echo "[>] Granting Cloud Tasks service agent permissions..."
 add_iam_binding "${PROJECT}" --member="serviceAccount:${CLOUD_TASKS_ACCOUNT}" --role="roles/cloudtasks.serviceAgent" --condition=None
 gcloud iam service-accounts add-iam-policy-binding "${SERVICE_ACCOUNT}" --member="serviceAccount:${CLOUD_TASKS_ACCOUNT}" --role="roles/iam.serviceAccountTokenCreator" --quiet > /dev/null
 
 echo
-echo "[▶] Provisioning API Gateway and routing infrastructure (Estimated time: ≈10 minutes)..."
+echo "[>] Provisioning API Gateway and routing infrastructure (Estimated time: ≈10 minutes)..."
 if ! gcloud api-gateway apis describe scenemachine-api --project=$PROJECT --format="value(managed_service)" &> /dev/null; then
   echo "API doesn't exist. Creating it..."
   gcloud api-gateway apis create scenemachine-api --project=$PROJECT

--- a/deploy.sh
+++ b/deploy.sh
@@ -82,7 +82,7 @@ add_iam_binding() {
   done
 }
 
-set -eu
+set -euo pipefail
 echo
 echo "================================================================================"
 echo "  Scene Machine backend deploy — running pre-flight checks first..."
@@ -96,7 +96,7 @@ require_tool() {
   local name="$1"
   local hint="$2"
   if ! command -v "$name" >/dev/null 2>&1; then
-    echo "ERROR: '$name' is not installed. $hint"
+    echo "ERROR: '$name' is not installed. $hint" >&2
     MISSING_TOOLS=$((MISSING_TOOLS + 1))
   fi
 }
@@ -111,8 +111,8 @@ if [ $MISSING_TOOLS -gt 0 ]; then
 fi
 ACTIVE_ACCOUNT=$(gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null || true)
 if [ -z "$ACTIVE_ACCOUNT" ]; then
-  echo "ERROR: gcloud has no active authenticated account."
-  echo "Run: gcloud auth login && gcloud auth application-default login"
+  echo "ERROR: gcloud has no active authenticated account." >&2
+  echo "Run: gcloud auth login && gcloud auth application-default login" >&2
   exit 1
 fi
 echo "✓ All required tools found (gcloud, firebase, node, npm, envsubst)."
@@ -143,12 +143,12 @@ REQUIRED_VARS=(
 MISSING=0
 for var in "${REQUIRED_VARS[@]}"; do
   if ! grep -qE "^(export )?${var}=[A-Za-z0-9._\$-]+" ./config.txt; then
-    echo "ERROR: $var is missing, empty, or has invalid characters in config.txt"
+    echo "ERROR: $var is missing, empty, or has invalid characters in config.txt" >&2
     MISSING=$((MISSING + 1))
   fi
 done
 if [ $MISSING -gt 0 ]; then
-  echo "Validation failed. Please fix config.txt and try again."
+  echo "Validation failed. Please fix config.txt and try again." >&2
   exit 1
 fi
 source ./config.txt
@@ -182,19 +182,18 @@ if [ "$CURRENT_GCLOUD_PROJECT" != "$PROJECT" ]; then
 fi
 echo "════════════════════════════════════════════════════════════════════════"
 if [ ! -t 0 ]; then
-  echo "ERROR: stdin is not a TTY — cannot confirm. Re-run interactively."
+  echo "ERROR: stdin is not a TTY — cannot confirm. Re-run interactively." >&2
   exit 1
 fi
 read -r -p "Proceed and deploy to '$PROJECT'? (y/N) " confirm
-case "$confirm" in
-  [yY]|[yY][eE][sS]) echo "✓ Continuing with project $PROJECT." ;;
-  *)
-    echo "Aborted. To align gcloud with config.txt:"
-    echo "  gcloud config set project $PROJECT"
-    echo "Or update PROJECT in config.txt to match your intended target."
-    exit 1
-    ;;
-esac
+confirm=$(echo "$confirm" | tr '[:upper:]' '[:lower:]')
+if [ "$confirm" != "y" ] && [ "$confirm" != "yes" ]; then
+  echo "Aborted. To align gcloud with config.txt:" >&2
+  echo "  gcloud config set project $PROJECT" >&2
+  echo "Or update PROJECT in config.txt to match your intended target." >&2
+  exit 1
+fi
+echo "✓ Continuing with project $PROJECT."
 
 echo 
 echo "════════════════════════════════════════════════════════════════════════"
@@ -285,7 +284,12 @@ firebase deploy --config firebase/firebase.json --only firestore --project $PROJ
 rm firebase/firebase.json
 rm firebase/.firebaserc
 
-export FIREBASE_API_KEY=$(firebase --non-interactive --project $PROJECT apps:sdkconfig WEB | grep '"apiKey":' | awk -F '"' '{print $4}')
+FIREBASE_API_KEY=$(firebase --non-interactive --project $PROJECT apps:sdkconfig WEB | grep '"apiKey":' | awk -F '"' '{print $4}')
+if [ -z "$FIREBASE_API_KEY" ]; then
+  echo "ERROR: Failed to extract Firebase API key from 'firebase apps:sdkconfig WEB'. Check that the Firebase Web app exists in project $PROJECT." >&2
+  exit 1
+fi
+export FIREBASE_API_KEY
 
 echo
 echo "[>] Setting up App Engine app..."
@@ -317,9 +321,9 @@ SA_WAIT_MAX=120   # 120 × 5s = 10 min total
 until gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" --project=$PROJECT &> /dev/null; do
   SA_WAIT_ATTEMPTS=$((SA_WAIT_ATTEMPTS + 1))
   if [ $SA_WAIT_ATTEMPTS -ge $SA_WAIT_MAX ]; then
-    echo "ERROR: default Compute Engine SA did not appear after 10 minutes."
-    echo "Try enabling Compute Engine API manually, then re-run $0:"
-    echo "  gcloud services enable compute.googleapis.com --project=$PROJECT"
+    echo "ERROR: default Compute Engine SA did not appear after 10 minutes." >&2
+    echo "Try enabling Compute Engine API manually, then re-run $0:" >&2
+    echo "  gcloud services enable compute.googleapis.com --project=$PROJECT" >&2
     exit 1
   fi
   sleep 5
@@ -352,10 +356,7 @@ echo "✓ Roles granted."
 AIPLATFORM_SA="service-${PROJECT_NUMBER}@gcp-sa-aiplatform.iam.gserviceaccount.com"
 echo
 echo "[>] Granting roles/storage.objectUser to Vertex AI service agent..."
-add_iam_binding $PROJECT \
-  --member="serviceAccount:${AIPLATFORM_SA}" \
-  --role="roles/storage.objectUser" \
-  --condition=None
+add_iam_binding $PROJECT --member="serviceAccount:${AIPLATFORM_SA}" --role="roles/storage.objectUser" --condition=None
 
 # Deploy backend (Cloud Run)
 COMMIT_DATE=$(git log -1 --format=%cI)
@@ -461,7 +462,7 @@ fi
 if [ -n "$API_UID" ]; then
   export API_KEY=$(gcloud services api-keys get-key-string $API_UID --project=$PROJECT --format="value(keyString)")
 else
-  echo "ERROR: Failed to retrieve API Key UID."
+  echo "ERROR: Failed to retrieve API Key UID." >&2
   exit 1
 fi
 export API_GATEWAY_HOST=$(gcloud api-gateway gateways describe scenemachine-api-gateway --project=$PROJECT --location=$API_GATEWAY_REGION --format="value(defaultHostname)")
@@ -523,7 +524,7 @@ echo
 echo "════════════════════════════════════════════════════════════════════════"
 echo
 read -r -p "Run ./deploy-ui.sh now? (y/N) " answer
-if [[ "$answer" =~ ^[Yy]$ ]]; then
+if [[ "$answer" =~ ^[Yy]([Ee][Ss])?$ ]]; then
   ./deploy-ui.sh
 else
   echo "To deploy the UI later, run ./deploy-ui.sh. Deployment guide:"

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,15 +13,93 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ---------------------------------------------------------------------------
+# Console output convention: lines beginning with "[▶]" mark the start of a
+# major deployment phase. If something fails, copy the "[▶]" prefix (or the
+# full prefix + echo message) from the terminal and Ctrl+F in this file to jump
+# straight to the matching section in the script.
+# ---------------------------------------------------------------------------
+
 # Generate ui/definitions/config.json for backend and frontend
 generate_config() {
   envsubst < ui/definitions/config.template.json > ui/definitions/config.json
 }
 
-set -eu
-echo "Deploying Scene Machine... (Total runtime estimate: ≈17 minutes)"
+# Wrapper for `gcloud projects add-iam-policy-binding` that (a) suppresses the
+# verbose updated-policy YAML on success, and (b) retries with exponential
+# backoff on concurrent-modification etag conflicts. Background GCP work (App
+# Engine setup, Firebase, service-agent provisioning) modifies the project
+# policy in parallel with our sequential read-modify-writes, occasionally
+# racing our etag. The gcloud error itself recommends "retry with exponential
+# backoff" — this helper does that automatically.
+add_iam_binding() {
+  # Pull the role out of the args so retry/success messages identify which
+  # binding hit the conflict (otherwise the log just says "an IAM binding").
+  local role=""
+  for arg in "$@"; do
+    case "$arg" in --role=*) role="${arg#--role=}" ;; esac
+  done
+  local label="${role:+ (for $role)}"
 
-# Check config
+  local attempt=1
+  local max_attempts=5
+  while true; do
+    if gcloud projects add-iam-policy-binding "$@" --quiet > /dev/null 2>&1; then
+      if [ $attempt -gt 1 ]; then
+        echo "  ✓ IAM binding${label} succeeded on attempt $attempt."
+      fi
+      return 0
+    fi
+    if [ $attempt -ge $max_attempts ]; then
+      # Final attempt: don't suppress so the real error reaches the user.
+      gcloud projects add-iam-policy-binding "$@" --quiet
+      return $?
+    fi
+    local backoff=$((2 ** attempt))
+    echo "  IAM binding${label} hit a transient conflict — retrying in ${backoff}s (attempt $attempt/$max_attempts)..."
+    sleep $backoff
+    attempt=$((attempt + 1))
+  done
+}
+
+set -eu
+echo "Deploying Scene Machine... (Total runtime estimate: ≈15 minutes)"
+
+# --- Pre-flight: required tools and gcloud auth -----------------------------
+# Fail fast if a required command is missing or gcloud isn't authenticated,
+# rather than 30+ seconds into a gcloud/firebase call with a confusing error.
+echo
+echo "[▶] Checking required tools..."
+MISSING_TOOLS=0
+require_tool() {
+  local name="$1"
+  local hint="$2"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "ERROR: '$name' is not installed. $hint"
+    MISSING_TOOLS=$((MISSING_TOOLS + 1))
+  fi
+}
+require_tool gcloud   "Install: https://cloud.google.com/sdk/docs/install"
+require_tool firebase "Install: npm i -g firebase-tools"
+require_tool node     "Install Node.js ≥ v22: https://nodejs.org/en/download"
+require_tool npm      "Install Node.js (includes npm): https://nodejs.org/en/download"
+require_tool envsubst "Install gettext (macOS: 'brew install gettext'; Debian/Ubuntu: 'apt-get install gettext')"
+if [ $MISSING_TOOLS -gt 0 ]; then
+  echo "Please install the missing tools above, then re-run $0."
+  exit 1
+fi
+ACTIVE_ACCOUNT=$(gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null || true)
+if [ -z "$ACTIVE_ACCOUNT" ]; then
+  echo "ERROR: gcloud has no active authenticated account."
+  echo "Run: gcloud auth login && gcloud auth application-default login"
+  exit 1
+fi
+echo "✓ All required tools found (gcloud, firebase, node, npm, envsubst)."
+echo "✓ gcloud authenticated as: $ACTIVE_ACCOUNT"
+
+# --- Check config.txt -------------------------------------------------------
+echo
+echo "[▶] Checking config.txt..."
 REQUIRED_VARS=(
   "API_GATEWAY"
   "API_GATEWAY_REGION"
@@ -53,13 +131,55 @@ if [ $MISSING -gt 0 ]; then
   exit 1
 fi
 source ./config.txt
+echo "✓ config.txt is valid. Target project: $PROJECT"
+
+# --- Sanity check: gcloud project matches config.txt ------------------------
+# Catches the footgun of forgetting to update config.txt (or gcloud's active
+# project) before running. The script proceeds to overwrite gcloud's active
+# project below, so we explicitly confirm the intended target first.
+CURRENT_GCLOUD_PROJECT=$(gcloud config get-value project 2>/dev/null || true)
+if [ -n "$CURRENT_GCLOUD_PROJECT" ] && [ "$CURRENT_GCLOUD_PROJECT" != "$PROJECT" ]; then
+  echo "============================================================"
+  echo "WARNING: project mismatch detected."
+  echo "  gcloud is currently set to: $CURRENT_GCLOUD_PROJECT"
+  echo "  config.txt PROJECT is:      $PROJECT"
+  echo "  This script will deploy to '$PROJECT' (from config.txt)."
+  echo "============================================================"
+  if [ ! -t 0 ]; then
+    echo "ERROR: stdin is not a TTY — cannot confirm. Re-run interactively,"
+    echo "       or align gcloud and config.txt before re-running."
+    exit 1
+  fi
+  read -r -p "Proceed and deploy to '$PROJECT'? (y/N) " confirm
+  case "$confirm" in
+    [yY]|[yY][eE][sS]) echo "✓ Continuing with project $PROJECT." ;;
+    *) echo "Aborted. Update config.txt, or run 'gcloud config set project $PROJECT' to align." ; exit 1 ;;
+  esac
+fi
 
 # 1) Enable services
+# Note: compute.googleapis.com is enabled here so the default Compute Engine
+# service account (used for role bindings below) is guaranteed to exist. Most
+# projects already have it enabled transitively; this handles fresh projects.
+echo
+echo "[▶] Enabling required Google Cloud APIs..."
 gcloud config set project $PROJECT
 gcloud auth application-default set-quota-project $PROJECT
-gcloud services enable aiplatform.googleapis.com apigateway.googleapis.com artifactregistry.googleapis.com cloudbuild.googleapis.com cloudtasks.googleapis.com firestore.googleapis.com run.googleapis.com servicecontrol.googleapis.com iap.googleapis.com --project=$PROJECT
+gcloud services enable aiplatform.googleapis.com apigateway.googleapis.com artifactregistry.googleapis.com cloudbuild.googleapis.com cloudtasks.googleapis.com compute.googleapis.com firestore.googleapis.com run.googleapis.com servicecontrol.googleapis.com iap.googleapis.com --project=$PROJECT
+
+# Warm up Vertex AI service agent. On a fresh project, the agent
+# (service-<PROJECT_NUMBER>@gcp-sa-aiplatform.iam.gserviceaccount.com) is
+# created lazily on first API use, and its auto-granted Storage Object access
+# takes ~5-15 min to propagate. Without this, the user's first Veo generation
+# fails with "Service agents are being provisioned." Triggering identity
+# creation now starts the propagation window during the rest of the deploy.
+echo
+echo "[▶] Provisioning Vertex AI service agent..."
+gcloud beta services identity create --service=aiplatform.googleapis.com --project=$PROJECT
 
 # 2) Create databases
+echo
+echo "[▶] Setting up GCS bucket and Firestore databases..."
 if ! gcloud storage buckets describe "gs://$GCS_BUCKET" &> /dev/null; then
     gcloud storage buckets create "gs://$GCS_BUCKET" --project=$PROJECT --location="$REGION"
 else
@@ -81,6 +201,8 @@ else
     gcloud firestore databases describe --database="$FIRESTORE_DB_UI" --project=$PROJECT --format="value(locationId)"
 fi
 
+echo
+echo "[▶] Setting up Firebase project and Web App..."
 if gcloud services list --enabled --project=$PROJECT --filter="name:firebase.googleapis.com" | grep -q "firebase.googleapis.com"; then
   echo "Firebase is already enabled for the project."
 else
@@ -102,7 +224,8 @@ envsubst < ./firebase/firebase.template.json > ./firebase/firebase.json
 envsubst < ./firebase/.firebaserc.template > ./firebase/.firebaserc
 firebase target:apply --config firebase/firebase.json storage bucket_target $GCS_BUCKET --project $PROJECT
 
-echo "Deploying rules for Backend Firestore DB..."
+echo
+echo "[▶] Deploying rules for Backend Firestore DB..."
 firebase deploy --config firebase/firebase.json --only firestore --project $PROJECT
 
 rm firebase/firebase.json
@@ -110,6 +233,8 @@ rm firebase/.firebaserc
 
 export FIREBASE_API_KEY=$(firebase --non-interactive --project $PROJECT apps:sdkconfig WEB | grep '"apiKey":' | awk -F '"' '{print $4}')
 
+echo
+echo "[▶] Setting up App Engine app..."
 if ! gcloud app describe --project=$PROJECT &> /dev/null; then
   echo "App Engine app doesn't exist. Creating it (Estimated time: ≈3 minutes)..."
   gcloud app create --region $APP_ENGINE_REGION --project $PROJECT
@@ -119,6 +244,7 @@ fi
 
 if [ -n "${CUSTOM_DOMAIN:-}" ]; then
   export UI_HOST="${CUSTOM_DOMAIN}"
+  echo "✓ Using custom domain: ${UI_HOST}"
 else
   export UI_HOST=$(gcloud app describe --project=$PROJECT --format="value(defaultHostname)")
 fi
@@ -126,9 +252,25 @@ fi
 # Identify service account and assign required permissions BEFORE deployment
 PROJECT_NUMBER=$(gcloud projects describe $PROJECT --format="value(projectNumber)")
 SERVICE_ACCOUNT="$PROJECT_NUMBER-compute@developer.gserviceaccount.com"
-if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" &> /dev/null; then
-  echo "Service account does not exist: ${SERVICE_ACCOUNT}"
-fi
+# The default Compute Engine SA is created when compute.googleapis.com is
+# enabled (above), but its propagation can take 30-60s on fresh projects.
+# Wait for it to exist before attempting role bindings below, rather than
+# failing inside the loop with a confusing "service account not found" error.
+echo
+echo "[▶] Waiting for default Compute Engine service account to exist..."
+SA_WAIT_ATTEMPTS=0
+SA_WAIT_MAX=60   # 60 × 5s = 5 min total
+until gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" --project=$PROJECT &> /dev/null; do
+  SA_WAIT_ATTEMPTS=$((SA_WAIT_ATTEMPTS + 1))
+  if [ $SA_WAIT_ATTEMPTS -ge $SA_WAIT_MAX ]; then
+    echo "ERROR: default Compute Engine SA did not appear after 5 minutes."
+    echo "Try enabling Compute Engine API manually, then re-run $0:"
+    echo "  gcloud services enable compute.googleapis.com --project=$PROJECT"
+    exit 1
+  fi
+  sleep 5
+done
+echo "✓ Service account ${SERVICE_ACCOUNT} ready."
 
 ROLES=(
   "roles/datastore.user"
@@ -141,9 +283,25 @@ ROLES=(
   "roles/logging.logWriter"
   "roles/iam.serviceAccountUser"
 )
+echo
+echo "[▶] Granting ${#ROLES[@]} roles to $SERVICE_ACCOUNT..."
 for ROLE in "${ROLES[@]}"; do
-  gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:${SERVICE_ACCOUNT}" --role="$ROLE" --condition=None
+  echo "  - $ROLE"
+  add_iam_binding $PROJECT --member="serviceAccount:${SERVICE_ACCOUNT}" --role="$ROLE" --condition=None
 done
+echo "✓ Roles granted."
+
+# Explicitly grant the Vertex AI service agent storage access. The agent is
+# auto-granted this on first use but propagation lags by ~5-15 min; binding it
+# now eliminates the first-Veo-generation "Service agents are being
+# provisioned" failure (see DEPLOY_NOTES.md issue #6).
+AIPLATFORM_SA="service-${PROJECT_NUMBER}@gcp-sa-aiplatform.iam.gserviceaccount.com"
+echo
+echo "[▶] Granting roles/storage.objectUser to Vertex AI service agent..."
+add_iam_binding $PROJECT \
+  --member="serviceAccount:${AIPLATFORM_SA}" \
+  --role="roles/storage.objectUser" \
+  --condition=None
 
 # 3) Deploy backend (Cloud Run)
 COMMIT_DATE=$(git log -1 --format=%cI)
@@ -158,11 +316,14 @@ fi
 # Write config.json since backend needs part of it
 generate_config
 
-echo "Deploying backend to Cloud Run (Estimated time: ~7 minutes)..."
+echo
+echo "[▶] Deploying backend to Cloud Run (Estimated time: ~5 minutes)..."
 gcloud run deploy "$BACKEND_SERVICE_NAME" --source . --image $REGION-docker.pkg.dev/$PROJECT/$ARTIFACT_REPO/$BACKEND_SERVICE_NAME:latest --region $REGION --project $PROJECT --cpu=8 --memory=16G --timeout=1800 --no-allow-unauthenticated
 export CLOUD_RUN_URL=$(gcloud run services describe "$BACKEND_SERVICE_NAME" --region=$REGION --project=$PROJECT --format='value(status.url)')
 
 # Ensure queues
+echo
+echo "[▶] Setting up Cloud Tasks queues..."
 QUEUES=("Other" "Gemini" "Veo")
 for QUEUE_SUFFIX in "${QUEUES[@]}"; do
   QUEUE_NAME="${TASKS_QUEUE_PREFIX}${QUEUE_SUFFIX}"
@@ -197,12 +358,15 @@ for QUEUE_SUFFIX in "${QUEUES[@]}"; do
     --project="$PROJECT"
 done
 
-# Apply IAM bindings (these are safe to run multiple times, though they will output "no change")
+# Apply IAM bindings for the Cloud Tasks service agent.
 CLOUD_TASKS_ACCOUNT="service-${PROJECT_NUMBER}@gcp-sa-cloudtasks.iam.gserviceaccount.com"
-gcloud projects add-iam-policy-binding "${PROJECT}" --member="serviceAccount:${CLOUD_TASKS_ACCOUNT}" --role="roles/cloudtasks.serviceAgent" --condition=None
-gcloud iam service-accounts add-iam-policy-binding "${SERVICE_ACCOUNT}" --member="serviceAccount:${CLOUD_TASKS_ACCOUNT}" --role="roles/iam.serviceAccountTokenCreator"
+echo
+echo "[▶] Granting Cloud Tasks service agent permissions..."
+add_iam_binding "${PROJECT}" --member="serviceAccount:${CLOUD_TASKS_ACCOUNT}" --role="roles/cloudtasks.serviceAgent" --condition=None
+gcloud iam service-accounts add-iam-policy-binding "${SERVICE_ACCOUNT}" --member="serviceAccount:${CLOUD_TASKS_ACCOUNT}" --role="roles/iam.serviceAccountTokenCreator" --quiet > /dev/null
 
-echo "Provisioning API Gateway and routing infrastructure (Estimated time: ≈6 minutes)..."
+echo
+echo "[▶] Provisioning API Gateway and routing infrastructure (Estimated time: ≈10 minutes)..."
 if ! gcloud api-gateway apis describe scenemachine-api --project=$PROJECT --format="value(managed_service)" &> /dev/null; then
   echo "API doesn't exist. Creating it..."
   gcloud api-gateway apis create scenemachine-api --project=$PROJECT
@@ -265,10 +429,50 @@ fi
 # 6) Upload example files
 gcloud storage cp workflow_examples/input/* gs://${GCS_BUCKET}/examples/
 
-read -p "Do you want to deploy the UI? (y/N) " answer
+echo
+echo "════════════════════════════════════════════════════════════════════════"
+echo "  ✓  BACKEND DEPLOYMENT COMPLETE"
+echo "════════════════════════════════════════════════════════════════════════"
+echo
+echo "  Next: ./deploy-ui.sh deploys the Angular UI to App Engine."
+echo
+echo "  Before that, 3 manual console steps are required. deploy-ui.sh polls"
+echo "  every 15s (or prompts you) and picks up automatically when you complete"
+echo "  them, so you can launch it now and finish the manual steps in parallel."
+echo
+echo "    1. Configure OAuth consent screen"
+echo "       https://console.cloud.google.com/auth/branding?project=${PROJECT}"
+echo "       First time on this project: click 'Get started' and walk through"
+echo "       the setup dialog. User Type is set under 'Audience' — pick"
+echo "       'Internal' if you have a Workspace org; otherwise 'External' and"
+echo "       add yourself as a test user."
+echo
+echo "    2. Enable Google as a Firebase sign-in provider"
+echo "       https://console.firebase.google.com/project/${PROJECT}/authentication/providers"
+echo "       If the providers list isn't visible yet, click 'Get started' on"
+echo "       the Authentication page first to reach it. Then: 'Add new"
+echo "       provider' → 'Google' → enable → save."
+echo
+echo "    3. Set up Firebase Storage — TWO sequential actions on this page:"
+echo "       https://console.firebase.google.com/project/${PROJECT}/storage"
+echo "       (a) Click 'Get started' and walk through the wizard. This creates"
+echo "           the project's default <project>.firebasestorage.app bucket"
+echo "           (separate from ${GCS_BUCKET}). Required by 'firebase deploy"
+echo "           --only storage' or it errors with 'Firebase Storage has not"
+echo "           been set up on project'."
+echo "       (b) On the same page, AFTER (a) finishes (the bucket dropdown"
+echo "           only appears once a bucket exists), click the dropdown →"
+echo "           '+ Add bucket' → 'Import existing Google Cloud Storage"
+echo "           buckets' → select ${GCS_BUCKET} → confirm. Registers your"
+echo "           project bucket so deploy-ui.sh can target it."
+echo
+echo "════════════════════════════════════════════════════════════════════════"
+echo
+read -p "Run ./deploy-ui.sh now? (y/N) " answer
 if [[ "$answer" =~ ^[Yy]$ ]]; then
   ./deploy-ui.sh
 else
-  echo "To deploy the UI later, follow the instructions in README.md or run ./deploy-ui.sh"
+  echo "To deploy the UI later, run ./deploy-ui.sh. Deployment guide:"
+  echo "  https://github.com/google-marketing-solutions/scene-machine#deployment"
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -41,21 +41,41 @@ add_iam_binding() {
   done
   local label="${role:+ (for $role)}"
 
+  local stderr_file
+  stderr_file=$(mktemp)
+  trap 'rm -f "$stderr_file"' RETURN
+
   local attempt=1
-  local max_attempts=5
+  local max_attempts=6
   while true; do
-    if gcloud projects add-iam-policy-binding "$@" --quiet > /dev/null 2>&1; then
+    if gcloud projects add-iam-policy-binding "$@" --quiet >/dev/null 2>"$stderr_file"; then
       if [ $attempt -gt 1 ]; then
         echo "  ✓ IAM binding${label} succeeded on attempt $attempt."
       fi
       return 0
     fi
-    if [ $attempt -ge $max_attempts ]; then
-      # Final attempt: don't suppress so the real error reaches the user.
-      gcloud projects add-iam-policy-binding "$@" --quiet
-      return $?
+
+    # Only retry on concurrent-modification / etag races. Permission, argument,
+    # and not-found errors won't fix themselves — surface them immediately.
+    if ! grep -qiE 'concurrent|aborted|etag|stale' "$stderr_file"; then
+      echo "  ERROR: IAM binding${label} failed with a non-retryable error:" >&2
+      cat "$stderr_file" >&2
+      return 1
     fi
-    local backoff=$((2 ** attempt))
+
+    if [ $attempt -ge $max_attempts ]; then
+      echo "  ERROR: IAM binding${label} still conflicting after $max_attempts attempts:" >&2
+      cat "$stderr_file" >&2
+      return 1
+    fi
+
+    # Exponential backoff with ±25% jitter to desynchronise retries when
+    # multiple bindings race the same background modifier.
+    local base=$((2 ** attempt))
+    local jitter=$((RANDOM % (base / 2 + 1) - base / 4))
+    local backoff=$((base + jitter))
+    [ $backoff -lt 1 ] && backoff=1
+
     echo "  IAM binding${label} hit a transient conflict — retrying in ${backoff}s (attempt $attempt/$max_attempts)..."
     sleep $backoff
     attempt=$((attempt + 1))

--- a/deploy.sh
+++ b/deploy.sh
@@ -493,7 +493,7 @@ echo "           project bucket so deploy-ui.sh can target it."
 echo
 echo "════════════════════════════════════════════════════════════════════════"
 echo
-read -p "Run ./deploy-ui.sh now? (y/N) " answer
+read -r -p "Run ./deploy-ui.sh now? (y/N) " answer
 if [[ "$answer" =~ ^[Yy]$ ]]; then
   ./deploy-ui.sh
 else

--- a/deploy.sh
+++ b/deploy.sh
@@ -153,29 +153,47 @@ fi
 source ./config.txt
 echo "✓ config.txt is valid. Target project: $PROJECT"
 
-# --- Sanity check: gcloud project matches config.txt ------------------------
-# Catches the footgun of forgetting to update config.txt (or gcloud's active
-# project) before running. The script proceeds to overwrite gcloud's active
-# project below, so we explicitly confirm the intended target first.
+# --- Confirm deployment target ----------------------------------------------
+# Final pre-flight gate. Always shows gcloud's current state alongside
+# config.txt's intended target and prompts the user to confirm. Catches the
+# footgun of forgetting to update either side when switching between
+# deployments. The script proceeds to overwrite gcloud's active project
+# immediately after this, so this is the last point at which a wrong target
+# can be aborted without any GCP mutation having occurred.
 CURRENT_GCLOUD_PROJECT=$(gcloud config get-value project 2>/dev/null || true)
-if [ -n "$CURRENT_GCLOUD_PROJECT" ] && [ "$CURRENT_GCLOUD_PROJECT" != "$PROJECT" ]; then
-  echo "============================================================"
-  echo "WARNING: project mismatch detected."
-  echo "  gcloud is currently set to: $CURRENT_GCLOUD_PROJECT"
-  echo "  config.txt PROJECT is:      $PROJECT"
-  echo "  This script will deploy to '$PROJECT' (from config.txt)."
-  echo "============================================================"
-  if [ ! -t 0 ]; then
-    echo "ERROR: stdin is not a TTY — cannot confirm. Re-run interactively,"
-    echo "       or align gcloud and config.txt before re-running."
-    exit 1
-  fi
-  read -r -p "Proceed and deploy to '$PROJECT'? (y/N) " confirm
-  case "$confirm" in
-    [yY]|[yY][eE][sS]) echo "✓ Continuing with project $PROJECT." ;;
-    *) echo "Aborted. Update config.txt, or run 'gcloud config set project $PROJECT' to align." ; exit 1 ;;
-  esac
+[ -z "$CURRENT_GCLOUD_PROJECT" ] && CURRENT_GCLOUD_PROJECT="(none set)"
+echo
+echo "[>] Confirming deployment target..."
+echo "════════════════════════════════════════════════════════════════════════"
+echo "  DEPLOYMENT TARGET — please confirm"
+echo "════════════════════════════════════════════════════════════════════════"
+echo "  gcloud is currently configured for:"
+echo "    Account:    $ACTIVE_ACCOUNT"
+echo "    Project:    $CURRENT_GCLOUD_PROJECT"
+echo
+echo "  config.txt says deploy to:"
+echo "    Project:    $PROJECT"
+echo "    Region:     $REGION"
+if [ "$CURRENT_GCLOUD_PROJECT" != "$PROJECT" ]; then
+  echo
+  echo "  ⚠ Project mismatch — this script will switch gcloud's active project"
+  echo "    to '$PROJECT' before deploying."
 fi
+echo "════════════════════════════════════════════════════════════════════════"
+if [ ! -t 0 ]; then
+  echo "ERROR: stdin is not a TTY — cannot confirm. Re-run interactively."
+  exit 1
+fi
+read -r -p "Proceed and deploy to '$PROJECT'? (y/N) " confirm
+case "$confirm" in
+  [yY]|[yY][eE][sS]) echo "✓ Continuing with project $PROJECT." ;;
+  *)
+    echo "Aborted. To align gcloud with config.txt:"
+    echo "  gcloud config set project $PROJECT"
+    echo "Or update PROJECT in config.txt to match your intended target."
+    exit 1
+    ;;
+esac
 
 # Enable services
 # Note: compute.googleapis.com is enabled here so the default Compute Engine

--- a/deploy.sh
+++ b/deploy.sh
@@ -198,27 +198,23 @@ esac
 
 echo 
 echo "════════════════════════════════════════════════════════════════════════"
-echo "[>] Starting Scene Machine backend deployment (estimated runtime ≈15 minutes)..."
+echo "  Starting Scene Machine backend deployment (estimated runtime ≈15 minutes)..."
 echo "════════════════════════════════════════════════════════════════════════"
+
+echo "[>] Setting active project to $PROJECT"
+gcloud config set project $PROJECT > /dev/null
+echo
+echo "[>] Setting ADC quota project to $PROJECT"
+gcloud auth application-default set-quota-project $PROJECT > /dev/null
+
 
 # Enable services
 # Note: compute.googleapis.com is enabled here so the default Compute Engine
 # service account (used for role bindings below) is guaranteed to exist. Most
 # projects already have it enabled transitively; this handles fresh projects.
 echo
-echo "[>] Enabling required Google Cloud APIs..."
-
-echo "  - Setting gcloud's active project to $PROJECT (local config only)..."
-gcloud config set project $PROJECT > /dev/null
-echo "  ✓ gcloud active project set to $PROJECT."
-
-echo "  - Pointing Application Default Credentials at $PROJECT for billing and quota..."
-gcloud auth application-default set-quota-project $PROJECT > /dev/null
-echo "  ✓ ADC quota project set to $PROJECT."
-
-echo "  - Enabling APIs (full list in README.md 'Google Cloud APIs Used'; may take 30-60s)..."
+echo "[>] Enabling required Google Cloud APIs (full list in README.md 'Google Cloud APIs Used'; may take 30-60s)"
 gcloud services enable aiplatform.googleapis.com apigateway.googleapis.com artifactregistry.googleapis.com cloudbuild.googleapis.com cloudtasks.googleapis.com compute.googleapis.com firestore.googleapis.com run.googleapis.com servicecontrol.googleapis.com iap.googleapis.com --project=$PROJECT > /dev/null
-echo "  ✓ APIs enabled."
 
 # Warm up Vertex AI service agent. On a fresh project, the agent
 # (service-<PROJECT_NUMBER>@gcp-sa-aiplatform.iam.gserviceaccount.com) is

--- a/deploy.sh
+++ b/deploy.sh
@@ -157,7 +157,7 @@ if [ -n "$CURRENT_GCLOUD_PROJECT" ] && [ "$CURRENT_GCLOUD_PROJECT" != "$PROJECT"
   esac
 fi
 
-# 1) Enable services
+# Enable services
 # Note: compute.googleapis.com is enabled here so the default Compute Engine
 # service account (used for role bindings below) is guaranteed to exist. Most
 # projects already have it enabled transitively; this handles fresh projects.
@@ -177,7 +177,7 @@ echo
 echo "[▶] Provisioning Vertex AI service agent..."
 gcloud beta services identity create --service=aiplatform.googleapis.com --project=$PROJECT
 
-# 2) Create databases
+# Create databases
 echo
 echo "[▶] Setting up GCS bucket and Firestore databases..."
 if ! gcloud storage buckets describe "gs://$GCS_BUCKET" &> /dev/null; then
@@ -303,7 +303,7 @@ add_iam_binding $PROJECT \
   --role="roles/storage.objectUser" \
   --condition=None
 
-# 3) Deploy backend (Cloud Run)
+# Deploy backend (Cloud Run)
 COMMIT_DATE=$(git log -1 --format=%cI)
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 echo "${GIT_BRANCH}/${COMMIT_DATE}" > deployed_version.txt
@@ -415,7 +415,7 @@ export API_GATEWAY_HOST=$(gcloud api-gateway gateways describe scenemachine-api-
 # Write config.json again, now with all values needed for UI
 generate_config
 
-# 5) Set permissions and create user role
+# Set permissions and create user role
 envsubst < ./gcs-cors-config.template.json > ./gcs-cors-config.json
 gcloud storage buckets update gs://$GCS_BUCKET --cors-file=./gcs-cors-config.json --project=$PROJECT
 
@@ -426,7 +426,7 @@ else
   echo "SceneMachineUser role already exists. Skipping."
 fi
 
-# 6) Upload example files
+# Upload example files
 gcloud storage cp workflow_examples/input/* gs://${GCS_BUCKET}/examples/
 
 echo

--- a/deploy.sh
+++ b/deploy.sh
@@ -83,12 +83,13 @@ add_iam_binding() {
 }
 
 set -eu
-echo "Scene Machine backend deploy — running pre-flight checks first..."
-
+echo
+echo "================================================================================"
+echo "  Scene Machine backend deploy — running pre-flight checks first..."
+echo "================================================================================"
 # --- Pre-flight: required tools and gcloud auth -----------------------------
 # Fail fast if a required command is missing or gcloud isn't authenticated,
 # rather than 30+ seconds into a gcloud/firebase call with a confusing error.
-echo
 echo "[>] Checking required tools..."
 MISSING_TOOLS=0
 require_tool() {
@@ -195,8 +196,10 @@ case "$confirm" in
     ;;
 esac
 
-echo
+echo 
+echo "════════════════════════════════════════════════════════════════════════"
 echo "[>] Starting Scene Machine backend deployment (estimated runtime ≈15 minutes)..."
+echo "════════════════════════════════════════════════════════════════════════"
 
 # Enable services
 # Note: compute.googleapis.com is enabled here so the default Compute Engine
@@ -204,9 +207,18 @@ echo "[>] Starting Scene Machine backend deployment (estimated runtime ≈15 min
 # projects already have it enabled transitively; this handles fresh projects.
 echo
 echo "[>] Enabling required Google Cloud APIs..."
-gcloud config set project $PROJECT
-gcloud auth application-default set-quota-project $PROJECT
-gcloud services enable aiplatform.googleapis.com apigateway.googleapis.com artifactregistry.googleapis.com cloudbuild.googleapis.com cloudtasks.googleapis.com compute.googleapis.com firestore.googleapis.com run.googleapis.com servicecontrol.googleapis.com iap.googleapis.com --project=$PROJECT
+
+echo "  - Setting gcloud's active project to $PROJECT (local config only)..."
+gcloud config set project $PROJECT > /dev/null
+echo "  ✓ gcloud active project set to $PROJECT."
+
+echo "  - Pointing Application Default Credentials at $PROJECT for billing and quota..."
+gcloud auth application-default set-quota-project $PROJECT > /dev/null
+echo "  ✓ ADC quota project set to $PROJECT."
+
+echo "  - Enabling APIs (full list in README.md 'Google Cloud APIs Used'; may take 30-60s)..."
+gcloud services enable aiplatform.googleapis.com apigateway.googleapis.com artifactregistry.googleapis.com cloudbuild.googleapis.com cloudtasks.googleapis.com compute.googleapis.com firestore.googleapis.com run.googleapis.com servicecontrol.googleapis.com iap.googleapis.com --project=$PROJECT > /dev/null
+echo "  ✓ APIs enabled."
 
 # Warm up Vertex AI service agent. On a fresh project, the agent
 # (service-<PROJECT_NUMBER>@gcp-sa-aiplatform.iam.gserviceaccount.com) is
@@ -477,7 +489,7 @@ gcloud storage cp workflow_examples/input/* gs://${GCS_BUCKET}/examples/
 
 echo
 echo "════════════════════════════════════════════════════════════════════════"
-echo "  ✓  BACKEND DEPLOYMENT COMPLETE"
+echo "  ✓  Scene Machine backend deployment complete."
 echo "════════════════════════════════════════════════════════════════════════"
 echo
 echo "  Next: ./deploy-ui.sh deploys the Angular UI to App Engine."


### PR DESCRIPTION
Reworks `deploy.sh` and `deploy-ui.sh` to be friendlier on fresh GCP projects and harder to misuse. Captured during a fresh deployment to a standalone GCP project; full per-issue write-up below.

## Summary

| # | Improvement | Files |
|---|---|---|
| 1 | Pre-flight tool & auth checks | `deploy.sh` |
| 2 | Project-mismatch sanity check (gcloud active vs config.txt) | `deploy.sh` |
| 3 | `add_iam_binding` helper: suppresses verbose YAML, retries on etag conflicts with backoff, labels role | both |
| 4 | Block on manual prereqs (polling loops + non-TTY guards) | `deploy-ui.sh` |
| 5 | Guarantee default Compute Engine SA exists (enable compute.googleapis.com + wait) | `deploy.sh` |
| 6 | Warm up Vertex AI service agent (eliminates first-Veo "Service agents being provisioned" failure) | `deploy.sh` |
| 7 | `[▶]` phase markers — Ctrl+F bridge between terminal output and script source | both |
| 8 | End-of-script success banners with deep links + ready-to-paste gcloud snippet | both |
| 9 | README updates (Firebase Storage two-step, parallel-execution note, Adding Users section) | `README.md` |

## Why these specific changes

1. **Pre-flight checks** — running into a missing `envsubst` or unauthenticated gcloud session 30 seconds into a multi-minute call wastes time. Fail fast.
2. **Project-mismatch check** — caught in testing: easy to update `config.txt` but forget `gcloud config set project`, deploying to the wrong project. Now blocks with y/N.
3. **IAM helper** — original loop printed a full IAM policy YAML per binding (very noisy) and hit etag conflicts on fresh projects when background GCP work modified the policy in parallel. New helper suppresses output, retries with backoff per gcloud's own recommendation, and identifies the role in retry messages.
4. **Polling vs. exit-1** — original script `exit 1`'d on every unmet manual prereq, forcing re-runs and re-validation of everything from scratch. Each iteration: configure one thing in console → re-run → fail on next thing → repeat. Three prereqs = three re-runs minimum. Polling lets the user complete all manual steps once in one session.
5. **Compute SA guarantee** — `compute.googleapis.com` wasn't explicitly enabled. On some fresh projects the default Compute Engine SA isn't there yet at the time of role bindings, causing confusing "service account not found" errors. Adding it to the enable list + a wait loop closes the race.
6. **Vertex AI warm-up** — well-documented "Service agents are being provisioned" failure on the user's first Veo generation, caused by ~5–15 min propagation lag of the auto-granted Storage Object access. Triggering identity creation in the deploy + explicitly binding `roles/storage.objectUser` to the agent eliminates the failure window.
7. **Phase markers** — the deploy is long and chatty (~17 minutes, many gcloud subcommands). When something fails, mapping terminal output back to the right place in the script was painful. `[▶]` is a visually distinctive prefix that's also independently grep-able (square-bracket-glyph won't collide with anything else in the script source or terminal output).
8. **Final UX** — original final block printed the deploy URL inline with the IAP and "grant user access" warnings; URL was easy to miss; "Grant User Access" had no link, no console URL, no `gcloud` snippet.

## Notes

- **OAuth consent screen verification** uses a manual gate ("Press Enter when configured") rather than upstream verification, because `gcloud iap oauth-brands list` (the original verification) was permanently shut down on 2026-03-19 and required project-in-org anyway. There's no public API to verify OAuth-consent state on standalone projects. The gate has a non-TTY guard so CI contexts fail cleanly rather than silently auto-proceeding.
- All `[▶]` markers and the convention comment are documented inline in both scripts.
- Rebased on top of #90 (CUSTOM_DOMAIN); a one-line echo confirms when CUSTOM_DOMAIN is honored.