### PR TITLE
Retry runtime service account project IAM propagation

### DIFF
--- a/deploy/libs.sh
+++ b/deploy/libs.sh
@@ -67,16 +67,30 @@ _retry_iam_write() {
       local policy_error_preamble
       local conflict_error
       local propagating_project
+      local propagation_residual
+      local line
       missing_sa_error="ERROR: (gcloud.projects.add-iam-policy-binding) INVALID_ARGUMENT: Service account ${propagating_runtime_sa} does not exist."
       policy_error_preamble='ERROR: Policy modification failed. For a binding with condition, run "gcloud alpha iam policies lint-condition" to identify issues in condition.'
       propagating_project="${propagating_runtime_sa#sm-runtime@}"
       propagating_project="${propagating_project%.iam.gserviceaccount.com}"
-      conflict_error="${err//${propagating_runtime_sa}/<runtime-sa>}"
-      conflict_error="${conflict_error//${propagating_project}/<project>}"
-      if [ "$err" = "$missing_sa_error" ] \
-          || [ "$err" = "${policy_error_preamble}"$'\n'"${missing_sa_error}" ]; then
-        retry_kind="runtime SA propagation"
-        propagation_seen=1
+      conflict_error="${err//"$propagating_runtime_sa"/<runtime-sa>}"
+      conflict_error="${conflict_error//"$propagating_project"/<project>}"
+      if grep -Fqx "$missing_sa_error" <<<"$err"; then
+        propagation_residual=""
+        while IFS= read -r line; do
+          if [ "$line" != "$missing_sa_error" ] \
+              && [ "$line" != "$policy_error_preamble" ]; then
+            propagation_residual="${propagation_residual}${line}"$'\n'
+          fi
+        done <<<"$err"
+        if ! grep -qiE \
+            'permission_denied|forbidden|unauthorized|invalid_argument|not_found|not found|does not exist|resource_exhausted|quota|concurrent|aborted|etag|stale' \
+            <<<"$propagation_residual" \
+            && ! grep -qE '^[[:space:]]*(ERROR|FATAL):' \
+              <<<"$propagation_residual"; then
+          retry_kind="runtime SA propagation"
+          propagation_seen=1
+        fi
       elif grep -qiE \
           'permission_denied|forbidden|unauthorized|invalid_argument|not_found|not found|does not exist' \
           <<<"$err"; then

--- a/deploy/libs.sh
+++ b/deploy/libs.sh
@@ -66,19 +66,24 @@ _retry_iam_write() {
       local missing_sa_error
       local policy_error_preamble
       local conflict_error
+      local propagating_project
       missing_sa_error="ERROR: (gcloud.projects.add-iam-policy-binding) INVALID_ARGUMENT: Service account ${propagating_runtime_sa} does not exist."
       policy_error_preamble='ERROR: Policy modification failed. For a binding with condition, run "gcloud alpha iam policies lint-condition" to identify issues in condition.'
+      propagating_project="${propagating_runtime_sa#sm-runtime@}"
+      propagating_project="${propagating_project%.iam.gserviceaccount.com}"
       conflict_error="${err//${propagating_runtime_sa}/<runtime-sa>}"
+      conflict_error="${conflict_error//${propagating_project}/<project>}"
       if [ "$err" = "$missing_sa_error" ] \
           || [ "$err" = "${policy_error_preamble}"$'\n'"${missing_sa_error}" ]; then
         retry_kind="runtime SA propagation"
         propagation_seen=1
-      elif grep -Fqx "$missing_sa_error" <<<"$err"; then
-        # Unexpected extra output around the known status fails closed instead
-        # of falling through to the broader conflict classifier.
+      elif grep -qiE \
+          'permission_denied|forbidden|unauthorized|invalid_argument|not_found|not found|does not exist' \
+          <<<"$err"; then
+        # Permanent auth, argument, and missing-resource failures must not
+        # inherit the longer budget after an earlier propagation miss.
         retry_kind=""
-      elif ! grep -qiE 'permission_denied|forbidden|unauthorized' <<<"$err" \
-          && grep -qiE 'concurrent|aborted|etag|stale' <<<"$conflict_error"; then
+      elif grep -qiE 'concurrent|aborted|etag|stale' <<<"$conflict_error"; then
         retry_kind="conflict"
       fi
     elif grep -qiE 'concurrent|aborted|etag|stale' <<<"$err"; then

--- a/deploy/libs.sh
+++ b/deploy/libs.sh
@@ -27,25 +27,32 @@
 # Core retry+backoff loop shared by every add-*-iam-binding wrapper below.
 # Background GCP work (service-agent provisioning) modifies IAM
 # policies in parallel with our sequential read-modify-writes, occasionally
-# racing our etag; the gcloud error itself recommends "retry with exponential
-# backoff", which this does. It retries ONLY on concurrent-modification/etag
-# races and fails fast on real errors (permission-denied, bad argument).
+# racing our etag. A newly created runtime SA can also pass `describe` before
+# project IAM accepts it as a policy member. This retries those two exact
+# transient cases and fails fast on real errors (permission, bad argument).
 #   $1     - log label, e.g. " (for roles/run.invoker on app)"
-#   $2..   - the full gcloud argv to run (--quiet is appended)
+#   $2     - expected newly-created runtime SA email, or empty
+#   $3..   - the full gcloud argv to run (--quiet is appended)
 # Used by add_iam_binding (project), add_run_invoker_binding (run service), and
 # add_sa_iam_binding (service-account resource) so all three share one tested
 # retry path instead of three hand-rolled raw calls. (D1/D2)
 _retry_iam_write() {
   local label="$1"
-  shift
+  local propagating_runtime_sa="$2"
+  shift 2
 
   # Capture stderr in a variable (stdout discarded) rather than a temp file +
   # RETURN trap: a RETURN trap set in this helper would also fire on the
   # CALLER wrapper's return, dereferencing an out-of-scope var under `set -u`
   # and aborting the deploy.
-  local err
+  local err retry_kind
   local attempt=1
-  local max_attempts=6
+  local conflict_max_attempts=6
+  # Fourteen attempts with the capped backoff below wait roughly 9 minutes
+  # before the final write, matching the fresh-project SA visibility budget.
+  local propagation_max_attempts=14
+  local propagation_seen=0
+
   while true; do
     if err=$("$@" --quiet 2>&1 >/dev/null); then
       if [ $attempt -gt 1 ]; then
@@ -54,16 +61,42 @@ _retry_iam_write() {
       return 0
     fi
 
-    # Only retry on concurrent-modification / etag races. Permission, argument,
-    # and not-found errors won't fix themselves — surface them immediately.
-    if ! grep -qiE 'concurrent|aborted|etag|stale' <<<"$err"; then
+    retry_kind=""
+    if [ -n "$propagating_runtime_sa" ]; then
+      local missing_sa_error
+      local policy_error_preamble
+      local conflict_error
+      missing_sa_error="ERROR: (gcloud.projects.add-iam-policy-binding) INVALID_ARGUMENT: Service account ${propagating_runtime_sa} does not exist."
+      policy_error_preamble='ERROR: Policy modification failed. For a binding with condition, run "gcloud alpha iam policies lint-condition" to identify issues in condition.'
+      conflict_error="${err//${propagating_runtime_sa}/<runtime-sa>}"
+      if [ "$err" = "$missing_sa_error" ] \
+          || [ "$err" = "${policy_error_preamble}"$'\n'"${missing_sa_error}" ]; then
+        retry_kind="runtime SA propagation"
+        propagation_seen=1
+      elif grep -Fqx "$missing_sa_error" <<<"$err"; then
+        # Unexpected extra output around the known status fails closed instead
+        # of falling through to the broader conflict classifier.
+        retry_kind=""
+      elif ! grep -qiE 'permission_denied|forbidden|unauthorized' <<<"$err" \
+          && grep -qiE 'concurrent|aborted|etag|stale' <<<"$conflict_error"; then
+        retry_kind="conflict"
+      fi
+    elif grep -qiE 'concurrent|aborted|etag|stale' <<<"$err"; then
+      retry_kind="conflict"
+    fi
+
+    if [ -z "$retry_kind" ]; then
       echo "  ERROR: IAM binding${label} failed with a non-retryable error:" >&2
       echo "$err" >&2
       return 1
     fi
 
+    local max_attempts=$conflict_max_attempts
+    if [ $propagation_seen -eq 1 ]; then
+      max_attempts=$propagation_max_attempts
+    fi
     if [ $attempt -ge $max_attempts ]; then
-      echo "  ERROR: IAM binding${label} still conflicting after $max_attempts attempts:" >&2
+      echo "  ERROR: IAM binding${label} still failing with a retryable error after $max_attempts attempts:" >&2
       echo "$err" >&2
       return 1
     fi
@@ -74,8 +107,12 @@ _retry_iam_write() {
     local jitter=$((RANDOM % (base / 2 + 1) - base / 4))
     local backoff=$((base + jitter))
     [ $backoff -lt 1 ] && backoff=1
+    if [ $propagation_seen -eq 1 ] \
+        && [ $backoff -gt 60 ]; then
+      backoff=60
+    fi
 
-    echo "  IAM binding${label} hit a transient conflict — retrying in ${backoff}s (attempt $attempt/$max_attempts)..."
+    echo "  IAM binding${label} hit a transient ${retry_kind} error — retrying in ${backoff}s (attempt $attempt/$max_attempts)..."
     sleep $backoff
     attempt=$((attempt + 1))
   done
@@ -137,6 +174,11 @@ add_iam_binding() {
   done
   local label="${role:+ (for $role)}"
   local project="$1"  # first positional arg
+  local propagating_runtime_sa=""
+  local expected_runtime_sa="sm-runtime@${project}.iam.gserviceaccount.com"
+  if [ "$member" = "serviceAccount:${expected_runtime_sa}" ]; then
+    propagating_runtime_sa="$expected_runtime_sa"
+  fi
 
   if [ -n "$role" ] && [ -n "$member" ] && [ -n "$project" ]; then
     if gcloud projects get-iam-policy "$project" \
@@ -148,7 +190,8 @@ add_iam_binding() {
     fi
   fi
 
-  _retry_iam_write "$label" gcloud projects add-iam-policy-binding "$@"
+  _retry_iam_write "$label" "$propagating_runtime_sa" \
+    gcloud projects add-iam-policy-binding "$@"
 }
 
 # Service-scoped run.invoker on a Cloud Run SERVICE, with the same pre-check +
@@ -168,7 +211,7 @@ add_run_invoker_binding() {
     return 0
   fi
 
-  _retry_iam_write "$label" \
+  _retry_iam_write "$label" "" \
     gcloud run services add-iam-policy-binding "$service" \
     --region="$region" --project="$project" \
     --member="$member" --role="roles/run.invoker"
@@ -190,7 +233,7 @@ add_sa_iam_binding() {
     return 0
   fi
 
-  _retry_iam_write "$label" \
+  _retry_iam_write "$label" "" \
     gcloud iam service-accounts add-iam-policy-binding "$sa" \
     --member="$member" --role="$role" --project="$project"
 }

--- a/test/test_deploy_service_accounts.py
+++ b/test/test_deploy_service_accounts.py
@@ -10,6 +10,23 @@ import pytest
 _REPO = pathlib.Path(__file__).resolve().parent.parent
 _DEPLOY_LIBS = _REPO / 'deploy' / 'libs.sh'
 _DEPLOY_SH = _REPO / 'deploy.sh'
+_POLICY_ERROR_PREAMBLE = (
+    'ERROR: Policy modification failed. For a binding with condition, run'
+    ' "gcloud alpha iam policies lint-condition" to identify issues in'
+    ' condition.'
+)
+
+
+def _runtime_sa_iam_lag(project: str = 'test-project') -> str:
+  return (
+      f'{_POLICY_ERROR_PREAMBLE}\n'
+      'ERROR: (gcloud.projects.add-iam-policy-binding) INVALID_ARGUMENT: '
+      f'Service account sm-runtime@{project}.iam.gserviceaccount.com does not '
+      'exist.'
+  )
+
+
+_RUNTIME_SA_IAM_LAG = _runtime_sa_iam_lag()
 
 
 def _run_runtime_sa_helper(tmp_path: pathlib.Path, create_error: str):
@@ -62,6 +79,83 @@ ensure_runtime_service_account \
       capture_output=True,
       env=env,
       text=True,
+      timeout=5,
+  )
+  calls = (
+      trace.read_text(encoding='utf-8').splitlines() if trace.exists() else []
+  )
+  return result, calls
+
+
+def _run_project_iam_binding(
+    tmp_path: pathlib.Path,
+    *,
+    write_error: str,
+    failures_before_success: int,
+    member: str | None = None,
+    project: str = 'test-project',
+    write_errors: tuple[str, ...] = (),
+):
+  trace = tmp_path / 'project-iam-trace.txt'
+  if member is None:
+    member = f'serviceAccount:sm-runtime@{project}.iam.gserviceaccount.com'
+  env = os.environ.copy()
+  env.update({
+      'GCLOUD_TRACE': str(trace),
+      'WRITE_ERROR': write_error,
+      'FAILURES_BEFORE_SUCCESS': str(failures_before_success),
+      'IAM_MEMBER': member,
+      'IAM_PROJECT': project,
+  })
+  for index, error in enumerate(write_errors, start=1):
+    env[f'WRITE_ERROR_{index}'] = error
+  env['WRITE_ERROR_COUNT'] = str(len(write_errors))
+  script = f"""
+set -euo pipefail
+source "{_DEPLOY_LIBS}"
+
+sleep() {{
+  printf 'sleep:%s\n' "$1" >>"$GCLOUD_TRACE"
+}}
+
+gcloud() {{
+  if [[ "$*" == "projects get-iam-policy"* ]]; then
+    printf 'get-policy\n' >>"$GCLOUD_TRACE"
+    return 0
+  fi
+
+  if [[ "$*" == "projects add-iam-policy-binding"* ]]; then
+    printf 'add-binding\n' >>"$GCLOUD_TRACE"
+    local write_count
+    write_count=$(grep -c '^add-binding$' "$GCLOUD_TRACE")
+    if [ "$write_count" -le "$WRITE_ERROR_COUNT" ]; then
+      local error_var="WRITE_ERROR_${{write_count}}"
+      printf '%s\n' "${{!error_var}}" >&2
+      return 1
+    fi
+    if [ "$write_count" -le "$FAILURES_BEFORE_SUCCESS" ]; then
+      printf '%s\n' "$WRITE_ERROR" >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  printf 'unexpected gcloud call: %s\n' "$*" >&2
+  return 2
+}}
+
+add_iam_binding \
+  "$IAM_PROJECT" \
+  "--member=$IAM_MEMBER" \
+  '--role=roles/aiplatform.user'
+"""
+  result = subprocess.run(
+      ['bash', '-c', script],
+      check=False,
+      capture_output=True,
+      env=env,
+      text=True,
+      timeout=5,
   )
   calls = (
       trace.read_text(encoding='utf-8').splitlines() if trace.exists() else []
@@ -115,6 +209,188 @@ def test_runtime_sa_does_not_hide_mixed_permission_error(tmp_path):
   assert 'PERMISSION_DENIED' in result.stderr
 
 
+@pytest.mark.parametrize(
+    'write_error',
+    [_RUNTIME_SA_IAM_LAG, _RUNTIME_SA_IAM_LAG.splitlines()[-1]],
+)
+def test_runtime_sa_project_binding_retries_until_iam_accepts_member(
+    tmp_path, write_error
+):
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error=write_error,
+      failures_before_success=2,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert calls[0] == 'get-policy'
+  assert calls.count('add-binding') == 3
+  assert sum(call.startswith('sleep:') for call in calls) == 2
+  assert 'succeeded on attempt 3' in result.stdout
+
+
+def test_runtime_sa_propagation_budget_ignores_retry_words_in_project_id(
+    tmp_path,
+):
+  project = 'stale-project'
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error=_runtime_sa_iam_lag(project),
+      failures_before_success=6,
+      project=project,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert calls.count('add-binding') == 7
+  assert sum(call.startswith('sleep:') for call in calls) == 6
+  assert 'succeeded on attempt 7' in result.stdout
+
+
+def test_runtime_sa_propagation_budget_survives_later_etag_conflict(tmp_path):
+  errors = (_RUNTIME_SA_IAM_LAG,) * 5 + ('ABORTED: stale etag',)
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error='',
+      failures_before_success=0,
+      write_errors=errors,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert calls.count('add-binding') == 7
+  assert sum(call.startswith('sleep:') for call in calls) == 6
+  assert 'succeeded on attempt 7' in result.stdout
+
+
+def test_runtime_sa_mixed_permission_error_fails_in_stale_named_project(
+    tmp_path,
+):
+  project = 'stale-project'
+  write_error = f'{_runtime_sa_iam_lag(project)}\nPERMISSION_DENIED: denied'
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error=write_error,
+      failures_before_success=1,
+      project=project,
+  )
+
+  assert result.returncode == 1
+  assert calls == ['get-policy', 'add-binding']
+  assert write_error in result.stderr
+
+
+def test_retry_word_in_runtime_email_does_not_make_other_error_retryable(
+    tmp_path,
+):
+  project = 'stale-project'
+  write_error = (
+      'INVALID_ARGUMENT: member serviceAccount:'
+      f'sm-runtime@{project}.iam.gserviceaccount.com is malformed'
+  )
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error=write_error,
+      failures_before_success=1,
+      project=project,
+  )
+
+  assert result.returncode == 1
+  assert calls == ['get-policy', 'add-binding']
+  assert write_error in result.stderr
+
+
+def test_runtime_sa_project_binding_propagation_retry_is_bounded(tmp_path):
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error=_RUNTIME_SA_IAM_LAG,
+      failures_before_success=99,
+  )
+
+  delays = [
+      int(call.removeprefix('sleep:'))
+      for call in calls
+      if call.startswith('sleep:')
+  ]
+  assert result.returncode == 1
+  assert calls.count('add-binding') == 14
+  assert len(delays) == 13
+  assert max(delays) <= 60
+  assert 480 <= sum(delays) < 600
+  assert 'after 14 attempts' in result.stderr
+
+
+def test_project_binding_first_attempt_success_does_not_sleep(tmp_path):
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error=_RUNTIME_SA_IAM_LAG,
+      failures_before_success=0,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert calls == ['get-policy', 'add-binding']
+
+
+def test_existing_etag_retry_keeps_its_six_attempt_bound(tmp_path):
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error='ABORTED: stale etag',
+      failures_before_success=99,
+  )
+
+  assert result.returncode == 1
+  assert calls.count('add-binding') == 6
+  assert sum(call.startswith('sleep:') for call in calls) == 5
+  assert 'after 6 attempts' in result.stderr
+
+
+@pytest.mark.parametrize(
+    ('write_error', 'member'),
+    [
+        (
+            (
+                'ERROR: (gcloud.projects.add-iam-policy-binding)'
+                ' INVALID_ARGUMENT: Service account'
+                ' other@test-project.iam.gserviceaccount.com does not exist.'
+            ),
+            'serviceAccount:other@test-project.iam.gserviceaccount.com',
+        ),
+        (
+            (
+                'ERROR: (gcloud.projects.add-iam-policy-binding)'
+                ' INVALID_ARGUMENT: Service account'
+                ' sm-runtime@other-project.iam.gserviceaccount.com does not'
+                ' exist.'
+            ),
+            'serviceAccount:sm-runtime@other-project.iam.gserviceaccount.com',
+        ),
+        (
+            f'{_RUNTIME_SA_IAM_LAG}\nPERMISSION_DENIED: access denied',
+            'serviceAccount:sm-runtime@test-project.iam.gserviceaccount.com',
+        ),
+        (
+            'INVALID_ARGUMENT: referenced resource does not exist',
+            'serviceAccount:sm-runtime@test-project.iam.gserviceaccount.com',
+        ),
+        (
+            'NOT_FOUND: an unrelated IAM resource does not exist',
+            'serviceAccount:sm-runtime@test-project.iam.gserviceaccount.com',
+        ),
+    ],
+)
+def test_project_binding_does_not_retry_unrelated_errors(
+    tmp_path, write_error, member
+):
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error=write_error,
+      failures_before_success=1,
+      member=member,
+  )
+
+  assert result.returncode == 1
+  assert calls == ['get-policy', 'add-binding']
+  assert write_error in result.stderr
+
+
 def test_deploy_uses_the_tested_runtime_sa_helper():
   text = _DEPLOY_SH.read_text(encoding='utf-8')
 
@@ -123,3 +399,17 @@ def test_deploy_uses_the_tested_runtime_sa_helper():
       in text
   )
   assert '|| gcloud iam service-accounts create sm-runtime' not in text
+
+
+def test_deploy_runtime_roles_use_the_tested_project_binding_helper():
+  text = _DEPLOY_SH.read_text(encoding='utf-8')
+  runtime_roles = text.split(
+      'phase "Granting ${#ROLES[@]} roles to ${RUNTIME_SA}..."', 1
+  )[1].split('echo "✓ Roles granted."', 1)[0]
+
+  assert (
+      'add_iam_binding $PROJECT '
+      '--member="serviceAccount:${RUNTIME_SA}" '
+      '--role="$ROLE" --condition=None'
+      in runtime_roles
+  )

--- a/test/test_deploy_service_accounts.py
+++ b/test/test_deploy_service_accounts.py
@@ -261,6 +261,60 @@ def test_runtime_sa_propagation_budget_survives_later_etag_conflict(tmp_path):
   assert 'succeeded on attempt 7' in result.stdout
 
 
+def test_fatal_error_after_propagation_does_not_inherit_long_retry_budget(
+    tmp_path,
+):
+  project = 'stale-project'
+  fatal_error = f'ERROR: project {project} was not found.'
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error='',
+      failures_before_success=0,
+      project=project,
+      write_errors=(_runtime_sa_iam_lag(project), fatal_error),
+  )
+
+  assert result.returncode == 1
+  assert calls.count('add-binding') == 2
+  assert sum(call.startswith('sleep:') for call in calls) == 1
+  assert fatal_error in result.stderr
+
+
+def test_unrelated_error_after_propagation_masks_retry_word_in_project_id(
+    tmp_path,
+):
+  project = 'stale-project'
+  unrelated_error = (
+      f'ERROR: RESOURCE_EXHAUSTED: quota exceeded for project {project}.'
+  )
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error='',
+      failures_before_success=0,
+      project=project,
+      write_errors=(_runtime_sa_iam_lag(project), unrelated_error),
+  )
+
+  assert result.returncode == 1
+  assert calls.count('add-binding') == 2
+  assert sum(call.startswith('sleep:') for call in calls) == 1
+  assert unrelated_error in result.stderr
+
+
+def test_known_missing_sa_line_with_conflict_output_fails_closed(tmp_path):
+  missing_sa_line = _RUNTIME_SA_IAM_LAG.splitlines()[-1]
+  write_error = f'{missing_sa_line}\nABORTED: stale etag'
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error=write_error,
+      failures_before_success=1,
+  )
+
+  assert result.returncode == 1
+  assert calls == ['get-policy', 'add-binding']
+  assert write_error in result.stderr
+
+
 def test_runtime_sa_mixed_permission_error_fails_in_stale_named_project(
     tmp_path,
 ):

