### PR TITLE
Validate configured models against the allowlist at deploy time

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -215,6 +215,7 @@ require_tool node     "Install Node.js ≥ v22: https://nodejs.org/en/download"
 require_tool npm      "Install Node.js (includes npm): https://nodejs.org/en/download"
 require_tool envsubst "Install gettext (macOS: 'brew install gettext'; Debian/Ubuntu: 'apt-get install gettext')"
 require_tool curl     "Install curl (it ships with macOS and most Linux distributions)"
+require_tool python3  "Install Python 3 (macOS: 'brew install python' or the Xcode CLT; Debian/Ubuntu: 'apt-get install python3')"
 if [ $MISSING_TOOLS -gt 0 ]; then
   echo "Please install the missing tools above, then re-run $0."
   exit 1

--- a/deploy.sh
+++ b/deploy.sh
@@ -272,7 +272,25 @@ if [ $MISSING -gt 0 ]; then
   echo "Validation failed. Please fix config.txt and try again." >&2
   exit 1
 fi
+# Export sourced config vars so Python checks and envsubst see bare VAR= lines.
+set -a
 source ./config.txt
+set +a
+# The grep above accepts a value like VAR=$OTHER (the $ is a valid char), but if
+# $OTHER is unset it expands to empty here -- which would slip past the model
+# check below (an empty model is skipped as "not configured"). Require every
+# required var to be non-empty after expansion.
+EMPTY_AFTER_SOURCE=0
+for var in "${REQUIRED_VARS[@]}"; do
+  if [ -z "${!var}" ]; then
+    echo "ERROR: $var is empty after expanding config.txt" >&2
+    EMPTY_AFTER_SOURCE=$((EMPTY_AFTER_SOURCE + 1))
+  fi
+done
+if [ $EMPTY_AFTER_SOURCE -gt 0 ]; then
+  echo "Validation failed. Please fix config.txt and try again." >&2
+  exit 1
+fi
 # Single image name for both Cloud Run services (overridable via env).
 IMAGE_NAME="${IMAGE_NAME:-scene-machine}"
 # App service minimum instances: 0 (default) scales to zero; 1 keeps one
@@ -290,6 +308,15 @@ fi
 # surface at all. This is always the case — there is no data-plane mode to
 # choose.
 echo "✓ config.txt is valid. Target project: $PROJECT"
+
+# --- Check configured models against the allowlist --------------------------
+# A model/region typo, or a model/region not in ui/definitions/models.json,
+# should fail here at deploy time -- not later at runtime against Vertex.
+echo "[>] Checking configured models against the allowlist..."
+if ! python3 scripts/validate_config_models.py; then
+  echo "Validation failed. Fix config.txt, or add the model/region to ui/definitions/models.json." >&2
+  exit 1
+fi
 
 # --- Confirm deployment target ----------------------------------------------
 # Final pre-flight gate. Shows gcloud's current state alongside config.txt's

--- a/scripts/validate_config_models.py
+++ b/scripts/validate_config_models.py
@@ -19,6 +19,8 @@ a model/region typo or an un-allowlisted choice fails loudly at deploy time
 instead of only at runtime against Vertex. Exits non-zero on any problem.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 from collections.abc import Mapping

