### PR TITLE
Refuse ROLE=all together with AUTH_MODE=iap at startup

### DIFF
--- a/orch.py
+++ b/orch.py
@@ -98,6 +98,11 @@ if _ROLE not in ('all', 'app', 'worker'):
   raise RuntimeError(f'Invalid ROLE: {_ROLE!r} (use all|app|worker)')
 if _AUTH_MODE not in ('none', 'iap'):
   raise RuntimeError(f'Invalid AUTH_MODE: {_AUTH_MODE!r} (use none|iap)')
+# Public deploys must use ROLE=app so /api/supplyNode is validated.
+if _ROLE == 'all' and _AUTH_MODE == 'iap':
+  raise RuntimeError(
+      'ROLE=all with AUTH_MODE=iap is not allowed: a public service must run '
+      'ROLE=app so submissions are validated. ROLE=all is dev-only (AUTH_MODE=none).')
 if _ROLE == 'app' and _AUTH_MODE == 'iap' and not _IAP_AUDIENCE:
   raise RuntimeError('IAP_AUDIENCE is required when AUTH_MODE=iap')
 # Without WORKER_URL the app derives the Cloud Tasks callback base from its own

--- a/test/test_frontdoor.py
+++ b/test/test_frontdoor.py
@@ -658,3 +658,12 @@ def test_worker_route_does_not_validate(monkeypatch, orchestrator_module):
       '/supplyNode', json=_video_node('rogue', 'global'))
   assert response.status_code == 200
   assert 'data' in captured
+
+
+def test_role_all_with_iap_is_refused(monkeypatch, orchestrator_module):
+  # A public (IAP) service must run ROLE=app so submissions are validated;
+  # ROLE=all skips validation and is dev-only. The misconfiguration must fail
+  # fast at import rather than silently serving an unvalidated route.
+  del orchestrator_module
+  with pytest.raises(RuntimeError, match='ROLE=all'):
+    _load_orch(monkeypatch, ROLE='all', AUTH_MODE='iap')


### PR DESCRIPTION
## Summary

Adds a startup guard that refuses to run `ROLE=all` together with `AUTH_MODE=iap`. This prevents a public, authenticated deploy from serving the worker route without submission validation.

## Behavior

- Submission validation runs only under `ROLE=app`. `ROLE=all` serves the worker route (`/supplyNode`) with no validation and is intended for dev only (its posture is `AUTH_MODE=none`).
- At import, `orch.py` now raises `RuntimeError` when `ROLE=all` and `AUTH_MODE=iap` are set together, so the process fails fast instead of serving an unvalidated submit route to authenticated users.
- The error message directs operators to run `ROLE=app` for a public service.
- Dev/legacy `ROLE=all` under `AUTH_MODE=none` is unaffected; the new check only triggers on the `iap` combination. The existing ROLE/AUTH_MODE validity checks are unchanged.

## Tests

`test/test_frontdoor.py` adds a case asserting that loading the module with `ROLE=all` and `AUTH_MODE=iap` raises `RuntimeError` (matched on `ROLE=all`). The prior worker-route and front-door tests still hold, confirming valid role/mode combinations continue to load.

## Risks / Notes

- The guard fires at import time, so a misconfigured deploy crashes on startup rather than degrading silently — intended, but operators must read the error to correct `ROLE`/`AUTH_MODE`.
