### PR TITLE
Keep output selection in sync with project

### DIFF
--- a/ui/src/app/output-video/output-video.spec.ts
+++ b/ui/src/app/output-video/output-video.spec.ts
@@ -16,35 +16,54 @@
 
 import {provideHttpClient} from '@angular/common/http';
 import {provideHttpClientTesting} from '@angular/common/http/testing';
+import {signal, WritableSignal} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {vi} from 'vitest';
-import {ConfigService} from '../services/config/config';
+import {ConfigService, RenderRun} from '../services/config/config';
 import {MediaService} from '../services/media/media';
 import {OutputVideo} from './output-video';
 
 describe('OutputVideo', () => {
   let component: OutputVideo;
   let fixture: ComponentFixture<OutputVideo>;
+  let projectConfig: WritableSignal<TestProject>;
+  let updateProjectConfig: ReturnType<typeof vi.fn>;
+
+  interface TestProject {
+    id: string;
+    name: string;
+    aspectRatio: string;
+    resolution: string;
+    renderRuns: RenderRun[];
+    storyboard: never[];
+  }
+
+  const run = (minute: number, isArchived = false): RenderRun => ({
+    createdAt: new Date(2026, 0, 1, 12, minute),
+    wasPlayed: true,
+    isArchived,
+    outputVideo: {path: `output/video-${minute}.mp4`, url: ''},
+  });
+
+  const project = (id: string, renderRuns: RenderRun[]): TestProject => ({
+    id,
+    name: 'Test Project',
+    aspectRatio: '16:9',
+    resolution: '1080p',
+    renderRuns,
+    storyboard: [],
+  });
 
   beforeEach(async () => {
+    projectConfig = signal(project('project-1', [run(0)]));
+    updateProjectConfig = vi.fn((updates: Partial<TestProject>) => {
+      projectConfig.update(current => ({...current, ...updates}));
+    });
     const configServiceMock = {
       projectConfig: {
-        value: () => ({
-          title: 'Test Project',
-          outputVideoUrl: 'http://test.com/video.mp4',
-          aspectRatio: '16:9',
-          renderRuns: [
-            {
-              createdAt: 1,
-              wasPlayed: true,
-              isArchived: false,
-              outputVideo: {path: 'output/video.mp4'},
-            },
-          ],
-          storyboard: [],
-        }),
+        value: projectConfig,
       },
-      updateProjectConfig: vi.fn(),
+      updateProjectConfig,
       isGeneratedScene: () => false,
     };
 
@@ -88,5 +107,104 @@ describe('OutputVideo', () => {
     // playsinline must stay.
     expect(video!.hasAttribute('controls')).toBe(true);
     expect(video!.hasAttribute('playsinline')).toBe(true);
+  });
+
+  it('selects the first active render when project data arrives later', () => {
+    projectConfig.set(project('project-2', []));
+    const directRouteFixture = TestBed.createComponent(OutputVideo);
+    const directRouteComponent = directRouteFixture.componentInstance;
+    directRouteFixture.detectChanges();
+    expect(directRouteComponent.selectedRenderRun()).toBeUndefined();
+
+    const loaded = run(1);
+    projectConfig.set(project('project-2', [loaded]));
+    directRouteFixture.detectChanges();
+
+    expect(directRouteComponent.selectedRenderRun()).toBe(loaded);
+  });
+
+  it('preserves an explicit selection across same-project updates', () => {
+    const first = run(1);
+    const selected = run(2);
+    projectConfig.set(project('project-2', [first, selected]));
+    fixture.detectChanges();
+    component.selectedRenderRun.set(selected);
+
+    const refreshedFirst = {...first};
+    const refreshedSelected = {...selected};
+    projectConfig.set(
+      project('project-2', [refreshedFirst, refreshedSelected, run(3)]),
+    );
+    fixture.detectChanges();
+
+    expect(component.selectedRenderRun()).toBe(refreshedSelected);
+  });
+
+  it('falls back to the first active run when the selected run is archived', () => {
+    const selected = run(1);
+    const fallback = run(2);
+    projectConfig.set(project('project-2', [selected, fallback]));
+    fixture.detectChanges();
+    component.selectedRenderRun.set(selected);
+
+    component.setRenderRunArchiveStatus(selected, true);
+    fixture.detectChanges();
+
+    expect(component.selectedRenderRun()?.createdAt).toEqual(
+      fallback.createdAt,
+    );
+  });
+
+  it('selects nothing when every render is archived', () => {
+    const selected = run(1);
+    projectConfig.set(project('project-2', [selected]));
+    fixture.detectChanges();
+    component.selectedRenderRun.set(selected);
+
+    component.setRenderRunArchiveStatus(selected, true);
+    fixture.detectChanges();
+
+    expect(component.selectedRenderRun()).toBeUndefined();
+  });
+
+  it('falls back when the selected run is removed', () => {
+    const fallback = run(1);
+    const selected = run(2);
+    projectConfig.set(project('project-2', [fallback, selected]));
+    fixture.detectChanges();
+    component.selectedRenderRun.set(selected);
+
+    projectConfig.set(project('project-2', [fallback]));
+    fixture.detectChanges();
+
+    expect(component.selectedRenderRun()).toBe(fallback);
+  });
+
+  it('falls back when a project refresh archives the selected run', () => {
+    const selected = run(1);
+    const fallback = run(2);
+    projectConfig.set(project('project-2', [selected, fallback]));
+    fixture.detectChanges();
+    component.selectedRenderRun.set(selected);
+
+    projectConfig.set(
+      project('project-2', [{...selected, isArchived: true}, fallback]),
+    );
+    fixture.detectChanges();
+
+    expect(component.selectedRenderRun()).toBe(fallback);
+  });
+
+  it('does not carry a selection into another project', () => {
+    const firstProjectRun = run(1);
+    projectConfig.set(project('project-2', [firstProjectRun]));
+    fixture.detectChanges();
+    component.selectedRenderRun.set(firstProjectRun);
+
+    const secondProjectRun = {...firstProjectRun};
+    projectConfig.set(project('project-3', [secondProjectRun]));
+    fixture.detectChanges();
+
+    expect(component.selectedRenderRun()).toBe(secondProjectRun);
   });
 });

--- a/ui/src/app/output-video/output-video.ts
+++ b/ui/src/app/output-video/output-video.ts
@@ -22,6 +22,7 @@ import {
   computed,
   effect,
   inject,
+  linkedSignal,
   signal,
 } from '@angular/core';
 import {MatBadgeModule} from '@angular/material/badge';
@@ -69,9 +70,30 @@ export class OutputVideo {
   private httpClient = inject(HttpClient);
   private mediaService = inject(MediaService);
 
-  selectedRenderRun = signal<RenderRun | undefined>(
-    this.configService.projectConfig.value().renderRuns?.[0],
-  );
+  selectedRenderRun = linkedSignal<
+    {projectId: string; renderRuns: RenderRun[]},
+    RenderRun | undefined
+  >({
+    source: () => {
+      const config = this.configService.projectConfig.value();
+      return {
+        projectId: config.id,
+        renderRuns: config.renderRuns ?? [],
+      };
+    },
+    computation: (source, previous) => {
+      if (previous?.source.projectId === source.projectId && previous.value) {
+        const selectedTime = previous.value.createdAt.getTime();
+        const selected = source.renderRuns.find(
+          run => run.createdAt.getTime() === selectedTime,
+        );
+        if (selected && !selected.isArchived) {
+          return selected;
+        }
+      }
+      return source.renderRuns.find(run => !run.isArchived);
+    },
+  });
   videoFile = computed(() => this.selectedRenderRun()?.outputVideo);
   previewAspectRatio = computed(() => {
     const ratio = this.configService.projectConfig.value().aspectRatio;


### PR DESCRIPTION
## Summary

Keep output-video selection synchronized with asynchronously loaded project render runs.

## Behavior

- A direct route load selects the first available non-archived render after project data arrives.
- A valid explicit user selection survives updates to the same project.
- Removing or archiving the selected run chooses the first active fallback.
- Switching projects never carries a selection from the previous project.
- Existing playback and download behavior is unchanged.

## Tests

- UI compile and lint.
- Spec type-check.
- 23 test files / 207 tests, including delayed load, retained selection, removal and archive fallback, all-archived state, and project switching.
- Diff whitespace check.

## Risks / Notes

The change is confined to output selection state. It does not alter render persistence, backend APIs, playback, or downloads.
