### PR TITLE
Handle runtime service account propagation race

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -484,18 +484,7 @@ echo "✓ Service account ${BUILD_SA} ready."
 # demand (idempotent: skip if it already exists), then wait for propagation the
 # same way before granting it roles below.
 phase "Ensuring runtime service account ${RUNTIME_SA} exists..."
-gcloud iam service-accounts describe "${RUNTIME_SA}" --project=$PROJECT &> /dev/null \
-  || gcloud iam service-accounts create sm-runtime --project=$PROJECT \
-       --display-name="Scene Machine runtime (app + worker)"
-RUNTIME_SA_WAIT_ATTEMPTS=0
-until gcloud iam service-accounts describe "${RUNTIME_SA}" --project=$PROJECT &> /dev/null; do
-  RUNTIME_SA_WAIT_ATTEMPTS=$((RUNTIME_SA_WAIT_ATTEMPTS + 1))
-  if [ $RUNTIME_SA_WAIT_ATTEMPTS -ge $SA_WAIT_MAX ]; then
-    echo "ERROR: runtime SA ${RUNTIME_SA} did not appear after 10 minutes." >&2
-    exit 1
-  fi
-  sleep 5
-done
+ensure_runtime_service_account "$RUNTIME_SA" "$PROJECT" "$SA_WAIT_MAX"
 echo "✓ Service account ${RUNTIME_SA} ready."
 
 # --- IAM: runtime SA roles + service agents ----------------------------------

--- a/deploy/libs.sh
+++ b/deploy/libs.sh
@@ -81,6 +81,48 @@ _retry_iam_write() {
   done
 }
 
+# Ensure the dedicated Scene Machine runtime service account exists and is
+# visible before the deploy grants it roles. A second deploy can observe the
+# account as missing while IAM is still propagating it, then lose the create
+# race with ALREADY_EXISTS. Treat only that specific create result as benign;
+# real create failures (permission, policy, invalid arguments) still fail
+# immediately. Call as: ensure_runtime_service_account <email> <project> <max>
+ensure_runtime_service_account() {
+  local runtime_sa="$1" project="$2" max_attempts="$3"
+  local create_output=""
+
+  if gcloud iam service-accounts describe "$runtime_sa" \
+      --project="$project" &>/dev/null; then
+    return 0
+  fi
+
+  if create_output=$(gcloud iam service-accounts create sm-runtime \
+      --project="$project" \
+      --display-name="Scene Machine runtime (app + worker)" 2>&1); then
+    [ -z "$create_output" ] || printf '%s\n' "$create_output"
+  elif grep -q 'ALREADY_EXISTS:' <<<"$create_output" \
+      || grep -Fq \
+        "Service account sm-runtime already exists within project projects/${project}" \
+        <<<"$create_output"; then
+    echo "  Runtime service account was created by another deploy; waiting for visibility."
+  else
+    echo "ERROR: failed to create runtime SA ${runtime_sa}:" >&2
+    printf '%s\n' "$create_output" >&2
+    return 1
+  fi
+
+  local attempts=0
+  until gcloud iam service-accounts describe "$runtime_sa" \
+      --project="$project" &>/dev/null; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge "$max_attempts" ]; then
+      echo "ERROR: runtime SA ${runtime_sa} did not appear after 10 minutes." >&2
+      return 1
+    fi
+    sleep 5
+  done
+}
+
 # `gcloud projects add-iam-policy-binding` with the shared retry, plus a cheap
 # get-iam-policy pre-check so a re-run on an already-provisioned project does no
 # write (no etag race). Call as: add_iam_binding "$PROJECT" --member=... --role=...

