### PR TITLE
Sign status viewer media URLs

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -56,5 +56,8 @@ jobs:
     - name: Unit tests
       run: npm test -- --watch=false
 
+    - name: Status viewer tests
+      run: node remix-engine-status-viewer/callBackend.spec.js
+
     - name: Production build
       run: npx ng build --configuration production

--- a/ui/remix-engine-status-viewer/callBackend.js
+++ b/ui/remix-engine-status-viewer/callBackend.js
@@ -58,16 +58,32 @@ function resolveStatusBaseUrl() {
  * configured. The front-door config carries a sentinel ('none'/empty) which we
  * must NOT send — the same-origin control plane has no api key.
  *
+ * @param {*} apiKeyValue Configured API key value.
  * @return {string} `&api_key=<encoded>` for a legacy key, otherwise ''.
  */
-function statusApiKeyParam() {
-  const apiKey = config.backendApi && config.backendApi.apiKey
-    ? String(config.backendApi.apiKey).trim()
-    : '';
+function statusApiKeyParam(apiKeyValue) {
+  const apiKey = apiKeyValue ? String(apiKeyValue).trim() : '';
   if (!apiKey || apiKey.toLowerCase() === 'none') {
     return '';
   }
   return `&api_key=${encodeURIComponent(apiKey)}`;
+}
+
+/**
+ * Builds a signed-media status request URL.
+ *
+ * @param {string} baseUrl Resolved status endpoint base URL.
+ * @param {string} gcsBucket Configured private GCS bucket.
+ * @param {string} executionId Workflow execution ID.
+ * @param {*} apiKeyValue Optional legacy API key.
+ * @return {string} Encoded status request URL.
+ */
+function buildStatusUrl(baseUrl, gcsBucket, executionId, apiKeyValue) {
+  return `${baseUrl}/getStatus?gcsBucket=${encodeURIComponent(
+    gcsBucket,
+  )}&executionId=${encodeURIComponent(
+    executionId,
+  )}&signUrls=true${statusApiKeyParam(apiKeyValue)}`;
 }
 
 /**
@@ -99,9 +115,12 @@ async function callCloudRunEndpoint() {
     alert('Could not get Execution ID or GCS Bucket.');
     return;
   }
-  const cloudRunUrl = `${resolveStatusBaseUrl()}/getStatus?gcsBucket=${encodeURIComponent(
+  const cloudRunUrl = buildStatusUrl(
+    resolveStatusBaseUrl(),
     config.gcsBucket,
-  )}&executionId=${encodeURIComponent(executionId)}${statusApiKeyParam()}`;
+    executionId,
+    config.backendApi && config.backendApi.apiKey,
+  );
   getStatusButton.disabled = true;
   // Served same-origin behind IAP: the default same-origin credentials carry the
   // IAP session cookie automatically, so no auth header is needed here.
@@ -144,5 +163,5 @@ async function callCloudRunEndpoint() {
 // status viewer loads this as a plain <script>, where `module` is undefined, so
 // this guard is a no-op there.
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = {classifyStatusResponse};
+  module.exports = {buildStatusUrl, classifyStatusResponse};
 }

--- a/ui/remix-engine-status-viewer/callBackend.spec.js
+++ b/ui/remix-engine-status-viewer/callBackend.spec.js
@@ -17,10 +17,29 @@
 /**
  * Node unit test for the status-viewer response classifier (V4). Run with:
  *   node ui/remix-engine-status-viewer/callBackend.spec.js
- * It exercises only the pure classifier (no DOM), so it needs no test harness.
+ * It exercises pure request construction and response classification (no DOM),
+ * so it needs no test harness.
  */
 const assert = require('assert');
-const {classifyStatusResponse} = require('./callBackend');
+const {buildStatusUrl, classifyStatusResponse} = require('./callBackend');
+
+assert.strictEqual(
+  buildStatusUrl('/api', 'private bucket', 'exec/one', ''),
+  '/api/getStatus?gcsBucket=private%20bucket&executionId=exec%2Fone&signUrls=true',
+);
+assert.strictEqual(
+  buildStatusUrl(
+    'https://backend.example.com/api',
+    'private-bucket',
+    'exec two',
+    'legacy key+',
+  ),
+  'https://backend.example.com/api/getStatus?gcsBucket=private-bucket&executionId=exec%20two&signUrls=true&api_key=legacy%20key%2B',
+);
+assert.strictEqual(
+  buildStatusUrl('/api', 'private-bucket', 'exec', 'none'),
+  '/api/getStatus?gcsBucket=private-bucket&executionId=exec&signUrls=true',
+);
 
 // An IAP login redirect: fetch followed the 302 to an HTML sign-in page, so
 // response.redirected is true even though the status is 200.
@@ -49,4 +68,4 @@ assert.strictEqual(
   'bad-json',
 );
 
-console.log('callBackend classifier tests passed ✓');
+console.log('callBackend tests passed ✓');


### PR DESCRIPTION
## Summary

Request signed media URLs from the standalone workflow status viewer.

## Behavior

Status requests always set `signUrls=true`, allowing private-bucket text, image, and video previews to load without a Cloud Storage browser session. Existing execution ID, bucket, optional legacy API-key, same-origin base URL, and encoding behavior remain unchanged.

## Tests

- Dependency-free viewer test covers request construction, encoding, legacy API-key handling, and response classification.
- The viewer test now runs in the UI GitHub Actions workflow.
- UI compile and lint.
- Spec type-check.
- 23 test files / 200 tests.
- Diff whitespace check.

## Risks / Notes

Large status responses sign every unique file, increasing IAM signing work and response latency. Pagination/capping and signer reuse remain follow-ups. The backend default is unchanged.
