### PR TITLE
deploy: review follow-ups (function placement, prompt consistency)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -527,7 +527,8 @@ echo
 echo "════════════════════════════════════════════════════════════════════════"
 echo
 read -r -p "Run ./deploy-ui.sh now? (y/N) " answer
-if [[ "$answer" =~ ^[Yy]([Ee][Ss])?$ ]]; then
+answer=$(echo "$answer" | tr '[:upper:]' '[:lower:]')
+if [ "$answer" = "y" ] || [ "$answer" = "yes" ]; then
   ./deploy-ui.sh
 else
   echo "To deploy the UI later, run ./deploy-ui.sh. Deployment guide:"

--- a/deploy.sh
+++ b/deploy.sh
@@ -82,6 +82,17 @@ add_iam_binding() {
   done
 }
 
+# Pre-flight helper used with the MISSING_TOOLS counter so all missing
+# tools are reported in one pass rather than failing on the first miss.
+require_tool() {
+  local name="$1"
+  local hint="$2"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "ERROR: '$name' is not installed. $hint" >&2
+    MISSING_TOOLS=$((MISSING_TOOLS + 1))
+  fi
+}
+
 set -euo pipefail
 echo
 echo "================================================================================"
@@ -92,14 +103,6 @@ echo "==========================================================================
 # rather than 30+ seconds into a gcloud/firebase call with a confusing error.
 echo "[>] Checking required tools..."
 MISSING_TOOLS=0
-require_tool() {
-  local name="$1"
-  local hint="$2"
-  if ! command -v "$name" >/dev/null 2>&1; then
-    echo "ERROR: '$name' is not installed. $hint" >&2
-    MISSING_TOOLS=$((MISSING_TOOLS + 1))
-  fi
-}
 require_tool gcloud   "Install: https://cloud.google.com/sdk/docs/install"
 require_tool firebase "Install: npm i -g firebase-tools"
 require_tool node     "Install Node.js ≥ v22: https://nodejs.org/en/download"

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,17 +14,17 @@
 # limitations under the License.
 
 # ---------------------------------------------------------------------------
-# Console output convention: lines beginning with "[>]" mark the start of a
-# major deployment phase. If something fails, copy the "[>]" prefix (or the
-# full prefix + echo message) from the terminal and Ctrl+F in this file to jump
-# straight to the matching section in the script.
+# Console output convention
+# ---------------------------------------------------------------------------
+# Lines beginning with "[>]" mark the start of a major deployment phase.
+# If something fails, copy the "[>]" prefix (or the full prefix + echo message)
+# from the terminal and Ctrl+F in this file to jump straight to the matching
+# section in the script.
 # ---------------------------------------------------------------------------
 
-# Generate ui/definitions/config.json for backend and frontend
-generate_config() {
-  envsubst < ui/definitions/config.template.json > ui/definitions/config.json
-}
-
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
 # Wrapper for `gcloud projects add-iam-policy-binding` that (a) suppresses the
 # verbose updated-policy YAML on success, and (b) retries with exponential
 # backoff on concurrent-modification etag conflicts. Background GCP work (App
@@ -82,8 +82,15 @@ add_iam_binding() {
   done
 }
 
-# Pre-flight helper used with the MISSING_TOOLS counter so all missing
-# tools are reported in one pass rather than failing on the first miss.
+# Generate ui/definitions/config.json for backend and frontend
+generate_config() {
+  envsubst < ui/definitions/config.template.json > ui/definitions/config.json
+}
+
+# Pre-flight helper + counter, kept together so the function and its
+# state aren't split across the script. All missing tools are reported
+# in one pass rather than failing on the first miss.
+MISSING_TOOLS=0
 require_tool() {
   local name="$1"
   local hint="$2"
@@ -93,6 +100,9 @@ require_tool() {
   fi
 }
 
+# ---------------------------------------------------------------------------
+# Main script
+# ---------------------------------------------------------------------------
 set -euo pipefail
 echo
 echo "================================================================================"
@@ -102,7 +112,6 @@ echo "==========================================================================
 # Fail fast if a required command is missing or gcloud isn't authenticated,
 # rather than 30+ seconds into a gcloud/firebase call with a confusing error.
 echo "[>] Checking required tools..."
-MISSING_TOOLS=0
 require_tool gcloud   "Install: https://cloud.google.com/sdk/docs/install"
 require_tool firebase "Install: npm i -g firebase-tools"
 require_tool node     "Install Node.js ≥ v22: https://nodejs.org/en/download"


### PR DESCRIPTION
## Summary

Follow-ups to @adamread's review comments on #88.

- **Function placement**: `require_tool` hoisted to the top of `deploy.sh` alongside the other helpers, with `MISSING_TOOLS=0` colocated so the function and its state aren't split across the script.
- **Prompt consistency**: both y/yes prompts in `deploy.sh` now share one mechanism (`tr` lowercase + simple comparison), replacing the inconsistent regex form on the second prompt.
- Minor file-layout tidy in `deploy.sh`: added "Console output convention", "Helper functions", and "Main script" section headers; reordered `generate_config` to sit with the other helpers.

## Deferred

- The shellcheck SC2086/SC2155 sweep (~90 quoting + declare-and-assign fixes flagged in the #88 review) is intentionally not in this PR — would dominate the diff. Planned as a separate change.
- README `mdformat --wrap=80` is held back to a separate PR so the formatting noise doesn't mask this code review.

## Test plan

- [x] `bash -n deploy.sh` clean
- [x] End-to-end `./deploy.sh` run on a fresh GCP project succeeded with these changes applied

cc @adamread — follow-ups from your #88 review.