--- a/test/test_deploy_service_accounts.py
+++ b/test/test_deploy_service_accounts.py
@@ -1,0 +1,125 @@
+"""Behavioral tests for service-account provisioning in the deploy helpers."""
+
+import os
+import pathlib
+import subprocess
+
+import pytest
+
+
+_REPO = pathlib.Path(__file__).resolve().parent.parent
+_DEPLOY_LIBS = _REPO / 'deploy' / 'libs.sh'
+_DEPLOY_SH = _REPO / 'deploy.sh'
+
+
+def _run_runtime_sa_helper(tmp_path: pathlib.Path, create_error: str):
+  """Run the helper with a fake gcloud and a persistent invocation trace."""
+  trace = tmp_path / 'gcloud-trace.txt'
+  env = os.environ.copy()
+  env['GCLOUD_TRACE'] = str(trace)
+  env['CREATE_ERROR'] = create_error
+  script = f"""
+set -euo pipefail
+source "{_DEPLOY_LIBS}"
+
+sleep() {{
+  printf 'sleep:%s\\n' "$1" >>"$GCLOUD_TRACE"
+}}
+
+gcloud() {{
+  if [[ "$*" == "iam service-accounts describe"* ]]; then
+    printf 'describe\\n' >>"$GCLOUD_TRACE"
+    local describe_count
+    describe_count=$(grep -c '^describe$' "$GCLOUD_TRACE")
+    if [ "$describe_count" -ge 3 ]; then
+      return 0
+    fi
+    printf 'NOT_FOUND: service account is not visible yet\\n' >&2
+    return 1
+  fi
+
+  if [[ "$*" == "iam service-accounts create"* ]]; then
+    printf 'create\\n' >>"$GCLOUD_TRACE"
+    if [ -z "$CREATE_ERROR" ]; then
+      return 0
+    fi
+    printf '%s\\n' "$CREATE_ERROR" >&2
+    return 1
+  fi
+
+  printf 'unexpected gcloud call: %s\\n' "$*" >&2
+  return 2
+}}
+
+ensure_runtime_service_account \
+  'sm-runtime@test-project.iam.gserviceaccount.com' \
+  'test-project' \
+  3
+"""
+  result = subprocess.run(
+      ['bash', '-c', script],
+      check=False,
+      capture_output=True,
+      env=env,
+      text=True,
+  )
+  calls = (
+      trace.read_text(encoding='utf-8').splitlines() if trace.exists() else []
+  )
+  return result, calls
+
+
+@pytest.mark.parametrize(
+    'create_error',
+    [
+        'ALREADY_EXISTS: service account already exists',
+        (
+            'Service account sm-runtime already exists within project '
+            'projects/test-project.'
+        ),
+    ],
+)
+def test_runtime_sa_concurrent_create_waits_until_visible(
+    tmp_path, create_error
+):
+  result, calls = _run_runtime_sa_helper(tmp_path, create_error)
+
+  assert result.returncode == 0, result.stderr
+  assert calls == ['describe', 'create', 'describe', 'sleep:5', 'describe']
+  assert 'created by another deploy' in result.stdout
+
+
+def test_runtime_sa_create_waits_until_visible(tmp_path):
+  result, calls = _run_runtime_sa_helper(tmp_path, '')
+
+  assert result.returncode == 0, result.stderr
+  assert calls == ['describe', 'create', 'describe', 'sleep:5', 'describe']
+
+
+def test_runtime_sa_nonretryable_create_error_fails_immediately(tmp_path):
+  result, calls = _run_runtime_sa_helper(tmp_path, 'PERMISSION_DENIED')
+
+  assert result.returncode == 1
+  assert calls == ['describe', 'create']
+  assert 'PERMISSION_DENIED' in result.stderr
+
+
+def test_runtime_sa_does_not_hide_mixed_permission_error(tmp_path):
+  result, calls = _run_runtime_sa_helper(
+      tmp_path,
+      'PERMISSION_DENIED: resource already exists but access is denied',
+  )
+
+  assert result.returncode == 1
+  assert calls == ['describe', 'create']
+  assert 'PERMISSION_DENIED' in result.stderr
+
+
+def test_deploy_uses_the_tested_runtime_sa_helper():
+  text = _DEPLOY_SH.read_text(encoding='utf-8')
+
+  assert (
+      'ensure_runtime_service_account "$RUNTIME_SA" "$PROJECT" "$SA_WAIT_MAX"'
+      in text
+  )
+  assert '|| gcloud iam service-accounts create sm-runtime' not in text


### PR DESCRIPTION
## Summary

- replace the inline `describe || create` runtime-service-account sequence with a tested provisioning helper
- treat only the known concurrent-create conflict as benign, then wait for IAM visibility
- keep permission, policy, and other create failures fail-fast
- add executable fake-`gcloud` coverage under production's `set -euo pipefail`

## Failure mode

A recent or concurrent deployment can create `sm-runtime` while IAM reads still return `NOT_FOUND`. The old `describe || create` sequence then receives an already-exists conflict from `create`; because the script uses `set -e`, it exits before reaching the existing visibility wait.

## Validation

- Python: 232 passed, 7 subtests passed
- UI: lint and spec typecheck passed; 23 test files / 200 tests passed
- deploy scripts: Bash syntax and error-level ShellCheck passed
- formatting and `git diff --check` passed
- fresh-project live deploy completed successfully in 391 seconds: runtime account created, Cloud Build succeeded, app and worker revisions became Ready, all three queues were Running, and Cloud Run error-log query was empty
- hybrid live race probe injected an initial lookup miss, consumed the installed `gcloud` CLI's real duplicate-create conflict response, and then confirmed account visibility successfully

## Deployment note

The fresh no-organization project still needs its documented one-time custom OAuth client before browser sign-in; this does not affect the completed automated deploy or service readiness checks.
