### PR TITLE
Bound fan-out, quantity, and node gcp_project at submission

### DIFF
--- a/test/test_submission_validation.py
+++ b/test/test_submission_validation.py
@@ -281,6 +281,49 @@ def test_input_files_not_object_rejected():
   assert validate_submission(data)[1] == 'MALFORMED_SUBMISSION'
 
 
+def test_input_files_inconsistent_dimension_keys_rejected():
+  # group_input indexes every entry by the first entry's non-file keys; a
+  # ragged entry raises KeyError in the worker.
+  wf = _pipeline(2)
+  wf['inputFiles']['image'] = [{'file': 'a', 'language': 'en'}, {'file': 'b'}]
+  assert validate_submission(wf)[1] == 'MALFORMED_SUBMISSION'
+
+
+def test_input_files_unhashable_dimension_value_rejected():
+  # group_input uses dimension values in a tuple dict key; a list value is
+  # unhashable in the worker.
+  wf = _pipeline(1)
+  wf['inputFiles']['image'] = [{'file': 'a', 'language': ['en', 'de']}]
+  assert validate_submission(wf)[1] == 'MALFORMED_SUBMISSION'
+
+
+def test_input_files_scalar_dimensions_ok():
+  wf = _pipeline(2)
+  wf['inputFiles']['image'] = [
+      {'file': 'a', 'language': 'en'}, {'file': 'b', 'language': 'de'}]
+  assert validate_submission(wf) is None
+
+
+def test_empty_input_group_is_valid():
+  # The UI's text-to-video shape submits image: []; it must stay accepted.
+  assert validate_submission(_pipeline(0)) is None
+
+
+def test_empty_input_group_does_not_zero_the_budget():
+  # The engine turns an empty group into ONE grouping slot, not zero, so a
+  # node that also consumes a populated group fans out with the populated
+  # group's full size. A 0 multiplier would erase that from the budget.
+  wf = _pipeline(100, groups=['image', 'prompt'])
+  wf['inputFiles']['image'] = []
+  wf['workflowDefinition']['v'] = {
+      'action': 'generate_video',
+      'input': {'image': {'node': 'root', 'output': 'image'},
+                'prompt': {'node': 'root', 'output': 'prompt'}},
+      'parameters': {'model': ['veo-3.1-generate-001'] * 3,
+                     'gcp_location': 'global'}}
+  assert validate_submission(wf)[1] == 'TOO_MANY_GENERATIONS'
+
+
 def _pipeline(n, image_nodes=(), video_nodes=(('v', 'root', 'image'),), groups=None):
   """Builds a wired workflow: `root` forwards inputFiles, then the named image /
   video nodes each draw from a predecessor's output."""

--- a/test/test_submission_validation.py
+++ b/test/test_submission_validation.py
@@ -136,14 +136,16 @@ def test_execution_id_falsy_still_rejected():
 # --- empty-list values must not fail open ------------------------------------
 
 def test_empty_list_model_rejected():
+  # An empty list expands to zero combinations, so the empty-list guard catches
+  # it up front (fail closed) before the missing-model check is reached.
   assert _code(_sub('generate_video',
-                    {'model': [], 'gcp_location': 'global'})) == 'MISSING_MODEL_PARAM'
+                    {'model': [], 'gcp_location': 'global'})) == 'EMPTY_LIST_PARAM'
 
 
 def test_empty_list_location_rejected():
   assert _code(_sub('generate_video',
                     {'model': 'veo-3.1-generate-001', 'gcp_location': []})
-              ) == 'MISSING_MODEL_PARAM'
+              ) == 'EMPTY_LIST_PARAM'
 
 
 def test_list_location_with_one_bad_element():
@@ -182,3 +184,314 @@ def test_non_string_action_rejected():
 
 def test_non_dict_parameters_rejected():
   assert _code(_sub('generate_video', 'not-a-dict')) == 'MALFORMED_SUBMISSION'
