### PR TITLE
Seed config/models from the repo catalog, with a diff preview

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -58,6 +58,15 @@ curl -s -X PATCH \
   -H "x-goog-user-project: ${PROJECT}" \
   -H "Content-Type: application/json" \
   -d @<(envsubst < ./firestore_config_frontdoor.template.json)
+
+# The model catalog document (config/models), seeded from the repo file the
+# same way deploy.sh does it:
+python3 scripts/seed_config_models.py convert < ui/definitions/models.json | curl -s -X PATCH \
+  "https://firestore.googleapis.com/v1/projects/${PROJECT}/databases/${FIRESTORE_DB_UI}/documents/config/models" \
+  -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  -H "x-goog-user-project: ${PROJECT}" \
+  -H "Content-Type: application/json" \
+  -d @-
 ```
 
 This requires a Firestore database to already exist in your dev project (the one `FIRESTORE_DB_UI` names) and ADC with write access to it.

--- a/deploy.sh
+++ b/deploy.sh
@@ -319,6 +319,26 @@ if ! python3 scripts/validate_config_models.py; then
   exit 1
 fi
 
+# --- Preview the model-catalog seed ------------------------------------------
+# Deploys overwrite config/models from ui/definitions/models.json (the repo is
+# the source of truth), so a live console edit does not survive a deploy. Show
+# what this deploy's seed will change before the confirmation prompt below. On
+# a fresh project the Firestore API or database does not exist yet, so any
+# read failure only means "nothing to diff" -- the preview never blocks.
+echo "[>] Previewing the model-catalog seed (config/models)..."
+LIVE_MODELS_DOC=$(mktemp)
+if curl -sf \
+  "https://firestore.googleapis.com/v1/projects/${PROJECT}/databases/${FIRESTORE_DB_UI}/documents/config/models" \
+  -H "Authorization: Bearer $(gcloud auth application-default print-access-token 2>/dev/null || true)" \
+  -H "x-goog-user-project: ${PROJECT}" \
+  -o "$LIVE_MODELS_DOC" 2>/dev/null; then
+  python3 scripts/seed_config_models.py diff ui/definitions/models.json "$LIVE_MODELS_DOC"
+else
+  echo "    no live config/models to read (fresh project or not seeded yet);"
+  echo "    this deploy seeds it from the repo."
+fi
+rm -f "$LIVE_MODELS_DOC"
+
 # --- Confirm deployment target ----------------------------------------------
 # Final pre-flight gate. Shows gcloud's current state alongside config.txt's
 # intended target. This script NEVER changes gcloud's
@@ -907,6 +927,23 @@ CONFIG_SEED_STATUS=$(curl -s -X PATCH \
 if [ "$CONFIG_SEED_STATUS" != "200" ]; then
   echo "ERROR: seeding the UI config (config/global) failed (HTTP ${CONFIG_SEED_STATUS:-no response})." >&2
   echo "       The app's backend wiring was not written; aborting." >&2
+  exit 1
+fi
+
+# The model catalog: config/models is overwritten from the repo file on every
+# deploy. Operators may edit the live doc between deploys; the pre-flight
+# preview above showed what this write replaces. Same fail-loudly contract as
+# the config/global seed.
+MODELS_SEED_STATUS=$(python3 scripts/seed_config_models.py convert < ui/definitions/models.json | curl -s -X PATCH \
+"https://firestore.googleapis.com/v1/projects/${PROJECT}/databases/${FIRESTORE_DB_UI}/documents/config/models" \
+  -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  -H "x-goog-user-project: ${PROJECT}" \
+  -H "Content-Type: application/json" \
+  -o /dev/null -w '%{http_code}' \
+  -d @-)
+if [ "$MODELS_SEED_STATUS" != "200" ]; then
+  echo "ERROR: seeding the model catalog (config/models) failed (HTTP ${MODELS_SEED_STATUS:-no response})." >&2
+  echo "       The runtime model catalog was not written; aborting." >&2
   exit 1
 fi
 

--- a/scripts/seed_config_models.py
+++ b/scripts/seed_config_models.py
@@ -93,6 +93,25 @@ def document_to_plain(doc: dict[str, Any]) -> dict[str, Any]:
   return {k: from_typed(v) for k, v in doc.get('fields', {}).items()}
 
 
+def values_equal(left: Any, right: Any) -> bool:
+  """Type-sensitive equality for the diff.
+
+  Python's == treats True == 1 and 4 == 4.0 as equal, but Firestore stores
+  boolean, integer, and double as distinct types, so a console edit that only
+  changes a field's type would preview as "changes nothing" while the seed
+  still rewrites the stored type.
+  """
+  if type(left) is not type(right):
+    return False
+  if isinstance(left, dict):
+    return (left.keys() == right.keys()
+            and all(values_equal(left[key], right[key]) for key in left))
+  if isinstance(left, list):
+    return (len(left) == len(right)
+            and all(values_equal(a, b) for a, b in zip(left, right)))
+  return left == right
+
+
 def diff_lines(repo: dict[str, Any], live: dict[str, Any]) -> list[str]:
   """What overwriting `live` with `repo` changes, one line per difference.
 
@@ -110,7 +129,7 @@ def diff_lines(repo: dict[str, Any], live: dict[str, Any]) -> list[str]:
       lines.append(f'- will remove section {section!r} (exists only live)')
       continue
     repo_value, live_value = repo[section], live[section]
-    if repo_value == live_value:
+    if values_equal(repo_value, live_value):
       continue
     if not (isinstance(repo_value, dict) and isinstance(live_value, dict)):
       lines.append(f'~ will replace {section!r}')
@@ -123,13 +142,13 @@ def diff_lines(repo: dict[str, Any], live: dict[str, Any]) -> list[str]:
         lines.append(f'- will remove {section}.{key} (exists only live)')
         continue
       entry_repo, entry_live = repo_value[key], live_value[key]
-      if entry_repo == entry_live:
+      if values_equal(entry_repo, entry_live):
         continue
       if isinstance(entry_repo, dict) and isinstance(entry_live, dict):
         changed = sorted(
             field for field in set(entry_repo) | set(entry_live)
             if (field in entry_repo) != (field in entry_live)
-            or entry_repo.get(field) != entry_live.get(field))
+            or not values_equal(entry_repo.get(field), entry_live.get(field)))
         lines.append(f'~ will change {section}.{key} ({", ".join(changed)})')
       else:
         lines.append(f'~ will change {section}.{key}: '

--- a/scripts/seed_config_models.py
+++ b/scripts/seed_config_models.py
@@ -1,0 +1,169 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Converts the repo model catalog for the Firestore REST API and previews
+what seeding will change.
+
+deploy.sh overwrites the `config/models` document from
+`ui/definitions/models.json` on every deploy (the repo is the source of
+truth), so a live console edit does not survive a deploy. This script does the
+two parts bash can't:
+
+  convert           read plain JSON on stdin, write a Firestore REST document
+                    ({"fields": ...} typed-value JSON) on stdout for
+                    `curl -d @-`.
+  diff REPO LIVE    print what overwriting LIVE (a document fetched from the
+                    REST API, typed-value JSON) with REPO (plain JSON) will
+                    change. Informational only -- always exits 0; the deploy's
+                    confirmation prompt is the gate.
+
+Stdlib-only, like validate_config_models.py: the deploy machine has python3
+but no pip environment.
+"""
+
+import json
+import sys
+from typing import Any
+
+
+def to_typed(value: Any) -> dict[str, Any]:
+  """Returns the Firestore REST 'Value' for a plain JSON value."""
+  # bool first: bool is an int subclass, and True encoded as an integerValue
+  # would silently change the field's type in Firestore.
+  if isinstance(value, bool):
+    return {'booleanValue': value}
+  if value is None:
+    return {'nullValue': None}
+  if isinstance(value, int):
+    return {'integerValue': str(value)}  # the REST API encodes int64 as string
+  if isinstance(value, float):
+    return {'doubleValue': value}
+  if isinstance(value, str):
+    return {'stringValue': value}
+  if isinstance(value, list):
+    return {'arrayValue': {'values': [to_typed(v) for v in value]}}
+  if isinstance(value, dict):
+    return {'mapValue': {'fields': {k: to_typed(v) for k, v in value.items()}}}
+  raise TypeError(f'unsupported JSON type: {type(value).__name__}')
+
+
+def from_typed(value: dict[str, Any]) -> Any:
+  """Inverse of to_typed, for documents fetched from the REST API."""
+  if 'booleanValue' in value:
+    return value['booleanValue']
+  if 'nullValue' in value:
+    return None
+  if 'integerValue' in value:
+    return int(value['integerValue'])
+  if 'doubleValue' in value:
+    return value['doubleValue']
+  if 'stringValue' in value:
+    return value['stringValue']
+  if 'arrayValue' in value:
+    # An empty array serializes as {'arrayValue': {}} -- no 'values' key.
+    return [from_typed(v) for v in value['arrayValue'].get('values', [])]
+  if 'mapValue' in value:
+    return {k: from_typed(v)
+            for k, v in value['mapValue'].get('fields', {}).items()}
+  # Console edits can hold Firestore-only types (timestamp, bytes, geopoint,
+  # reference). The repo file can never contain them, so for diffing they
+  # render as a marker the diff will report as replaced/removed -- the seed
+  # overwrites them -- rather than crashing the preview.
+  return '<firestore ' + '/'.join(sorted(value)) + '>'
+
+
+def plain_to_document(data: dict[str, Any]) -> dict[str, Any]:
+  """REST document body for a plain dict."""
+  return {'fields': {k: to_typed(v) for k, v in data.items()}}
+
+
+def document_to_plain(doc: dict[str, Any]) -> dict[str, Any]:
+  """Plain dict from a REST document ({'name': ..., 'fields': {...}})."""
+  return {k: from_typed(v) for k, v in doc.get('fields', {}).items()}
+
+
+def diff_lines(repo: dict[str, Any], live: dict[str, Any]) -> list[str]:
+  """What overwriting `live` with `repo` changes, one line per difference.
+
+  One level of detail for dict sections (per model / per default), a single
+  line for anything else. Empty list = the seed changes nothing.
+  """
+  lines = []
+  # Membership is checked before values so an explicit null is still reported
+  # (dict.get would make a live-only null field look identical to absence).
+  for section in sorted(set(repo) | set(live)):
+    if section not in live:
+      lines.append(f'+ will add section {section!r}')
+      continue
+    if section not in repo:
+      lines.append(f'- will remove section {section!r} (exists only live)')
+      continue
+    repo_value, live_value = repo[section], live[section]
+    if repo_value == live_value:
+      continue
+    if not (isinstance(repo_value, dict) and isinstance(live_value, dict)):
+      lines.append(f'~ will replace {section!r}')
+      continue
+    for key in sorted(set(repo_value) | set(live_value)):
+      if key not in live_value:
+        lines.append(f'+ will add {section}.{key}')
+        continue
+      if key not in repo_value:
+        lines.append(f'- will remove {section}.{key} (exists only live)')
+        continue
+      entry_repo, entry_live = repo_value[key], live_value[key]
+      if entry_repo == entry_live:
+        continue
+      if isinstance(entry_repo, dict) and isinstance(entry_live, dict):
+        changed = sorted(
+            field for field in set(entry_repo) | set(entry_live)
+            if (field in entry_repo) != (field in entry_live)
+            or entry_repo.get(field) != entry_live.get(field))
+        lines.append(f'~ will change {section}.{key} ({", ".join(changed)})')
+      else:
+        lines.append(f'~ will change {section}.{key}: '
+                     f'{entry_live!r} -> {entry_repo!r}')
+  return lines
+
+
+def main(argv: list[str]) -> int:
+  if len(argv) == 2 and argv[1] == 'convert':
+    json.dump(plain_to_document(json.load(sys.stdin)), sys.stdout)
+    return 0
+  if len(argv) == 4 and argv[1] == 'diff':
+    try:
+      with open(argv[2], encoding='utf-8') as f:
+        repo = json.load(f)
+      with open(argv[3], encoding='utf-8') as f:
+        live = document_to_plain(json.load(f))
+      lines = diff_lines(repo, live)
+    except Exception:  # the preview informs; it must never block a deploy
+      print('    could not compute the config/models diff; this deploy '
+            'seeds it from the repo.')
+      return 0
+    if not lines:
+      print('    live config/models matches the repo catalog; the seed '
+            'changes nothing.')
+      return 0
+    print('    the seed will overwrite these live differences (console edits '
+          'do not survive a deploy):')
+    for line in lines:
+      print(f'      {line}')
+    return 0
+  print(__doc__, file=sys.stderr)
+  return 2
+
+
+if __name__ == '__main__':
+  sys.exit(main(sys.argv))

--- a/test/test_seed_config_models.py
+++ b/test/test_seed_config_models.py
@@ -1,0 +1,185 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for scripts/seed_config_models.py (the config/models deploy seed)."""
+
+import json
+import os
+
+import pytest
+
+from scripts import seed_config_models
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_MODELS_JSON = os.path.join(_REPO, 'ui', 'definitions', 'models.json')
+
+
+def test_to_typed_scalars():
+  assert seed_config_models.to_typed('x') == {'stringValue': 'x'}
+  assert seed_config_models.to_typed(8) == {'integerValue': '8'}
+  assert seed_config_models.to_typed(1.5) == {'doubleValue': 1.5}
+  assert seed_config_models.to_typed(None) == {'nullValue': None}
+
+
+def test_to_typed_bool_is_not_an_integer():
+  assert seed_config_models.to_typed(True) == {'booleanValue': True}
+  assert seed_config_models.to_typed(False) == {'booleanValue': False}
+
+
+def test_to_typed_nested():
+  assert seed_config_models.to_typed({'a': [1, 'b']}) == {
+      'mapValue': {'fields': {'a': {'arrayValue': {'values': [
+          {'integerValue': '1'}, {'stringValue': 'b'}]}}}}
+  }
+
+
+def test_to_typed_rejects_non_json():
+  with pytest.raises(TypeError):
+    seed_config_models.to_typed(object())
+
+
+def test_from_typed_tolerates_empty_array_and_map():
+  assert seed_config_models.from_typed({'arrayValue': {}}) == []
+  assert seed_config_models.from_typed({'mapValue': {}}) == {}
+
+
+def test_from_typed_renders_firestore_only_types_as_markers():
+  # A console edit can hold types the repo file never can (timestamp, bytes).
+  # They must not crash the preview; the diff reports them as overwritten.
+  assert seed_config_models.from_typed(
+      {'timestampValue': '2026-07-01T00:00:00Z'}
+  ) == '<firestore timestampValue>'
+
+
+def test_round_trip_preserves_the_real_catalog():
+  with open(_MODELS_JSON, encoding='utf-8') as f:
+    catalog = json.load(f)
+  document = seed_config_models.plain_to_document(catalog)
+  assert seed_config_models.document_to_plain(document) == catalog
+
+
+def test_dotted_model_ids_stay_plain_map_keys():
+  document = seed_config_models.plain_to_document(
+      {'models': {'gemini-3.5-flash': {'family': 'gemini'}}})
+  fields = document['fields']['models']['mapValue']['fields']
+  assert 'gemini-3.5-flash' in fields
+
+
+def test_diff_identical_is_empty():
+  catalog = {'models': {'m': {'family': 'veo'}}, 'defaults': {'veo': 'm'}}
+  assert seed_config_models.diff_lines(catalog, catalog) == []
+
+
+def test_diff_names_added_removed_and_changed_models():
+  repo = {'models': {'kept': {'family': 'veo', 'locations': ['global']},
+                     'new': {'family': 'veo'}}}
+  live = {'models': {'kept': {'family': 'veo', 'locations': ['us-central1']},
+                     'hotfix': {'family': 'veo'}}}
+  lines = seed_config_models.diff_lines(repo, live)
+  assert any(line.startswith('+ will add models.new') for line in lines)
+  assert any(line.startswith('- will remove models.hotfix') for line in lines)
+  assert any('will change models.kept (locations)' in line for line in lines)
+
+
+def test_diff_scalar_default_change_shows_both_values():
+  lines = seed_config_models.diff_lines(
+      {'defaults': {'veo': 'a'}}, {'defaults': {'veo': 'b'}})
+  assert lines == ["~ will change defaults.veo: 'b' -> 'a'"]
+
+
+def test_diff_reports_a_live_only_null_field():
+  lines = seed_config_models.diff_lines(
+      {'models': {}}, {'models': {}, 'note': None})
+  assert lines == ["- will remove section 'note' (exists only live)"]
+
+
+def test_diff_names_a_null_only_subfield_change():
+  lines = seed_config_models.diff_lines(
+      {'models': {'m': {'family': 'veo'}}},
+      {'models': {'m': {'family': 'veo', 'note': None}}})
+  assert lines == ['~ will change models.m (note)']
+
+
+def test_diff_labels_one_sided_sections_as_add_or_remove():
+  assert seed_config_models.diff_lines({'defaults': {}}, {}) == [
+      "+ will add section 'defaults'"]
+  assert seed_config_models.diff_lines({}, {'ops_flags': ['x']}) == [
+      "- will remove section 'ops_flags' (exists only live)"]
+
+
+def test_cli_convert_round_trips_stdin(capsys, monkeypatch):
+  monkeypatch.setattr('sys.stdin', __import__('io').StringIO('{"a": true}'))
+  assert seed_config_models.main(['prog', 'convert']) == 0
+  out = json.loads(capsys.readouterr().out)
+  assert out == {'fields': {'a': {'booleanValue': True}}}
+
+
+def test_cli_diff_unreadable_live_doc_degrades(tmp_path, capsys):
+  repo = tmp_path / 'repo.json'
+  repo.write_text('{"models": {}}')
+  missing = tmp_path / 'nope.json'
+  assert seed_config_models.main(['prog', 'diff', str(repo),
+                                  str(missing)]) == 0
+  assert 'seeds it from the repo' in capsys.readouterr().out
+
+
+def test_cli_diff_malformed_live_doc_degrades(tmp_path, capsys):
+  repo = tmp_path / 'repo.json'
+  repo.write_text('{"models": {}}')
+  for content in ('not json', '[1, 2]'):  # invalid JSON; JSON but not a doc
+    garbage = tmp_path / 'live.json'
+    garbage.write_text(content)
+    assert seed_config_models.main(['prog', 'diff', str(repo),
+                                    str(garbage)]) == 0
+    assert 'seeds it from the repo' in capsys.readouterr().out
+
+
+def test_cli_diff_live_doc_with_firestore_only_types_never_blocks(
+    tmp_path, capsys):
+  repo = tmp_path / 'repo.json'
+  repo.write_text(json.dumps({'models': {}}))
+  live = tmp_path / 'live.json'
+  live.write_text(json.dumps({'fields': {
+      'models': {'mapValue': {'fields': {}}},
+      'lastEdited': {'timestampValue': '2026-07-01T00:00:00Z'},
+  }}))
+  assert seed_config_models.main(['prog', 'diff', str(repo), str(live)]) == 0
+  out = capsys.readouterr().out
+  assert "- will remove section 'lastEdited'" in out
+
+
+def test_cli_diff_reports_live_only_edit(tmp_path, capsys):
+  repo = tmp_path / 'repo.json'
+  repo.write_text(json.dumps({'models': {}}))
+  live = tmp_path / 'live.json'
+  live.write_text(json.dumps(seed_config_models.plain_to_document(
+      {'models': {'operator-added': {'family': 'veo'}}})))
+  assert seed_config_models.main(['prog', 'diff', str(repo), str(live)]) == 0
+  out = capsys.readouterr().out
+  assert 'do not survive a deploy' in out
+  assert '- will remove models.operator-added' in out
+
+
+def test_cli_diff_no_changes_message(tmp_path, capsys):
+  catalog = {'models': {'m': {'family': 'veo'}}}
+  repo = tmp_path / 'repo.json'
+  repo.write_text(json.dumps(catalog))
+  live = tmp_path / 'live.json'
+  live.write_text(json.dumps(seed_config_models.plain_to_document(catalog)))
+  assert seed_config_models.main(['prog', 'diff', str(repo), str(live)]) == 0
+  assert 'changes nothing' in capsys.readouterr().out
+
+
+def test_cli_usage_error():
+  assert seed_config_models.main(['prog']) == 2

--- a/test/test_seed_config_models.py
+++ b/test/test_seed_config_models.py
@@ -104,6 +104,22 @@ def test_diff_reports_a_live_only_null_field():
   assert lines == ["- will remove section 'note' (exists only live)"]
 
 
+def test_diff_reports_a_boolean_vs_integer_type_change():
+  # Python's == calls True == 1 equal; Firestore types are distinct and the
+  # seed rewrites them, so the preview must not claim "changes nothing".
+  lines = seed_config_models.diff_lines(
+      {'models': {'m': {'supports_audio': True}}},
+      {'models': {'m': {'supports_audio': 1}}})
+  assert lines == ['~ will change models.m (supports_audio)']
+
+
+def test_diff_reports_an_integer_vs_double_type_change():
+  lines = seed_config_models.diff_lines(
+      {'models': {'m': {'duration': 4}}},
+      {'models': {'m': {'duration': 4.0}}})
+  assert lines == ['~ will change models.m (duration)']
+
+
 def test_diff_names_a_null_only_subfield_change():
   lines = seed_config_models.diff_lines(
       {'models': {'m': {'family': 'veo'}}},


### PR DESCRIPTION
## Summary
Every deploy writes the model catalog (`ui/definitions/models.json`) to the `config/models` Firestore document, and previews what that write will change before the deployment-confirmation prompt. Nothing reads the document yet; runtime behavior is unchanged.

## Behavior
- During pre-flight, `deploy.sh` fetches the live `config/models` doc and prints a per-entry diff — models added/removed/changed, defaults changes, and anything that exists only live — so a console edit is replaced visibly, never silently. Any preview failure (fresh project, API not enabled, unseeded doc, a Firestore-only value type in the doc) degrades to "seeding from the repo" and never blocks the deploy.
- After the existing `config/global` seed, the deploy converts the repo catalog to the Firestore REST typed-value format and PATCHes `config/models`, failing loudly on a non-200 like the other seeds. The PATCH replaces the whole document by design: the repo is the source of truth and live edits are temporary.
- `scripts/seed_config_models.py` is stdlib-only (the deploy machine has no pip environment). Booleans are checked before integers so `true` cannot be written as an `integerValue`; Firestore-only types found in the live doc (timestamp, bytes) render as markers the diff reports as overwritten; a live-only field with a `null` value is still reported as removed.
- The dev-database seed instructions gain the same document.

## Tests
- Conversion in both directions: scalar types, bool-vs-int ordering, int64-as-string, nested maps/lists, dotted model-id map keys, empty array/map encodings, Firestore-only-type markers; a round-trip assertion over the real `models.json`.
- Diff output: identical docs, unreadable/malformed live docs (degrade, exit 0), live docs with Firestore-only types (exit 0, reported as removed), live-only entries including explicit nulls, one-sided sections, and per-field change lines.

## Risks / Notes
- The pre-flight preview runs two network calls (token + GET) earlier in the deploy than any existing Firestore access; both degrade to "nothing to diff" on failure.