--- a/test/test_deploy_service_accounts.py
+++ b/test/test_deploy_service_accounts.py
@@ -229,6 +229,55 @@ def test_runtime_sa_project_binding_retries_until_iam_accepts_member(
   assert 'succeeded on attempt 3' in result.stdout
 
 
+@pytest.mark.parametrize(
+    'write_error',
+    [
+        f'WARNING: Google Cloud CLI update available.\n{_RUNTIME_SA_IAM_LAG}',
+        f'{_RUNTIME_SA_IAM_LAG}\nNOTICE: diagnostic details omitted.',
+    ],
+)
+def test_runtime_sa_project_binding_tolerates_benign_extra_output(
+    tmp_path, write_error
+):
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error=write_error,
+      failures_before_success=1,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert calls[0] == 'get-policy'
+  assert calls.count('add-binding') == 2
+  assert sum(call.startswith('sleep:') for call in calls) == 1
+  assert 'succeeded on attempt 2' in result.stdout
+
+
+@pytest.mark.parametrize(
+    'extra_error',
+    [
+        'PERMISSION_DENIED: access denied',
+        'ABORTED: stale etag',
+        'ERROR: RESOURCE_EXHAUSTED',
+    ],
+)
+def test_runtime_sa_project_binding_rejects_extra_error_output(
+    tmp_path, extra_error
+):
+  write_error = (
+      'WARNING: Google Cloud CLI update available.\n'
+      f'{_RUNTIME_SA_IAM_LAG}\n{extra_error}'
+  )
+  result, calls = _run_project_iam_binding(
+      tmp_path,
+      write_error=write_error,
+      failures_before_success=1,
+  )
+
+  assert result.returncode == 1
+  assert calls == ['get-policy', 'add-binding']
+  assert write_error in result.stderr
+
+
 def test_runtime_sa_propagation_budget_ignores_retry_words_in_project_id(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary

A fresh-project deploy can create and describe `sm-runtime` before project IAM accepts the account as a policy member. Retry the observed project-binding response at the failing write instead of treating service-account visibility as sufficient.

## Behavior

- Enables the longer propagation retry only for `serviceAccount:sm-runtime@<same-project>.iam.gserviceaccount.com` on a project IAM binding.
- Recognizes the expected missing-account response as a complete line even when `gcloud` adds non-error output around it.
- Fails immediately when the remaining output contains a permission, argument, missing-resource, quota, generic error, or conflict signal.
- Masks the expected account and project identifiers with literal replacements before legacy conflict matching, so names such as `stale-project` cannot cause retries.
- Uses 14 attempts for runtime-account propagation, with each backoff sleep capped at 60 seconds; ordinary IAM conflicts retain their six-attempt budget.

## Tests

- Covers recovery from the observed one-line and two-line responses, plus harmless warning and notice output before or after them.
- Covers immediate failure for mixed permission, quota, missing-resource, unrelated, and conflict responses, including after propagation has armed the longer budget.
- Covers permanent exhaustion, backoff bounds, identifier masking, unchanged legacy conflict behavior, and first-attempt success.
- Runs the backend suite across the supported Python versions, action signatures, formatting, Bash syntax, ShellCheck, and whitespace validation.

## Risks / Notes

- The expected missing-account sentence must still appear as an unchanged complete line. A same-line wording change stops deployment loudly and an idempotent rerun remains available.
- The longer budget deliberately applies only to the `sm-runtime` account created by this deploy. Supporting a configurable runtime-account name would require passing that created identity explicitly rather than inferring it from any IAM member.