+
+
+# --- enqueue fan-out / quantity / project-pin limits (generous caps) ---------
+
+_VALID_VIDEO = {'model': 'veo-3.1-generate-001', 'gcp_location': 'global'}
+_VALID_IMAGE = {'image_model': 'gemini-3-pro-image', 'image_model_location': 'global'}
+
+
+def test_node_gcp_project_rejected():
+  # The server pins the project; a node must not point at another.
+  assert _code(_sub('generate_video', {**_VALID_VIDEO, 'gcp_project': 'other'})
+              ) == 'GCP_PROJECT_NOT_ALLOWED'
+
+
+def test_node_empty_gcp_project_ok():
+  # The UI always sends gcp_project='' -- that is allowed.
+  assert validate_submission(
+      _sub('generate_video', {**_VALID_VIDEO, 'gcp_project': ''})) is None
+
+
+def test_quantity_too_large():
+  assert _code(_sub('generate_video',
+                    {**_VALID_VIDEO, 'video_variant_quantity': 101})
+              ) == 'QUANTITY_TOO_LARGE'
+
+
+def test_quantity_within_cap_ok():
+  assert validate_submission(
+      _sub('generate_video', {**_VALID_VIDEO, 'video_variant_quantity': 4})) is None
+
+
+def test_list_parameter_too_long():
+  assert _code(_sub('translate',
+                    {'gemini_model': 'gemini-3.5-flash',
+                     'gemini_model_location': 'global',
+                     'target_language': ['x'] * 101})) == 'LIST_TOO_LONG'
+
+
+def test_fan_out_product_too_large():
+  # 40 models x 40 locations = 1600 > the fan-out cap (each list is under the
+  # per-list cap, so it is the product that trips).
+  assert _code(_sub('generate_video',
+                    {'model': ['veo-3.1-generate-001'] * 40,
+                     'gcp_location': ['global'] * 40})) == 'FAN_OUT_TOO_LARGE'
+
+
+def test_too_many_nodes():
+  nodes = {f'n{i}': {'action': 'pass', 'parameters': {}} for i in range(201)}
+  assert validate_submission({'workflowDefinition': nodes})[1] == 'TOO_MANY_NODES'
+
+
+def test_too_many_input_files():
+  data = _sub('generate_video', _VALID_VIDEO)
+  data['inputFiles'] = {'images': [{'file': str(i)} for i in range(201)]}
+  assert validate_submission(data)[1] == 'TOO_MANY_INPUT_FILES'
+
+
+# Engine expands list params before execution; validate expanded values too.
+
+def test_node_gcp_project_list_bypass_rejected():
+  assert _code(_sub('generate_video', {**_VALID_VIDEO, 'gcp_project': ['other']})
+              ) == 'GCP_PROJECT_NOT_ALLOWED'
+
+
+def test_node_gcp_project_non_string_rejected():
+  # A number or object is not a valid empty project either; reject both.
+  for bad in (123, {'p': 'other'}, ['a', 'b']):
+    assert _code(_sub('generate_video', {**_VALID_VIDEO, 'gcp_project': bad})
+                ) == 'GCP_PROJECT_NOT_ALLOWED', f'gcp_project={bad!r} slipped through'
+
+
+def test_node_empty_gcp_project_list_ok():
+  # A list of blank strings still resolves to no project, so it stays allowed --
+  # the fix must not over-reject the UI's empty value in list form.
+  assert validate_submission(
+      _sub('generate_video', {**_VALID_VIDEO, 'gcp_project': ['']})) is None
+
+
+def test_quantity_list_shape_bypass_rejected():
+  for name in ('video_variant_quantity', 'variant_quantity', 'story_variant_quantity'):
+    assert _code(_sub('generate_video', {**_VALID_VIDEO, name: [101]})
+                ) == 'QUANTITY_TOO_LARGE', f'{name}=[101] slipped through'
+
+
+def test_quantity_list_within_cap_ok():
+  # A list of in-range quantities is legitimate fan-out and must pass.
+  assert validate_submission(
+      _sub('generate_video', {**_VALID_VIDEO, 'video_variant_quantity': [4, 10]})) is None
+
+
+def test_input_files_not_object_rejected():
+  # A non-object inputFiles would crash verify_input downstream; fail closed.
+  data = _sub('generate_video', _VALID_VIDEO)
+  data['inputFiles'] = [{'file': '1'}, {'file': '2'}]
+  assert validate_submission(data)[1] == 'MALFORMED_SUBMISSION'
+
+
+def _pipeline(n, image_nodes=(), video_nodes=(('v', 'root', 'image'),), groups=None):
+  """Builds a wired workflow: `root` forwards inputFiles, then the named image /
+  video nodes each draw from a predecessor's output."""
+  nodes = {'root': {'action': 'pass', 'input': dict.fromkeys(groups or ['image'])}}
+  for nid, pred, out in image_nodes:
+    nodes[nid] = {'action': 'outpaint_image', 'parameters': dict(_VALID_IMAGE),
+                  'input': {'image': {'node': pred, 'output': out}}}
+  for nid, pred, out in video_nodes:
+    nodes[nid] = {'action': 'generate_video', 'parameters': dict(_VALID_VIDEO),
+                  'input': {'image': {'node': pred, 'output': out}}}
+  return {'inputFiles': {g: [{'file': str(i)} for i in range(n)]
+                         for g in (groups or ['image'])},
+          'workflowDefinition': nodes}
+
+
+def test_billable_generations_over_cap_rejected():
+  # 100 images x a 3-model list on one video node = 300 generations > 200.
+  wf = _pipeline(100, video_nodes=())
+  wf['workflowDefinition']['v'] = {
+      'action': 'generate_video',
+      'input': {'image': {'node': 'root', 'output': 'image'}},
+      'parameters': {'model': ['veo-3.1-generate-001'] * 3, 'gcp_location': 'global'}}
+  assert validate_submission(wf)[1] == 'TOO_MANY_GENERATIONS'
+
+
+def test_billable_generations_within_budget_ok():
+  # 50 images -> outpaint + video = 100 generations, under the cap.
+  wf = _pipeline(50, image_nodes=(('o', 'root', 'image'),),
+                 video_nodes=(('v', 'o', 'outpainted_image'),))
+  assert validate_submission(wf) is None
+
+
+def test_sibling_billable_nodes_sum_not_multiply():
+  # Independent sibling branches SUM, not multiply: 3 video siblings over 60
+  # images = 180 (not 60**3); a 4th would make 240 > 200.
+  assert validate_submission(_pipeline(
+      60, video_nodes=[(f'v{i}', 'root', 'image') for i in range(3)])) is None
+  assert _code(_pipeline(
+      60, video_nodes=[(f'v{i}', 'root', 'image') for i in range(4)])
+             ) == 'TOO_MANY_GENERATIONS'
+
+
+def test_shared_lineage_counted_once():
+  # A node drawing two inputs that trace to the same source counts it once, not
+  # squared. prompt(1) + image(N) both via root: outpaint(N) + video(N) = 2N, so
+  # N=100 -> 200 (ok), N=101 -> 202 (over). Squaring would blow up far sooner.
+  def wf(n):
+    return {'inputFiles': {'prompt': [{'file': 'p'}],
+                           'image': [{'file': str(i)} for i in range(n)]},
+            'workflowDefinition': {
+                'root': {'action': 'pass', 'input': {'prompt': None, 'image': None}},
+                'o': {'action': 'outpaint_image', 'parameters': dict(_VALID_IMAGE),
+                      'input': {'image': {'node': 'root', 'output': 'image'}}},
+                'v': {'action': 'generate_video', 'parameters': dict(_VALID_VIDEO),
+                      'input': {'prompt': {'node': 'root', 'output': 'prompt'},
+                                'image': {'node': 'o', 'output': 'outpainted_image'}}}}}
+  assert validate_submission(wf(100)) is None
+  assert validate_submission(wf(101))[1] == 'TOO_MANY_GENERATIONS'
+
+
+# --- review round: non-int quantity, empty lists, malformed inputFiles --------
+
+def test_non_int_quantity_rejected():
+  # The prior guard only capped ints, so a non-int quantity slipped through and
+  # then range()/min() misbehaved in the worker. Reject type and shape, not just
+  # magnitude.
+  for name in ('video_variant_quantity', 'variant_quantity', 'story_variant_quantity'):
+    for bad in ('1000', 1.5, [[101]], ['1'], True, -1, 0):
+      assert _code(_sub('generate_video', {**_VALID_VIDEO, name: bad})
+                  ) == 'QUANTITY_INVALID', f'{name}={bad!r} slipped through'
+
+
+def test_empty_list_param_no_ops_rejected():
+  # aspect_ratio=[] expands to zero combinations, so the node silently never
+  # runs; reject rather than accept a workflow that looks queued but does nothing.
+  assert _code(_sub('generate_video', {**_VALID_VIDEO, 'aspect_ratio': []})
+              ) == 'EMPTY_LIST_PARAM'
+
+
+def test_malformed_input_files_values_rejected():
+  # Entries must be dicts with a real file path; a dict without a non-empty
+  # 'file' passes shape but crashes the action (a 500, not a 400).
+  base = _sub('generate_video', _VALID_VIDEO)
+  for bad in ('not-list', [1], [{'file': 'ok'}, 'bad'],
+              [{}], [{'file': ''}], [{'file': '  '}], [{'file': 123}]):
+    data = dict(base)
+    data['inputFiles'] = {'images': bad}
+    assert validate_submission(data)[1] == 'MALFORMED_SUBMISSION', f'{bad!r} passed'
+
+
+def test_quantity_list_summed_not_multiplied():
+  # A quantity list is alternatives, not a product: [100, 100] = two runs of 100
+  # = 200 outputs (at the cap), not 100*100=10000. [10,10,10] = 30. But the sum
+  # over the cap ([100,100,100] = 300) still trips the generation cap.
+  assert validate_submission(
+      _sub('generate_video', {**_VALID_VIDEO, 'video_variant_quantity': [100, 100]})) is None
+  assert validate_submission(
+      _sub('generate_video', {**_VALID_VIDEO, 'video_variant_quantity': [10, 10, 10]})) is None
+  assert _code(_sub('generate_video',
+                    {**_VALID_VIDEO, 'video_variant_quantity': [100, 100, 100]})
+              ) == 'TOO_MANY_GENERATIONS'
+
+
+def test_cheap_text_generations_not_counted():
+  # Gemini text is not billable: fanning a text action well past the generation
+  # cap still passes -- only image/Veo/Omni families count toward the cost cap.
+  data = {'inputFiles': {'images': [{'file': str(i)} for i in range(150)]},
+          'workflowDefinition': {
+              't': {'action': 'translate',
+                    'parameters': {'gemini_model': 'gemini-3.5-flash',
+                                   'gemini_model_location': 'global'}}}}
+  assert validate_submission(data) is None
+
+
+def test_billable_generations_boundary():
+  # The user's serial pipeline: N images -> outpaint -> video = 2N generations.
+  # 100 -> 200 (at cap); 101 -> 202 (over).
+  def wf(n):
+    return _pipeline(n, image_nodes=(('o', 'root', 'image'),),
+                     video_nodes=(('v', 'o', 'outpainted_image'),))
+  assert validate_submission(wf(100)) is None
+  assert validate_submission(wf(101))[1] == 'TOO_MANY_GENERATIONS'
+
+
+def test_queue_safety_fan_out_rejected():
+  # Non-billable pass nodes chained via edges compound their list fan-out
+  # (100 -> 10,000 -> 1,000,000 executions) past the queue cap, though nothing is
+  # billable. (Independent, unchained nodes would only sum -- this must chain.)
+  nodes = {'root': {'action': 'pass', 'input': {'image': None}}}
+  prev = 'root'
+  for i in range(3):
+    nodes[f'p{i}'] = {'action': 'pass', 'parameters': {'x': list(range(100))},
+                      'input': {'image': {'node': prev, 'output': 'image'}}}
+    prev = f'p{i}'
+  wf = {'inputFiles': {'image': [{'file': '0'}]}, 'workflowDefinition': nodes}
+  assert validate_submission(wf)[1] == 'TOTAL_FAN_OUT_TOO_LARGE'
+
+
+# --- review round 3: client dimension controls must not under-count -----------
+
+def test_dimensions_mapping_under_count_rejected():
+  # A dimensionsMapping rename can split a shared source into independent
+  # dimensions the engine cross-products (n -> n*n). A dim-altering node's output
+  # is treated as an opaque source, so the merge at z multiplies (100*100 > 200)
+  # instead of deduping by origin (which under-counted to 100).
+  wf = {'inputFiles': {'src': [{'file': str(i), 'd': str(i)} for i in range(100)]},
+        'workflowDefinition': {
+            'root': {'action': 'pass', 'input': {'src': None}},
+            'x': {'action': 'translate', 'dimensionsMapping': {'d': 'd2'},
+                  'input': {'src': {'node': 'root', 'output': 'src'}},
+                  'parameters': {'gemini_model': 'gemini-3.5-flash',
+                                 'gemini_model_location': 'global'}},
+            'y': {'action': 'pass', 'input': {'src': {'node': 'root', 'output': 'src'}}},
+            'z': {'action': 'generate_image', 'parameters': dict(_VALID_IMAGE),
+                  'input': {'a': {'node': 'x', 'output': 'src'},
+                            'b': {'node': 'y', 'output': 'src'}}}}}
+  assert validate_submission(wf)[1] == 'TOO_MANY_GENERATIONS'
+
+
+def test_dimensions_consumed_under_count_rejected():
+  # dimensionsConsumed splits a source into independent dimensions too, no rename
+  # needed: p projects out dim2, q projects out dim1, so they cross-product at c.
+  def branch(drop):
+    return {'action': 'translate', 'dimensionsConsumed': [drop],
+            'input': {'src': {'node': 'root', 'output': 'src'}},
+            'parameters': {'gemini_model': 'gemini-3.5-flash',
+                           'gemini_model_location': 'global'}}
+  wf = {'inputFiles': {'src': [{'file': str(i), 'dim1': str(i), 'dim2': str(i)}
+                               for i in range(100)]},
+        'workflowDefinition': {
+            'root': {'action': 'pass', 'input': {'src': None}},
+            'p': branch('dim2'), 'q': branch('dim1'),
+            'c': {'action': 'generate_image', 'parameters': dict(_VALID_IMAGE),
+                  'input': {'a': {'node': 'p', 'output': 'src'},
+                            'b': {'node': 'q', 'output': 'src'}}}}}
+  assert validate_submission(wf)[1] == 'TOO_MANY_GENERATIONS'
+
+
+def test_malformed_input_edge_rejected():
+  # A predecessor edge must be {node: str, output: str}: a non-string node throws
+  # when hashed in the graph walk, a missing/empty output crashes the mapper.
+  for edge in ({'node': [], 'output': 'i'}, {'node': 'r', 'output': []},
+               {'node': 'r'}, {'node': '', 'output': 'i'}, {'node': 'r', 'output': ''}):
+    wf = {'workflowDefinition': {'a': {'action': 'pass', 'input': {'x': edge}},
+                                 'r': {'action': 'pass'}}}
+    assert validate_submission(wf)[1] == 'MALFORMED_SUBMISSION', f'{edge!r} passed'
+
+
+def test_malformed_dimensions_mapping_rejected():
+  # A non-dict throws when the worker inverts the mapping; an unhashable/non-string
+  # value or a duplicate target corrupts the rename. All must fail closed here.
+  for mapping in ('evil', ['d'], {'d': ['x']}, {'d': 1}, {'': 'd2'}, {'d': ''},
+                  {'a': 'x', 'b': 'x'}):
+    wf = {'workflowDefinition': {'n': {'action': 'pass', 'dimensionsMapping': mapping}}}
+    assert validate_submission(wf)[1] == 'MALFORMED_SUBMISSION', f'{mapping!r} passed'
+
+
+def test_malformed_dimensions_consumed_rejected():
+  # A non-list throws when the worker does `key in dimensionsConsumed`; a non-string
+  # element never matches and silently fails to project. Reject both shapes.
+  for consumed in (123, True, 'x', {'d': 1}, [1], [''], ['ok', 2]):
+    wf = {'workflowDefinition': {'n': {'action': 'pass', 'dimensionsConsumed': consumed}}}
+    assert validate_submission(wf)[1] == 'MALFORMED_SUBMISSION', f'{consumed!r} passed'
+
+
+def test_wellformed_dimension_controls_accepted():
+  # The shape check must not reject a legitimate rename/projection.
+  wf = {'inputFiles': {'src': [{'file': '1', 'd': 'x'}]},
+        'workflowDefinition': {
+            'root': {'action': 'pass', 'input': {'src': None}},
+            'x': {'action': 'pass', 'dimensionsMapping': {'d': 'd2'},
+                  'dimensionsConsumed': ['other'],
+                  'input': {'src': {'node': 'root', 'output': 'src'}}}}}
+  assert validate_submission(wf) is None