--- a/scripts/validate_config_models.py
+++ b/scripts/validate_config_models.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fails the deploy if a configured model/region is not in the allowlist.
+
+deploy.sh runs this after sourcing config.txt and before building the image, so
+a model/region typo or an un-allowlisted choice fails loudly at deploy time
+instead of only at runtime against Vertex. Exits non-zero on any problem.
+"""
+
+import os
+import sys
+from collections.abc import Mapping
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from util.model_allowlist import load_allowlist  # noqa: E402
+
+# (model env var, region env var, expected family, human label)
+_CHECKS = (
+    ('GEMINI_MODEL', 'GEMINI_REGION', 'gemini', 'Gemini text'),
+    ('IMAGE_MODEL', 'IMAGE_MODEL_REGION', 'image', 'Image'),
+    ('VEO_MODEL', 'VEO_REGION', 'veo', 'Veo'),
+)
+
+
+def collect_errors(env: Mapping[str, str], models: dict) -> list[str]:
+  """Returns a list of human-readable problems ([] if the config is valid)."""
+  errors = []
+  for model_var, region_var, family, label in _CHECKS:
+    model = env.get(model_var)
+    if not model:
+      continue  # not configured here
+    entry = models.get(model)
+    if entry is None:
+      errors.append(
+          f'{label}: {model_var}={model!r} is not in the allowlist '
+          '(ui/definitions/models.json).')
+      continue
+    if entry.get('family') != family:
+      errors.append(
+          f'{label}: {model_var}={model!r} is a {entry.get("family")!r} model, '
+          f'not {family!r}.')
+    region = env.get(region_var)
+    locations = entry.get('locations', [])
+    if not region:
+      # The model is configured but its region is not. A region is required to
+      # reach the model, so an empty one is a broken config, not a skip.
+      errors.append(
+          f'{label}: {model_var}={model!r} is set but {region_var} is empty; '
+          'a region is required.')
+    elif region not in locations:
+      errors.append(
+          f'{label}: {region_var}={region!r} is not allowed for {model} '
+          f'(allowed: {", ".join(locations) or "none"}).')
+  return errors
+
+
+def main() -> None:
+  errors = collect_errors(os.environ, load_allowlist()['models'])
+  if errors:
+    sys.stderr.write('Model/region config check FAILED:\n')
+    for error in errors:
+      sys.stderr.write(f'  - {error}\n')
+    sys.stderr.write(
+        'Fix config.txt, or add the model/region to '
+        'ui/definitions/models.json and rebuild.\n')
+    sys.exit(1)
+  print('✓ Configured models/regions match the allowlist.')
+
+
+if __name__ == '__main__':
+  main()

--- a/test/test_validate_config_models.py
+++ b/test/test_validate_config_models.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for scripts/validate_config_models.py (the deploy-time model check)."""
+
+import os
+import re
+
+from scripts import validate_config_models
+from util.model_allowlist import load_allowlist
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+_MODELS = {
+    'gemini-3.5-flash': {'family': 'gemini', 'locations': ['global']},
+    'gemini-3-pro-image': {'family': 'image', 'locations': ['global']},
+    'veo-3.1-generate-001': {'family': 'veo', 'locations': ['global', 'us-central1']},
+}
+
+
+def _parse_shell_env(path: str) -> dict[str, str]:
+  """Reads `VAR=value` / `export VAR=value` assignments from a shell file,
+  dropping inline `# comments` -- so the test uses the template's real values."""
+  env = {}
+  with open(path, encoding='utf-8') as f:
+    for line in f:
+      match = re.match(r'\s*(?:export\s+)?([A-Z_]+)=(.*)', line)
+      if match:
+        value = match.group(2).split(' #', 1)[0].strip().strip('"\'')
+        env[match.group(1)] = value
+  return env
+
+
+def test_valid_config_passes():
+  env = {
+      'GEMINI_MODEL': 'gemini-3.5-flash', 'GEMINI_REGION': 'global',
+      'IMAGE_MODEL': 'gemini-3-pro-image', 'IMAGE_MODEL_REGION': 'global',
+      'VEO_MODEL': 'veo-3.1-generate-001', 'VEO_REGION': 'us-central1',
+  }
+  assert validate_config_models.collect_errors(env, _MODELS) == []
+
+
+def test_unknown_model_flagged():
+  errors = validate_config_models.collect_errors(
+      {'VEO_MODEL': 'veo-does-not-exist', 'VEO_REGION': 'global'}, _MODELS)
+  assert any('not in the allowlist' in e for e in errors)
+
+
+def test_disallowed_region_flagged():
+  errors = validate_config_models.collect_errors(
+      {'GEMINI_MODEL': 'gemini-3.5-flash', 'GEMINI_REGION': 'europe-west4'},
+      _MODELS)
+  assert any('not allowed' in e for e in errors)
+
+
+def test_wrong_family_flagged():
+  # A gemini model configured as the Veo model.
+  errors = validate_config_models.collect_errors(
+      {'VEO_MODEL': 'gemini-3.5-flash', 'VEO_REGION': 'global'}, _MODELS)
+  assert any('not' in e and "'veo'" in e for e in errors)
+
+
+def test_unconfigured_var_is_skipped():
+  assert validate_config_models.collect_errors({}, _MODELS) == []
+
+
+def test_model_set_without_region_flagged():
+  # A model configured with no region can't be reached; catch it at deploy time
+  # rather than skipping the check.
+  errors = validate_config_models.collect_errors(
+      {'VEO_MODEL': 'veo-3.1-generate-001'}, _MODELS)
+  assert any('region is required' in e for e in errors)
+
+
+def test_config_template_defaults_pass_real_allowlist():
+  # The actual config.template.txt defaults must validate against the shipped
+  # allowlist -- parsed from the file, not hard-coded, so a drifted default
+  # (e.g. a model bumped in the template but not the allowlist) fails here.
+  env = _parse_shell_env(os.path.join(_REPO, 'config.template.txt'))
+  assert validate_config_models.collect_errors(
+      env, load_allowlist()['models']) == []


### PR DESCRIPTION
## Summary

`deploy.sh` now validates each modality's configured model and region against the model allowlist before building the image. A typo, an un-allowlisted model, a family mismatch, or a region the model doesn't support fails the deploy with a clear message instead of surfacing later at runtime against Vertex.

## Behavior

- After sourcing `config.txt` and before the build, `deploy.sh` runs `scripts/validate_config_models.py`; a non-zero exit aborts the deploy.
- The `source ./config.txt` line is wrapped in `set -a` / `set +a` so that config vars written as a bare `VAR=` (no `export`) are exported to child processes. The required-vars check accepts a bare `VAR=`, but without `set -a` such a var is invisible to the Python check's `os.environ` and renders empty in `envsubst`.
- For each modality (`GEMINI_MODEL`/`GEMINI_REGION`, `IMAGE_MODEL`/`IMAGE_MODEL_REGION`, `VEO_MODEL`/`VEO_REGION`), the check requires the model to be present in `ui/definitions/models.json`, to have the expected family (`gemini`/`image`/`veo`), and to have its configured region listed in that model's `locations`.
- A modality whose model is unset is skipped. A model that is set but has an empty region is an error, not a skip — a region is required to reach the model.
- Validation is against the local allowlist only. It does not call Vertex, so it does not prove a listed model actually resolves there.

## Tests

- `collect_errors()` is a pure function covered by unit tests for: a valid config passing, an unknown model, a disallowed region, a wrong-family model, an unconfigured modality being skipped, and a model set without a region.
- A test parses `config.template.txt`'s actual defaults from the file (rather than hard-coding them) and asserts they validate against the shipped allowlist, so a default bumped in the template but not in the allowlist fails the test.

## Risks / Notes

- Local-only validation: a model present in the allowlist but not yet confirmed on Vertex passes this check. Confirming a model resolves against Vertex is out of scope.
