### PR TITLE
Fix is_retryable for google-genai 429 quota errors

### DIFF
--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for util.errors.is_retryable.
+
+Uses REAL exception instances (not monkeypatched predicates) so the classifier
+is checked against the shapes the SDKs actually raise.
+"""
+
+import google.api_core.exceptions as google_exceptions
+from google.genai import errors as genai_errors
+
+from util.errors import is_retryable
+
+
+def _genai_error(status_code):
+  """A real google-genai APIError as the client raises it for an HTTP error.
+
+  4xx -> ClientError; `.code` is the integer HTTP status (there is no
+  `.status_code` attribute).
+  """
+  return genai_errors.ClientError(
+      status_code,
+      {
+          'error': {
+              'code': status_code,
+              'status': 'RESOURCE_EXHAUSTED',
+              'message': 'quota exceeded',
+          }
+      },
+      None,
+  )
+
+
+def test_genai_429_is_retryable():
+  # Regression: genai's APIError has an integer `.code` and no `.status_code`,
+  # so before the fix a 429 was misclassified as non-retryable.
+  e = _genai_error(429)
+  assert getattr(e, 'code', None) == 429
+  assert getattr(e, 'status_code', None) is None
+  assert is_retryable(e) is True
+
+
+def test_genai_400_is_not_retryable():
+  assert is_retryable(_genai_error(400)) is False
+
+
+def test_api_core_resource_exhausted_is_retryable():
+  assert is_retryable(google_exceptions.ResourceExhausted('quota')) is True
+
+
+def test_api_core_too_many_requests_is_retryable():
+  # HTTP 429: not a ResourceExhausted, and `.code` is an HTTPStatus (not a plain
+  # int), so this only passes via the integer-like `code` branch.
+  e = google_exceptions.TooManyRequests('quota')
+  assert getattr(e, 'status_code', None) is None
+  assert is_retryable(e) is True
+
+
+def test_plain_exception_is_not_retryable():
+  assert is_retryable(ValueError('nope')) is False

--- a/util/errors.py
+++ b/util/errors.py
@@ -61,6 +61,12 @@ def is_retryable(e: Exception) -> bool:
       getattr(e, 'status_code', None) == TOO_MANY_REQUESTS,
       callable(code_attr)
       and getattr(code_attr(), 'value', None) == TOO_MANY_REQUESTS,
+      # Some SDKs put the HTTP status in `code` as an integer-like value:
+      # google-genai's is a plain int, api_core's is an HTTPStatus that compares
+      # equal to 429. Retry 429 only -- it means throttled before any work ran,
+      # so repeating is safe. 5xx is deliberately left non-retryable: generation
+      # is not idempotent, so a retry could bill twice.
+      code_attr == TOO_MANY_REQUESTS,
       # Removed because this would need to be retried much later:
       # isinstance(e, RuntimeError) and 'try again later' in repr(e).lower(),
   ])


### PR DESCRIPTION
## Summary

`util/errors.is_retryable` misclassifies google-genai quota errors (HTTP 429) as non-retryable, so the first quota error becomes a permanent failure with no retry.

## Behavior

google-genai's `APIError` reports the HTTP status as a plain integer `.code` and has no `.status_code`. The existing checks matched only `api_core.ResourceExhausted`, a `.status_code` attribute, or a *callable* `.code` — none of which match a genai `ClientError(429)`. This adds an integer `code == 429` check so genai quota errors are retried.

Only 429 is treated as retryable: it means the request was throttled before any work ran, so repeating is safe. 5xx is left non-retryable on purpose — generation is not idempotent, so a retry could bill twice.

## Tests

`test/test_errors.py` exercises `is_retryable` against real exception instances rather than monkeypatched predicates: a genai `ClientError(429)` and `ClientError(400)`, `api_core.ResourceExhausted`, `api_core.TooManyRequests` (whose `.code` is an `HTTPStatus`, exercising the integer-like branch), and a plain `ValueError`.

## Risks / Notes

Independent of the google-genai 2.x upgrade — the bug is present in both 1.73.1 and 2.x.