--- a/util/submission_validation.py
+++ b/util/submission_validation.py
@@ -131,15 +131,34 @@ def validate_submission(
     for key, files in input_files.items():
       if not isinstance(files, list):
         return (f'inputFiles {key!r} is not a list', 'MALFORMED_SUBMISSION')
+      dimension_keys = None
       for entry in files:
         if (not isinstance(entry, dict) or not isinstance(entry.get('file'), str)
             or not entry['file'].strip()):
           return (f'inputFiles {key!r} entries must each have a non-empty '
                   f'file', 'MALFORMED_SUBMISSION')
+        # The engine groups on the non-file fields of the first entry and
+        # indexes every entry by them (group_input._group_dictionaries), so
+        # ragged keys raise KeyError there and a non-scalar value makes an
+        # unhashable group key. Fail closed on both shapes.
+        entry_keys = frozenset(entry) - {'file'}
+        if dimension_keys is None:
+          dimension_keys = entry_keys
+        elif entry_keys != dimension_keys:
+          return (f'inputFiles {key!r} entries carry inconsistent dimension '
+                  'keys', 'MALFORMED_SUBMISSION')
+        for field in entry_keys:
+          value = entry[field]
+          if value is not None and not isinstance(value, (str, int, float, bool)):
+            return (f'inputFiles {key!r} dimension {field!r} must be a scalar',
+                    'MALFORMED_SUBMISSION')
       if len(files) > _MAX_INPUT_FILES:
         return (f'inputFiles {key!r} has too many entries '
                 f'({len(files)} > {_MAX_INPUT_FILES})', 'TOO_MANY_INPUT_FILES')
-      input_group_sizes[key] = len(files)
+      # An empty group still becomes one grouping slot in the engine
+      # (group_input returns {(): []}), so counting it as 0 would zero out
+      # every downstream multiplier and hide real fan-out from the budget.
+      input_group_sizes[key] = max(1, len(files))
 
   definition = data.get(_WORKFLOW_DEFINITION)
   if definition is None:

--- a/util/submission_validation.py
+++ b/util/submission_validation.py
@@ -34,6 +34,38 @@ _ACTIONS_JSON = os.path.join(
 _MODEL_PARAM_NAMES = ('gemini_model', 'image_model', 'model')
 _EXECUTION_ID = 'executionId'
 _WORKFLOW_DEFINITION = 'workflowDefinition'
+_INPUT_FILES = 'inputFiles'
+_GCP_PROJECT = 'gcp_project'
+# Node input-edge keys (raw submission JSON; mirrors common.Key).
+_INPUT = 'input'
+_NODE = 'node'
+_OUTPUT = 'output'
+_PASS = 'pass'
+# Client-settable dimension controls (common.Key). A node carrying either can
+# split a shared source into independent dimensions the engine cross-products.
+_DIMENSIONS_MAPPING = 'dimensionsMapping'
+_DIMENSIONS_CONSUMED = 'dimensionsConsumed'
+
+# Cost cap: how many *billable* generations (image / Veo / Omni) one submission
+# may spawn. Gemini text calls are cheap and deliberately not counted. This is
+# the money guardrail.
+_MAX_GENERATIONS = 200
+# A node's family costs money when the allowlist's per-action default_key names
+# one of these. (Omni's key joins here when that action lands.)
+_EXPENSIVE_DEFAULT_KEYS = ('imageModel', 'veoModel')
+
+# Structural / queue-safety caps -- generous; the cost cap above is the real
+# money bound. _MAX_TOTAL_FAN_OUT bounds the total node executions the
+# orchestrator must materialize (billable or not), so a pass-node blow-up can't
+# exhaust it.
+_MAX_NODES = 200            # nodes in a single workflow
+_MAX_INPUT_FILES = 200      # entries in one inputFiles group
+_MAX_LIST_LEN = 100         # length of any list-valued node parameter
+_MAX_FAN_OUT = 1000         # product of a single node's list-parameter lengths
+_MAX_TOTAL_FAN_OUT = 100000  # total node executions across the whole workflow
+_MAX_QUANTITY = 100         # value of a variant/video quantity parameter
+_QUANTITY_PARAMS = (
+    'video_variant_quantity', 'variant_quantity', 'story_variant_quantity')
 
 
 @functools.lru_cache(maxsize=1)
@@ -58,13 +90,17 @@ def _model_param_name(action: str, actions_json: dict) -> str | None:
   return None
 
 
+def _as_values(value: Any) -> list:
+  """Returns values after engine-style list expansion (util.workflow)."""
+  return value if isinstance(value, list) else [value]
+
+
 def validate_submission(
     data: Any,
     allowlist: dict | None = None,
     actions_json: dict | None = None,
 ) -> tuple[str, str] | None:
-  """Returns ``(message, code)`` for the first problem, else ``None``. Stops at
-  the first problem, in node order.
+  """Returns ``(message, code)`` for the first problem, else ``None``.
 
   This runs at the app's trust boundary, so it fails closed: any shape it can't
   make sense of is rejected as ``MALFORMED_SUBMISSION`` rather than passed on --
@@ -83,20 +119,92 @@ def validate_submission(
   if _EXECUTION_ID in data:
     return ('executionId is not allowed on this route', 'EXECUTION_ID_NOT_ALLOWED')
 
+  # inputFiles is optional. Each group must be a list of file objects with a
+  # real file path -- the actions read entry['file'] (Key.FILE), so a non-list
+  # group or an entry missing 'file' would crash the engine; fail closed. Record
+  # each group's size for the DAG fan-out below.
+  input_files = data.get(_INPUT_FILES)
+  input_group_sizes = {}
+  if input_files is not None:
+    if not isinstance(input_files, dict):
+      return ('inputFiles is not an object', 'MALFORMED_SUBMISSION')
+    for key, files in input_files.items():
+      if not isinstance(files, list):
+        return (f'inputFiles {key!r} is not a list', 'MALFORMED_SUBMISSION')
+      for entry in files:
+        if (not isinstance(entry, dict) or not isinstance(entry.get('file'), str)
+            or not entry['file'].strip()):
+          return (f'inputFiles {key!r} entries must each have a non-empty '
+                  f'file', 'MALFORMED_SUBMISSION')
+      if len(files) > _MAX_INPUT_FILES:
+        return (f'inputFiles {key!r} has too many entries '
+                f'({len(files)} > {_MAX_INPUT_FILES})', 'TOO_MANY_INPUT_FILES')
+      input_group_sizes[key] = len(files)
+
   definition = data.get(_WORKFLOW_DEFINITION)
   if definition is None:
     definition = {}
   if not isinstance(definition, dict):
     return ('workflowDefinition is not an object', 'MALFORMED_SUBMISSION')
+  if len(definition) > _MAX_NODES:
+    return (f'workflow has too many nodes ({len(definition)} > {_MAX_NODES})',
+            'TOO_MANY_NODES')
 
+  # Pass 1: per-node structural, model/location, and per-node-limit checks, in
+  # node order. Collect each node's own fan-out (its list/quantity multiplier)
+  # for the graph-aware budget below.
+  node_locals = {}
   for node_id, node in definition.items():
     if not isinstance(node, dict):
       return (f'Node {node_id!r} is not an object', 'MALFORMED_SUBMISSION')
     action = node.get('action')
     if not isinstance(action, str):
       return (f'Node {node_id!r} has a non-string action', 'MALFORMED_SUBMISSION')
-    if action not in action_specs:
-      continue  # only actions that take a model are checked here
+    node_input = node.get(_INPUT)
+    if node_input is not None:
+      if not isinstance(node_input, dict):
+        return (f'Node {node_id!r} input is not an object', 'MALFORMED_SUBMISSION')
+      for source in node_input.values():
+        # An edge is null (top-level input) or a {node, output} object; anything
+        # else would crash the engine's map_output_to_input (.get on a non-dict).
+        if source is None:
+          continue
+        if not isinstance(source, dict):
+          return (f'Node {node_id!r} has a malformed input source',
+                  'MALFORMED_SUBMISSION')
+        # A predecessor edge carries {node, output}; both must be non-empty
+        # strings. A non-string node throws when hashed in the graph walk; a
+        # missing/empty output raises KeyError mapping the predecessor output.
+        if _NODE in source or _OUTPUT in source:
+          if (not isinstance(source.get(_NODE), str) or not source.get(_NODE)
+              or not isinstance(source.get(_OUTPUT), str) or not source.get(_OUTPUT)):
+            return (f'Node {node_id!r} has a malformed input edge (node/output '
+                    f'must be non-empty strings)', 'MALFORMED_SUBMISSION')
+
+    # dimensionsMapping / dimensionsConsumed reach the worker unvalidated: the
+    # orchestrator inverts the mapping ({v: k for k, v in mapping.items()}), which
+    # throws on a non-dict or an unhashable value, and does `key in
+    # dimensionsConsumed`, which throws on a non-list. Fail closed on shape here so
+    # a bad control is a 400, not a 500.
+    mapping = node.get(_DIMENSIONS_MAPPING)
+    if mapping is not None:
+      if not isinstance(mapping, dict) or any(
+          not isinstance(k, str) or not k or not isinstance(v, str) or not v
+          for k, v in mapping.items()):
+        return (f'Node {node_id!r} has a malformed dimensionsMapping (expected '
+                f'an object of non-empty string pairs)', 'MALFORMED_SUBMISSION')
+      # The engine inverts the mapping, so duplicate targets silently drop a
+      # rename; rename_dimensions requires targets to be unique.
+      targets = list(mapping.values())
+      if len(set(targets)) != len(targets):
+        return (f'Node {node_id!r} dimensionsMapping has duplicate targets',
+                'MALFORMED_SUBMISSION')
+    consumed = node.get(_DIMENSIONS_CONSUMED)
+    if consumed is not None and (not isinstance(consumed, list) or any(
+        not isinstance(dimension, str) or not dimension
+        for dimension in consumed)):
+      return (f'Node {node_id!r} has a malformed dimensionsConsumed (expected a '
+              f'list of non-empty strings)', 'MALFORMED_SUBMISSION')
 
     params = node.get('parameters')
     if params is None:
@@ -104,10 +212,17 @@ def validate_submission(
     if not isinstance(params, dict):
       return (f'Node {node_id!r} has non-object parameters', 'MALFORMED_SUBMISSION')
 
+    limit, node_fan = _node_limit_violation(node_id, params)
+    if limit is not None:
+      return limit
+    node_locals[node_id] = node_fan
+
+    if action not in action_specs:
+      continue  # only model-parameterized actions get the model/location checks
+
     model_param = _model_param_name(action, actions_json)
     model_value = params.get(model_param) if model_param else None
     model_list = model_value if isinstance(model_value, list) else [model_value]
-    # Empty list, or any empty element, means no model was actually supplied.
     if not model_list or any(model is None or model == '' for model in model_list):
       return (f'Node {node_id!r}: {action} is missing its model ({model_param})',
               'MISSING_MODEL_PARAM')
@@ -118,8 +233,6 @@ def validate_submission(
       location_value = params.get(location_param)
       locations = (location_value if isinstance(location_value, list)
                    else [location_value])
-      # Empty list or empty element falls back to the infra region at run time,
-      # so the checked pair would differ from what actually runs. Reject it.
       if not locations or any(
           location is None or location == '' for location in locations):
         return (f'Node {node_id!r}: {action} is missing its location '
@@ -135,4 +248,197 @@ def validate_submission(
           if not is_pair_allowed(action, model, location, allowlist):
             return (f'Node {node_id!r}: {action} model {model!r} is not allowed '
                     f'in {location!r}', 'MODEL_LOCATION_PAIR_INVALID')
+
+  # Pass 2: graph-aware fan-out -- bound total executions (queue) and billable
+  # generations (cost) along the actual DAG.
+  return _fan_out_budget(definition, input_group_sizes, node_locals, action_specs)
+
+
+def _fan_out_budget(
+    definition: dict,
+    input_group_sizes: dict,
+    node_locals: dict,
+    action_specs: dict,
+) -> tuple[str, str] | None:
+  """Bounds total node executions and billable generations over the workflow DAG.
+
+  The orchestrator runs a node ``len(input_groups) * len(expanded_parameters)``
+  times, so fan-out flows along input edges. We track each node's fan-out as the
+  product of its distinct lineage *sources* -- inputFiles groups plus each node's
+  own list/quantity multiplier. Merging by source means a source reached by more
+  than one path (shared lineage) is counted once, while independent sources
+  multiply and sibling branches simply sum. This is a conservative upper bound on
+  the engine's dimension-aligned grouping (it never under-counts)."""
+  order = _topo_order(definition)
+  if order is None:
+    return ('workflowDefinition has a cycle or an edge to an unknown node',
+            'MALFORMED_SUBMISSION')
+
+  node_lineage = {}   # node_id -> {source_key: multiplier} (an action's outputs)
+  out_lineage = {}    # (node_id, output_key) -> {...} (a pass forwards per output)
+  generations = 0
+  total = 0
+  for node_id in order:
+    node = definition[node_id]
+    inputs = node.get(_INPUT) if isinstance(node.get(_INPUT), dict) else {}
+    combined = {}
+    for in_key, source in inputs.items():
+      combined.update(_edge_lineage(in_key, source, out_lineage, node_lineage,
+                                    input_group_sizes))
+    local = node_locals.get(node_id, 1)
+    if local > 1:
+      combined['loc:' + node_id] = local
+
+    node_fan = 1
+    for multiplier in combined.values():
+      node_fan *= multiplier
+    total += node_fan
+    if total > _MAX_TOTAL_FAN_OUT:
+      return (f'workflow fan-out too large across all nodes '
+              f'({total} > {_MAX_TOTAL_FAN_OUT})', 'TOTAL_FAN_OUT_TOO_LARGE')
+    if action_specs.get(node.get('action'), {}).get('default_key') in _EXPENSIVE_DEFAULT_KEYS:
+      generations += node_fan
+      if generations > _MAX_GENERATIONS:
+        return (f'workflow spawns too many billable generations '
+                f'({generations} > {_MAX_GENERATIONS})', 'TOO_MANY_GENERATIONS')
+
+    if node.get(_DIMENSIONS_MAPPING) or node.get(_DIMENSIONS_CONSUMED):
+      # This node renames/projects dimensions (dimensionsMapping/dimensionsConsumed
+      # are client-settable and applied in orchestrator.py). That can SPLIT a
+      # shared source into independent dimension keys the engine then
+      # cross-products (n -> n*n), so model the output as one fresh opaque source:
+      # a downstream merge then multiplies it instead of deduping by origin.
+      # Conservative -- it can over-count a rename that happens to realign, but
+      # it never under-counts (the property the cost cap depends on).
+      opaque = {'dim:' + node_id: node_fan}
+      node_lineage[node_id] = opaque
+      if node.get('action') == _PASS:
+        for in_key in inputs:
+          out_lineage[(node_id, in_key)] = dict(opaque)
+    else:
+      node_lineage[node_id] = combined
+      # A pass forwards each input to the same-named output, so a consumer of one
+      # output must not inherit the node's *other* inputs. Track per-output.
+      if node.get('action') == _PASS:
+        for in_key, source in inputs.items():
+          lineage = dict(_edge_lineage(in_key, source, out_lineage, node_lineage,
+                                       input_group_sizes))
+          if local > 1:
+            lineage['loc:' + node_id] = local
+          out_lineage[(node_id, in_key)] = lineage
   return None
+
+
+def _edge_lineage(
+    in_key: str,
+    source: Any,
+    out_lineage: dict,
+    node_lineage: dict,
+    input_group_sizes: dict,
+) -> dict:
+  """The lineage an input edge carries: a predecessor output's lineage, or the
+  inputFiles group named by a top-level input, else nothing (a constant)."""
+  if isinstance(source, dict) and source.get(_NODE) is not None:
+    pred_id = source.get(_NODE)
+    output_key = source.get(_OUTPUT)
+    lineage = out_lineage.get((pred_id, output_key))
+    return lineage if lineage is not None else node_lineage.get(pred_id, {})
+  if in_key in input_group_sizes:
+    return {'in:' + in_key: input_group_sizes[in_key]}
+  return {}
+
+
+def _topo_order(definition: dict) -> list[str] | None:
+  """Nodes ordered so every predecessor precedes its successors, or ``None`` on a
+  cycle, a self-edge, or an edge to an unknown node (all malformed)."""
+  preds = {}
+  for node_id, node in definition.items():
+    node_preds = set()
+    inputs = node.get(_INPUT) if isinstance(node, dict) else None
+    if isinstance(inputs, dict):
+      for source in inputs.values():
+        if isinstance(source, dict) and source.get(_NODE) is not None:
+          pred_id = source.get(_NODE)
+          if pred_id == node_id or pred_id not in definition:
+            return None
+          node_preds.add(pred_id)
+    preds[node_id] = node_preds
+  order, done = [], set()
+  progress = True
+  while progress and len(order) < len(definition):
+    progress = False
+    for node_id in definition:
+      if node_id not in done and preds[node_id] <= done:
+        order.append(node_id)
+        done.add(node_id)
+        progress = True
+  return order if len(order) == len(definition) else None
+
+
+def _node_limit_violation(
+    node_id: str, params: dict
+) -> tuple[tuple[str, str] | None, int]:
+  """Per-node checks; returns ``((message, code) or None, node_fan_out)``.
+
+  ``node_fan_out`` is this node's own output multiplier: the product of its
+  list-parameter lengths times its quantity outputs (quantity *alternatives* are
+  summed, not multiplied -- see below). The caller compounds it over the DAG to
+  bound whole-workflow fan-out and billable-generation totals. List-shaped values
+  are checked element-wise -- the engine expands them to scalars before
+  execution, so the raw type alone can't be trusted (see ``_as_values``)."""
+  # The server pins the GCP project; a node must not point elsewhere. The UI
+  # sends an empty string (allowed). Anything else is rejected, including a
+  # one-element list the engine would unwrap to a real project.
+  if _GCP_PROJECT in params:
+    for value in _as_values(params[_GCP_PROJECT]):
+      if not (isinstance(value, str) and not value.strip()):
+        return ((f'Node {node_id!r}: gcp_project may not be set on a node',
+                 'GCP_PROJECT_NOT_ALLOWED'), 1)
+
+  fan_out = 1
+  for name, value in params.items():
+    if name in _QUANTITY_PARAMS:
+      continue  # an output multiplier, summed below -- not a plain dimension
+    if isinstance(value, list):
+      # An empty list expands to zero combinations (itertools.product), so the
+      # node silently never runs. Reject it rather than accept a no-op workflow.
+      if not value:
+        return ((f'Node {node_id!r}: parameter {name!r} is an empty list',
+                 'EMPTY_LIST_PARAM'), fan_out)
+      if len(value) > _MAX_LIST_LEN:
+        return ((f'Node {node_id!r}: parameter {name!r} list too long '
+                 f'({len(value)} > {_MAX_LIST_LEN})', 'LIST_TOO_LONG'), fan_out)
+      fan_out *= len(value)
+  if fan_out > _MAX_FAN_OUT:
+    return ((f'Node {node_id!r}: list-parameter fan-out too large '
+             f'({fan_out} > {_MAX_FAN_OUT})', 'FAN_OUT_TOO_LARGE'), fan_out)
+
+  # A quantity param is a dimension of *alternatives*, not a multiplier: [10, 10]
+  # is two runs of 10 outputs = 20, not 10*10. Sum the values within a param;
+  # multiply across independent quantity params. Each value must be a plain int
+  # in 1..cap -- the executor does range()/min() on it, so a string, float,
+  # nested list, bool, or <=0 would 500 or clamp silently (type AND shape, not
+  # just magnitude, since the prior guard only capped ints).
+  quantity = 1
+  for name in _QUANTITY_PARAMS:
+    if name not in params:
+      continue
+    values = _as_values(params[name])
+    if isinstance(params[name], list):
+      if not values:
+        return ((f'Node {node_id!r}: parameter {name!r} is an empty list',
+                 'EMPTY_LIST_PARAM'), fan_out)
+      if len(values) > _MAX_LIST_LEN:
+        return ((f'Node {node_id!r}: parameter {name!r} list too long '
+                 f'({len(values)} > {_MAX_LIST_LEN})', 'LIST_TOO_LONG'), fan_out)
+    total = 0
+    for value in values:
+      if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        return ((f'Node {node_id!r}: {name} must be an integer in '
+                 f'1..{_MAX_QUANTITY}', 'QUANTITY_INVALID'), fan_out)
+      if value > _MAX_QUANTITY:
+        return ((f'Node {node_id!r}: {name} too large '
+                 f'({value} > {_MAX_QUANTITY})', 'QUANTITY_TOO_LARGE'), fan_out)
+      total += value
+    quantity *= total
+  return None, fan_out * quantity


### PR DESCRIPTION
## Summary

Extends the enqueue submission validator with fan-out, quantity, node-count, input-file, and per-node `gcp_project` limits. The checks inspect the values the engine will actually run, so a value wrapped in a one-element list can no longer slip past a scalar type check.

## Behavior

The validator returns `(message, code)` for the first problem it finds, else `None`. The new checks reject:

- **Node `gcp_project`** (`GCP_PROJECT_NOT_ALLOWED`) — a node may carry `gcp_project` only if every value it expands to is an empty/blank string. The server pins the project; the UI sends `''`, which is allowed. Anything else (a real project string, a number, an object, or a list whose elements aren't blank strings) is rejected, because the executor's `gcp_project or workflow_params[...]` fallback would otherwise let the node override the pinned project.
- **List too long** (`LIST_TOO_LONG`) — any list-valued node parameter longer than `_MAX_LIST_LEN` (100).
- **Per-node fan-out** (`FAN_OUT_TOO_LARGE`) — the product of one node's list-parameter lengths exceeds `_MAX_FAN_OUT` (1000). Each list can be under the length cap while their product is not.
- **Whole-workflow fan-out** (`TOTAL_FAN_OUT_TOO_LARGE`) — fan-out composes along edges, so a chain of nodes each under the per-node cap can still multiply past a sane total. The validator tracks the running product across nodes (seeded by the largest `inputFiles` group) and bounds it with `_MAX_TOTAL_FAN_OUT` (100000).
- **Quantity too large** (`QUANTITY_TOO_LARGE`) — any parameter in `_QUANTITY_PARAMS` (`video_variant_quantity`, `variant_quantity`, `story_variant_quantity`) exceeds `_MAX_QUANTITY` (100), in scalar or list form. Booleans are skipped: a `bool` is an `int` subclass but is a flag, not a quantity.
- **Too many nodes** (`TOO_MANY_NODES`) — the workflow has more than `_MAX_NODES` (200) nodes.
- **Too many input files** (`TOO_MANY_INPUT_FILES`) — an `inputFiles` group has more than `_MAX_INPUT_FILES` (200) entries.
- **Malformed `inputFiles`** (`MALFORMED_SUBMISSION`) — `inputFiles` is present but not an object. It fails closed here rather than reaching `verify_input`, whose `.items()` would raise and turn a client error into a 500.

List-shape handling: the engine expands a list parameter into one execution per element and runs a scalar as itself (`util/workflow.py` `expand_parameters` normalizes each value with `v if isinstance(v, list) else [v]`). A guard that only checks the raw value's type is therefore fooled by a one-element list — `['other']` fails an `isinstance(str)` check but the engine unwraps it to `'other'`. A helper `_as_values()` mirrors that expansion and normalizes every value to the list the engine will run; the `gcp_project` and quantity guards check those normalized values, so scalar, one-element-list, and multi-element-list forms are all covered.

Caps are named constants chosen as conservative upper bounds — generous enough that every `workflow_example` and current UI submission still passes, tight enough to stop an absurd fan-out.

## Tests

`test/test_submission_validation.py` adds coverage for each new check and its bypasses:

- One rejection test per check: node `gcp_project`, list too long, per-node fan-out product, too many nodes, too many input files, quantity too large, whole-workflow fan-out across a three-node chain, and non-object `inputFiles`.
- List-shaped inputs that must still be rejected: `gcp_project` as `['other']`, `123`, `{...}`, and `['a','b']`; each quantity parameter as `[101]`; `inputFiles` as a list.
- Happy paths that must still pass: `gcp_project=''` and `['']`, quantities within cap in scalar and list form, and a two-node workflow whose total fan-out stays under budget.

## Risks / Notes

- Cap values are chosen bounds, not derived from a measured product limit — worth confirming against real workflow sizes before merge.
- The `gcp_project` rule depends on the executor keeping the `gcp_project or workflow_params[...]` fallback; if that resolution changes, revisit the allowed-value rule.
