### PR TITLE
Bump idna to 3.15 and urllib3 to 2.7.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -543,9 +543,9 @@ httpx==0.28.1 \
     --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
     # via google-genai
-idna==3.12 \
-    --hash=sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67 \
-    --hash=sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254
+idna==3.15 \
+    --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 \
+    --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc
     # via
     #   anyio
     #   httpx
@@ -1048,9 +1048,9 @@ typing-inspection==0.4.2 \
     --hash=sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7 \
     --hash=sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
     # via pydantic
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via requests
 websockets==16.0 \
     --hash=sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c \

--- a/requirements.txt
+++ b/requirements.txt
@@ -515,9 +515,9 @@ httpx==0.28.1 \
     --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
     # via google-genai
-idna==3.11 \
-    --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
-    --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
+idna==3.15 \
+    --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 \
+    --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc
     # via
     #   anyio
     #   httpx
@@ -929,9 +929,9 @@ typing-inspection==0.4.2 \
     --hash=sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7 \
     --hash=sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
     # via pydantic
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via requests
 websockets==16.0 \
     --hash=sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c \


### PR DESCRIPTION
## Summary

Bumps the Python HTTP-stack transitive pins `idna` and `urllib3` to their latest security/patch releases.

## Behavior

- `requirements.txt`: `idna` 3.11 → 3.15, `urllib3` 2.6.3 → 2.7.0.
- `requirements-dev.txt`: `idna` 3.12 → 3.15, `urllib3` 2.6.3 → 2.7.0.

This also aligns a pre-existing prod/dev `idna` split (prod was 3.11, dev 3.12) onto a single 3.15. Both packages are transitive leaf dependencies of the `requests` / `google-auth` closure — no first-party or direct pin changes, and nothing else in the lock moves. Hashes are the published PyPI artifacts.

Subsumes dependabot #96 (idna) and #87 (urllib3).

## Tests

CI's Python gate under the hash-pinned dev lock: `pip install -r requirements-dev.txt`, `pytest actions/test actions_lib/test test`, and `test.test_actions_sig` — all green across Python 3.11/3.12/3.13 (baseline → bump → still-green).

## Risks / Notes

- `idna`/`urllib3` are the live HTTP/TLS transport for Google API calls, and the unit tests mock the model — so a live-call behavior change would not surface in CI. These are minor/patch bumps (low risk); the residual is covered by a deploy smoke over settled `main`.
- `urllib3` 2.7.0 raises its minimum Python from 3.9 to 3.10. Inert here — CI runs 3.11–3.13 and the deploy image is Python 3.13 — but it forecloses running on 3.9.
