### PR TITLE
Serve the model allowlist from config/models in the app service

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -127,6 +127,17 @@ Today `deploy.sh` builds **one** image and runs it as two Cloud Run services via
 
 If deploy speed ever becomes the main bottleneck, the two services could be built as separate images: a small `app` image (Flask, `/api`, static UI) and a heavier `worker` image (action execution, ffmpeg, generation libraries). The services already differ only by `ROLE`, so this is mostly a packaging change. It is deferred because it raises operational complexity: two images to build, tag, version, and keep in sync, and more branches in the deploy path. Do it only after the local UI loop and the layer cache, which capture most of the day-to-day speed win at far lower risk.
 
+## Editing the model catalog at runtime
+
+The model catalog — which models exist, their locations and capabilities, and the per-family defaults — lives in the repo at `ui/definitions/models.json` and is written to the `config/models` Firestore document on every deploy. The app service reads the live document on every request, so anyone with Firestore access can change the served catalog without a deploy:
+
+- **Editable live:** the `models` and `defaults` sections — add a model, remove one, fix a location or a capability flag.
+- **Not editable live:** the `actions` section. It wires the catalog to `actions.json` parameter names; if the live document's copy differs from the shipped one, the app rejects the whole document and falls back to the shipped file. Change it in the repo.
+- **Edits are temporary.** The next deploy overwrites `config/models` from the repo (after showing a diff at the confirmation prompt). To make a change permanent, land it in `ui/definitions/models.json`.
+- **A malformed edit is safe but ignored.** The app logs `config/models unusable (...)` and keeps serving the catalog that shipped with the deploy — check the app service logs if an edit doesn't seem to apply.
+- **The worker does not see live edits.** Capability flags read at execution time (for example `supports_audio`) come from the shipped file until the next deploy. Live edits change which submissions are accepted immediately; they change execution behavior only after a deploy. (Exception: local dev runs everything in one `ROLE=app` process, so in-process actions there read the live doc.)
+- Consider enabling Firestore point-in-time recovery on the UI database as a general safety net for console edits.
+
 ## Creating Applications
 
 [< Local Development](#local-development-and-faster-deploys) • [Top](#developing-top) • [Modules not used by Scene Machine >](#modules-not-used-by-scene-machine)

--- a/actions_lib/test/test_veo.py
+++ b/actions_lib/test/test_veo.py
@@ -158,9 +158,9 @@ def test_allowlist_generate_video_models_carry_capability_flags():
   invariant must cover every generate_video model, not just family=='veo' --
   otherwise an entry checked in with a mistyped family and empty capabilities
   escapes the net and silently fails open."""
-  from util.model_allowlist import load_allowlist
+  from util.model_allowlist import load_shipped_allowlist
   video_models = {
-      mid: m for mid, m in load_allowlist()['models'].items()
+      mid: m for mid, m in load_shipped_allowlist()['models'].items()
       if 'generate_video' in m.get('actions', [])}
   assert video_models, 'no generate_video models in the allowlist'
   for mid, m in video_models.items():

--- a/scripts/validate_config_models.py
+++ b/scripts/validate_config_models.py
@@ -27,7 +27,10 @@ from collections.abc import Mapping
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from util.model_allowlist import load_allowlist  # noqa: E402
+# The check validates config.txt against what THIS deploy ships, so it
+# reads the repo file explicitly -- never the live Firestore doc, which
+# may hold operator edits the seed is about to replace.
+from util.model_allowlist import load_shipped_allowlist  # noqa: E402
 
 # (model env var, region env var, expected family, human label)
 _CHECKS = (
@@ -70,7 +73,7 @@ def collect_errors(env: Mapping[str, str], models: dict) -> list[str]:
 
 
 def main() -> None:
-  errors = collect_errors(os.environ, load_allowlist()['models'])
+  errors = collect_errors(os.environ, load_shipped_allowlist()['models'])
   if errors:
     sys.stderr.write('Model/region config check FAILED:\n')
     for error in errors:

--- a/test/test_model_allowlist.py
+++ b/test/test_model_allowlist.py
@@ -26,6 +26,11 @@ import json
 import os
 import re
 
+from google.api_core.retry import Retry
+from google.auth.credentials import AnonymousCredentials
+from google.cloud import firestore
+import pytest
+
 from util import model_allowlist
 from util.model_allowlist import (
     is_pair_allowed,
@@ -244,6 +249,10 @@ def test_app_role_falls_back_on_a_fetch_error(monkeypatch, caplog):
   assert source == 'shipped'
   assert catalog == load_shipped_allowlist()
   assert 'config/models unusable' in caplog.text
+  record = next(
+      record for record in caplog.records
+      if 'config/models unusable' in record.getMessage())
+  assert record.exc_info is not None
 
 
 def test_app_role_falls_back_on_a_malformed_doc(monkeypatch, caplog):
@@ -253,6 +262,35 @@ def test_app_role_falls_back_on_a_malformed_doc(monkeypatch, caplog):
   _, source = load_allowlist_with_source()
   assert source == 'shipped'
   assert 'not an object' in caplog.text
+  record = next(
+      record for record in caplog.records
+      if 'config/models unusable' in record.getMessage())
+  assert record.exc_info is None
+
+
+def test_live_catalog_read_has_short_sdk_retry_and_rpc_timeouts(monkeypatch):
+  client = firestore.Client(
+      project='test-project',
+      credentials=AnonymousCredentials(),
+      database='test-database',
+  )
+  captured = {}
+
+  def empty_batch_get(*, request, metadata, retry, timeout):
+    captured.update(
+        request=request, metadata=metadata, retry=retry, timeout=timeout)
+    return iter(())
+
+  monkeypatch.setattr(
+      client._firestore_api, 'batch_get_documents', empty_batch_get)
+  monkeypatch.setattr(model_allowlist, '_get_catalog_db', lambda: client)
+
+  with pytest.raises(LookupError, match='not seeded'):
+    model_allowlist._fetch_live_catalog()
+
+  assert captured['timeout'] == 2.0
+  assert isinstance(captured['retry'], Retry)
+  assert captured['retry'].timeout == 3.0
 
 
 def test_app_role_rejects_a_tampered_actions_section(monkeypatch, caplog):
@@ -325,6 +363,15 @@ def test_shape_rejects_malformed_model_entries():
     assert validate_catalog_shape(catalog, _MODELS['actions'])
 
 
+def test_shape_requires_capabilities():
+  catalog = load_shipped_allowlist()
+  del catalog['models']['veo-3.1-generate-001']['capabilities']
+
+  problem = validate_catalog_shape(catalog, _MODELS['actions'])
+
+  assert problem and 'capabilities' in problem
+
+
 def test_shape_rejects_broken_defaults():
   catalog = load_shipped_allowlist()
   catalog['defaults']['veo'] = 'not-a-model'
@@ -350,6 +397,16 @@ def test_shape_rejects_firestore_only_values_anywhere():
     plant(catalog)
     problem = validate_catalog_shape(catalog, _MODELS['actions'])
     assert problem and 'non-JSON' in problem
+
+
+def test_shape_rejects_non_finite_floats():
+  for value in (float('nan'), float('inf'), float('-inf')):
+    catalog = load_shipped_allowlist()
+    catalog['models']['veo-3.1-generate-001']['capabilities']['limit'] = value
+
+    problem = validate_catalog_shape(catalog, _MODELS['actions'])
+
+    assert problem and 'non-finite float' in problem
 
 
 def test_shape_rejects_non_boolean_capability_flags():

--- a/test/test_model_allowlist.py
+++ b/test/test_model_allowlist.py
@@ -20,15 +20,20 @@ is exercised and cannot drift from what the runtime uses. CI is the single
 strictness point for the allowlist.
 """
 
+import datetime
 import glob
 import json
 import os
 import re
 
+from util import model_allowlist
 from util.model_allowlist import (
     is_pair_allowed,
     load_allowlist,
+    load_allowlist_with_source,
+    load_shipped_allowlist,
     models_for_action,
+    validate_catalog_shape,
 )
 
 _REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -40,7 +45,7 @@ _CONFIG_TS = os.path.join(
 # Param names that mark a model-parameterized action in actions.json.
 _MODEL_PARAM_NAMES = {'gemini_model', 'image_model', 'model'}
 
-_MODELS = load_allowlist()  # through the shared loader (exercises it)
+_MODELS = load_shipped_allowlist()  # the checked-in file; CI pins this one
 with open(_ACTIONS_JSON, encoding='utf-8') as _f:
   _ACTIONS = json.load(_f)
 
@@ -64,18 +69,12 @@ def _model_parameterized_actions():
 
 # --- allowlist structure -----------------------------------------------------
 
-def test_parses_and_has_sections():
-  assert 'actions' in _MODELS and 'models' in _MODELS
-
-
-def test_defaults_reference_real_models_of_their_family():
-  defaults = _MODELS.get('defaults', {})
-  assert defaults, 'no defaults declared'
-  for family, model_id in defaults.items():
-    model = _MODELS['models'].get(model_id)
-    assert model is not None, f'default {model_id!r} is not a real model'
-    assert model['family'] == family, (
-        f'default {model_id!r} is family {model["family"]!r}, not {family!r}')
+def test_shipped_catalog_passes_the_runtime_shape_check():
+  # Sections, model-entry fields, and family-correct defaults -- via the same
+  # function the app-role loader runs on live Firestore reads, so the shipped
+  # file can never fail the runtime's own fallback rules.
+  assert _MODELS.get('defaults'), 'no defaults declared'
+  assert validate_catalog_shape(_MODELS, _MODELS['actions']) is None
 
 
 def test_outpaint_models_cover_2k_and_4k():
@@ -201,11 +200,11 @@ def test_every_shipped_model_is_allowlisted():
   assert not missing, f'shipped but not allowlisted (outage on enforcement): {missing}'
 
 
-def test_load_allowlist_returns_defensive_copy():
-  a = load_allowlist()
+def test_load_shipped_allowlist_returns_defensive_copy():
+  a = load_shipped_allowlist()
   a['models'].clear()
   a['actions'].clear()
-  b = load_allowlist()
+  b = load_shipped_allowlist()
   assert b['models'] and b['actions'], 'mutation leaked into the cached allowlist'
 
 
@@ -215,3 +214,157 @@ def test_validator_and_test_share_model_param_names():
   # two can't silently diverge and hide an action from both.
   from util.submission_validation import _MODEL_PARAM_NAMES as validator_names
   assert set(validator_names) == _MODEL_PARAM_NAMES
+
+
+# --- runtime source: the live config/models doc (ROLE=app only) ---------------
+
+def _live_catalog_with_hotfix():
+  catalog = load_shipped_allowlist()
+  catalog['models']['veo-live-hotfix'] = {
+      'family': 'veo', 'actions': ['generate_video'],
+      'locations': ['global'], 'capabilities': {}}
+  return catalog
+
+
+def test_app_role_serves_the_live_catalog(monkeypatch):
+  monkeypatch.setenv('ROLE', 'app')
+  monkeypatch.setattr(
+      model_allowlist, '_fetch_live_catalog', _live_catalog_with_hotfix)
+  catalog, source = load_allowlist_with_source()
+  assert source == 'firestore'
+  assert 'veo-live-hotfix' in catalog['models']
+
+
+def test_app_role_falls_back_on_a_fetch_error(monkeypatch, caplog):
+  monkeypatch.setenv('ROLE', 'app')
+  def unreachable():
+    raise RuntimeError('firestore down')
+  monkeypatch.setattr(model_allowlist, '_fetch_live_catalog', unreachable)
+  catalog, source = load_allowlist_with_source()
+  assert source == 'shipped'
+  assert catalog == load_shipped_allowlist()
+  assert 'config/models unusable' in caplog.text
+
+
+def test_app_role_falls_back_on_a_malformed_doc(monkeypatch, caplog):
+  monkeypatch.setenv('ROLE', 'app')
+  monkeypatch.setattr(
+      model_allowlist, '_fetch_live_catalog', lambda: {'models': 'oops'})
+  _, source = load_allowlist_with_source()
+  assert source == 'shipped'
+  assert 'not an object' in caplog.text
+
+
+def test_app_role_rejects_a_tampered_actions_section(monkeypatch, caplog):
+  monkeypatch.setenv('ROLE', 'app')
+  def tampered():
+    catalog = load_shipped_allowlist()
+    catalog['actions'] = {}
+    return catalog
+  monkeypatch.setattr(model_allowlist, '_fetch_live_catalog', tampered)
+  _, source = load_allowlist_with_source()
+  assert source == 'shipped'
+  assert "'actions' differs" in caplog.text
+
+
+def test_other_roles_never_touch_firestore(monkeypatch):
+  # Counted, not raised: an exception sentinel would be swallowed by the
+  # loader's catch-everything fallback and the test would pass vacuously.
+  calls = []
+  def counting():
+    calls.append(1)
+    return _live_catalog_with_hotfix()
+  monkeypatch.setattr(model_allowlist, '_fetch_live_catalog', counting)
+  for role in ('worker', 'all'):
+    monkeypatch.setenv('ROLE', role)
+    assert load_allowlist_with_source()[1] == 'shipped'
+  monkeypatch.delenv('ROLE')
+  assert load_allowlist_with_source()[1] == 'shipped'
+  assert not calls, 'only ROLE=app may read Firestore'
+
+
+def test_app_role_fetches_fresh_per_call(monkeypatch):
+  # Live edits apply on the next submission; there is no cache to invalidate.
+  calls = []
+  def counting():
+    calls.append(1)
+    return _live_catalog_with_hotfix()
+  monkeypatch.setenv('ROLE', 'app')
+  monkeypatch.setattr(model_allowlist, '_fetch_live_catalog', counting)
+  load_allowlist()
+  load_allowlist()
+  assert len(calls) == 2
+
+
+# --- validate_catalog_shape: what a console edit must satisfy -----------------
+
+def test_shape_rejects_a_non_object():
+  assert validate_catalog_shape('nope', _MODELS['actions'])
+
+
+def test_shape_rejects_missing_sections():
+  for section in ('defaults', 'actions', 'models'):
+    catalog = load_shipped_allowlist()
+    del catalog[section]
+    problem = validate_catalog_shape(catalog, _MODELS['actions'])
+    assert problem and section in problem
+
+
+def test_shape_rejects_malformed_model_entries():
+  mutations = (
+      lambda m: 'not-an-object',
+      lambda m: {**m, 'family': None},
+      lambda m: {**m, 'actions': 'generate_video'},
+      lambda m: {**m, 'locations': [1]},
+      lambda m: {**m, 'capabilities': 'fast'},
+  )
+  for mutate in mutations:
+    catalog = load_shipped_allowlist()
+    catalog['models']['veo-3.1-generate-001'] = mutate(
+        catalog['models']['veo-3.1-generate-001'])
+    assert validate_catalog_shape(catalog, _MODELS['actions'])
+
+
+def test_shape_rejects_broken_defaults():
+  catalog = load_shipped_allowlist()
+  catalog['defaults']['veo'] = 'not-a-model'
+  assert 'not in models' in validate_catalog_shape(catalog, _MODELS['actions'])
+  catalog = load_shipped_allowlist()
+  catalog['defaults']['veo'] = 'gemini-3.5-flash'  # real model, wrong family
+  assert 'family' in validate_catalog_shape(catalog, _MODELS['actions'])
+
+
+def test_shape_rejects_firestore_only_values_anywhere():
+  # A console edit can add a timestamp/bytes field in spots the structural
+  # checks don't pin. Such a doc must be rejected wholesale: it would crash
+  # json serialization wherever the catalog is served.
+  timestamp = datetime.datetime(2026, 7, 1)
+  for plant in (
+      lambda c: c.__setitem__('updated_at', timestamp),  # extra top-level key
+      lambda c: c['models']['veo-3.1-generate-001']['capabilities']
+      .__setitem__('added_at', timestamp),               # capability value
+      lambda c: c['models']['veo-3.1-generate-001']
+      .__setitem__('note', [b'bytes']),                  # extra model field
+  ):
+    catalog = load_shipped_allowlist()
+    plant(catalog)
+    problem = validate_catalog_shape(catalog, _MODELS['actions'])
+    assert problem and 'non-JSON' in problem
+
+
+def test_shape_rejects_non_boolean_capability_flags():
+  # veo.generate applies these with `is True`; a console-edited string
+  # "false" must reject the doc, not silently disable the behavior.
+  for flag in ('supports_audio', 'enhance_prompt_locked'):
+    catalog = load_shipped_allowlist()
+    catalog['models']['veo-3.1-generate-001']['capabilities'][flag] = 'false'
+    problem = validate_catalog_shape(catalog, _MODELS['actions'])
+    assert problem and 'boolean' in problem
+
+
+def test_shape_allows_json_typed_extra_fields():
+  # Extra keys that are plain JSON are harmless (e.g. _notes strings) and
+  # must not reject the doc.
+  catalog = load_shipped_allowlist()
+  catalog['_notes'] = 'operator scratch note'
+  assert validate_catalog_shape(catalog, _MODELS['actions']) is None

--- a/test/test_validate_config_models.py
+++ b/test/test_validate_config_models.py
@@ -18,7 +18,7 @@ import os
 import re
 
 from scripts import validate_config_models
-from util.model_allowlist import load_allowlist
+from util.model_allowlist import load_shipped_allowlist
 
 _REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -89,4 +89,4 @@ def test_config_template_defaults_pass_real_allowlist():
   # (e.g. a model bumped in the template but not the allowlist) fails here.
   env = _parse_shell_env(os.path.join(_REPO, 'config.template.txt'))
   assert validate_config_models.collect_errors(
-      env, load_allowlist()['models']) == []
+      env, load_shipped_allowlist()['models']) == []

--- a/util/model_allowlist.py
+++ b/util/model_allowlist.py
@@ -39,6 +39,7 @@ import copy
 import functools
 import json
 import logging
+import math
 import os
 from typing import TYPE_CHECKING
 
@@ -53,6 +54,8 @@ _ALLOWLIST_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     'ui', 'definitions', 'models.json',
 )
+_LIVE_CATALOG_RPC_TIMEOUT_SECONDS = 2.0
+_LIVE_CATALOG_RETRY_TIMEOUT_SECONDS = 3.0
 
 _catalog_db = None
 
@@ -84,7 +87,17 @@ def _get_catalog_db() -> 'firestore.Client':
 
 
 def _fetch_live_catalog() -> dict:
-  snapshot = _get_catalog_db().collection('config').document('models').get()
+  from google.api_core import retry as api_retry
+
+  snapshot = _get_catalog_db().collection('config').document('models').get(
+      retry=api_retry.Retry(
+          initial=0.1,
+          maximum=0.5,
+          multiplier=2.0,
+          timeout=_LIVE_CATALOG_RETRY_TIMEOUT_SECONDS,
+      ),
+      timeout=_LIVE_CATALOG_RPC_TIMEOUT_SECONDS,
+  )
   if not snapshot.exists:
     raise LookupError('config/models is not seeded')
   return snapshot.to_dict()
@@ -99,6 +112,8 @@ def _first_non_json_value(value: object, path: str) -> str | None:
   as SDK objects and would crash json serialization downstream, so the
   whole catalog must be JSON-typed.
   """
+  if isinstance(value, float) and not math.isfinite(value):
+    return f'{path} (non-finite float)'
   if value is None or isinstance(value, (bool, int, float, str)):
     return None
   if isinstance(value, list):
@@ -145,13 +160,14 @@ def validate_catalog_shape(catalog: object, shipped_actions: dict) -> str | None
       if (not isinstance(values, list)
           or not all(isinstance(v, str) for v in values)):
         return f'model {mid!r}: {field!r} is not a list of strings'
-    if not isinstance(model.get('capabilities', {}), dict):
-      return f'model {mid!r}: capabilities is not an object'
+    capabilities = model.get('capabilities')
+    if not isinstance(capabilities, dict):
+      return f'model {mid!r}: capabilities is missing or not an object'
     # veo.generate applies these with `is True`; a string "false" is a
     # console-edit mistake, not a policy. Required-and-boolean is the
     # snapshot PR's job; present-implies-boolean holds the line here.
     for flag in ('supports_audio', 'enhance_prompt_locked'):
-      flag_value = model.get('capabilities', {}).get(flag)
+      flag_value = capabilities.get(flag)
       if flag_value is not None and not isinstance(flag_value, bool):
         return f'model {mid!r}: {flag} must be a boolean'
   for family, mid in catalog['defaults'].items():
@@ -171,14 +187,22 @@ def load_allowlist_with_source() -> tuple[dict, str]:
   if os.environ.get('ROLE', 'all') == 'app':
     try:
       catalog = _fetch_live_catalog()
-      problem = validate_catalog_shape(
-          catalog, _parse_allowlist(_ALLOWLIST_PATH)['actions'])
-      if problem:
-        raise ValueError(problem)
-      return catalog, 'firestore'
-    except Exception as error:  # any failure -> serve the last-known-good file
+    except Exception as error:  # any read failure -> last-known-good file
       logger.exception(
           'config/models unusable (%s); serving the shipped allowlist', error)
+      return load_shipped_allowlist(), 'shipped'
+    try:
+      problem = validate_catalog_shape(
+          catalog, _parse_allowlist(_ALLOWLIST_PATH)['actions'])
+    except Exception as error:  # unexpected validation failure -> safe fallback
+      logger.exception(
+          'config/models unusable (%s); serving the shipped allowlist', error)
+      return load_shipped_allowlist(), 'shipped'
+    if problem:
+      logger.error(
+          'config/models unusable (%s); serving the shipped allowlist', problem)
+      return load_shipped_allowlist(), 'shipped'
+    return catalog, 'firestore'
   return load_shipped_allowlist(), 'shipped'
 
 

--- a/util/model_allowlist.py
+++ b/util/model_allowlist.py
@@ -12,20 +12,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Loads the checked-in model allowlist (`ui/definitions/models.json`).
+"""Loads the model allowlist.
 
-One shared loader so every reader parses the file the same way.
+One shared loader so every reader gets the catalog the same way. Two sources:
+
+  - the checked-in `ui/definitions/models.json` (the shipped file), and
+  - in the app service only (`ROLE=app`), the live `config/models` Firestore
+    document, which every deploy seeds from the shipped file and operators may
+    edit between deploys.
+
+The live doc is fetched fresh per call (edits apply immediately; submissions
+are human-paced, so the read volume matches /api/config's per-request reads)
+and shape-checked before use. Any problem -- no Firestore access, unseeded
+doc, malformed edit -- logs one error and falls back to the shipped file, so a
+bad console edit can degrade freshness but never take validation down.
+
+The worker deliberately stays on the shipped file: it has no access to the UI
+database (deploy.sh sets no FIRESTORE_DB_UI on it), and execution behavior
+stays deterministic per deploy. A live capability edit therefore changes what
+the validator accepts immediately, but worker behavior only at the next
+deploy. Local dev is the exception because everything there runs in one
+ROLE=app process, including in-process actions.
 """
 
 import copy
 import functools
 import json
+import logging
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+  # Never imported at runtime: the deploy-time check runs this module on
+  # machines that only have the stdlib.
+  from google.cloud import firestore
+
+logger = logging.getLogger(__name__)
 
 _ALLOWLIST_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     'ui', 'definitions', 'models.json',
 )
+
+_catalog_db = None
 
 
 @functools.lru_cache(maxsize=1)
@@ -34,14 +63,128 @@ def _parse_allowlist(path: str) -> dict:
     return json.load(f)
 
 
-def load_allowlist(path: str = _ALLOWLIST_PATH) -> dict:
-  """Loads and returns the allowlist ({'actions': {...}, 'models': {...}}).
+def load_shipped_allowlist(path: str = _ALLOWLIST_PATH) -> dict:
+  """Loads the checked-in allowlist ({'actions': ..., 'models': ...}).
 
   Parsed once and cached, like actions.json. Callers get a deep copy so this
   security data can't be mutated process-wide by a stray writer. A
   missing/unparseable file raises here (startup failure), never per-request.
   """
   return copy.deepcopy(_parse_allowlist(path))
+
+
+def _get_catalog_db() -> 'firestore.Client':
+  global _catalog_db
+  if _catalog_db is None:
+    # Imported here, not at module top: the deploy-time check imports this
+    # module on machines that only have the stdlib.
+    from google.cloud import firestore
+    _catalog_db = firestore.Client(database=os.environ['FIRESTORE_DB_UI'])
+  return _catalog_db
+
+
+def _fetch_live_catalog() -> dict:
+  snapshot = _get_catalog_db().collection('config').document('models').get()
+  if not snapshot.exists:
+    raise LookupError('config/models is not seeded')
+  return snapshot.to_dict()
+
+
+def _first_non_json_value(value: object, path: str) -> str | None:
+  """The path of a value that is not plain JSON, or None.
+
+  A console edit can introduce Firestore-only types (timestamp, bytes,
+  geopoint, reference) anywhere -- including spots the structural checks
+  don't pin, like capability values or extra keys. Those survive to_dict()
+  as SDK objects and would crash json serialization downstream, so the
+  whole catalog must be JSON-typed.
+  """
+  if value is None or isinstance(value, (bool, int, float, str)):
+    return None
+  if isinstance(value, list):
+    for index, item in enumerate(value):
+      found = _first_non_json_value(item, f'{path}[{index}]')
+      if found:
+        return found
+    return None
+  if isinstance(value, dict):
+    for key, item in value.items():
+      if not isinstance(key, str):
+        return f'{path}.{key!r} (non-string key)'
+      found = _first_non_json_value(item, f'{path}.{key}')
+      if found:
+        return found
+    return None
+  return f'{path} ({type(value).__name__})'
+
+
+def validate_catalog_shape(catalog: object, shipped_actions: dict) -> str | None:
+  """Returns why `catalog` is unusable, or None if it is well-formed.
+
+  Console edits get no CI, so the runtime applies the structural rules the
+  validator and its consumers depend on (a subset of the CI tests, which call
+  this function too so the two cannot drift). The `actions` section must
+  equal the shipped one exactly: it is wiring to actions.json param names,
+  not operator data.
+  """
+  if not isinstance(catalog, dict):
+    return 'catalog is not an object'
+  non_json = _first_non_json_value(catalog, 'catalog')
+  if non_json:
+    return f'contains a non-JSON value at {non_json}'
+  for section in ('defaults', 'actions', 'models'):
+    if not isinstance(catalog.get(section), dict):
+      return f'{section!r} is missing or not an object'
+  for mid, model in catalog['models'].items():
+    if not isinstance(model, dict):
+      return f'model {mid!r} is not an object'
+    if not isinstance(model.get('family'), str):
+      return f'model {mid!r} has no family string'
+    for field in ('actions', 'locations'):
+      values = model.get(field)
+      if (not isinstance(values, list)
+          or not all(isinstance(v, str) for v in values)):
+        return f'model {mid!r}: {field!r} is not a list of strings'
+    if not isinstance(model.get('capabilities', {}), dict):
+      return f'model {mid!r}: capabilities is not an object'
+    # veo.generate applies these with `is True`; a string "false" is a
+    # console-edit mistake, not a policy. Required-and-boolean is the
+    # snapshot PR's job; present-implies-boolean holds the line here.
+    for flag in ('supports_audio', 'enhance_prompt_locked'):
+      flag_value = model.get('capabilities', {}).get(flag)
+      if flag_value is not None and not isinstance(flag_value, bool):
+        return f'model {mid!r}: {flag} must be a boolean'
+  for family, mid in catalog['defaults'].items():
+    model = catalog['models'].get(mid)
+    if model is None:
+      return f'default {mid!r} ({family!r}) is not in models'
+    if model.get('family') != family:
+      return f'default {mid!r} is family {model.get("family")!r}, not {family!r}'
+  if catalog['actions'] != shipped_actions:
+    return ("'actions' differs from the shipped file; it is wiring to the "
+            'code, not operator data -- change it in the repo')
+  return None
+
+
+def load_allowlist_with_source() -> tuple[dict, str]:
+  """The allowlist plus where it came from: 'firestore' or 'shipped'."""
+  if os.environ.get('ROLE', 'all') == 'app':
+    try:
+      catalog = _fetch_live_catalog()
+      problem = validate_catalog_shape(
+          catalog, _parse_allowlist(_ALLOWLIST_PATH)['actions'])
+      if problem:
+        raise ValueError(problem)
+      return catalog, 'firestore'
+    except Exception as error:  # any failure -> serve the last-known-good file
+      logger.exception(
+          'config/models unusable (%s); serving the shipped allowlist', error)
+  return load_shipped_allowlist(), 'shipped'
+
+
+def load_allowlist() -> dict:
+  """The allowlist every runtime reader should use (source per module doc)."""
+  return load_allowlist_with_source()[0]
 
 
 def models_for_action(action: str, allowlist: dict | None = None) -> list[str]:


### PR DESCRIPTION
## Summary

The app service reads the live `config/models` Firestore document through the existing allowlist seam. The document is shape-checked on every app-side load and falls back to the shipped catalog within a short bounded read; workers, deploy checks, and static tests remain pinned to the checked-in catalog.

## Behavior

- `ROLE=app` fetches `config/models` fresh per call, so an operator edit applies to the next validated submission without a cache to invalidate.
- The Firestore read uses a three-second retry budget and a two-second per-RPC timeout, allowing the shipped fallback to respond during an outage.
- Missing, unreachable, malformed, non-JSON, or action-tampered documents log the reason and serve the shipped catalog instead of failing the request.
- Shape validation rejects non-finite numbers and requires every model to contain a `capabilities` object before the catalog can reach browser-facing consumers.
- Worker, `ROLE=all`, unset-role, CI, and deploy-time reads never fetch Firestore. This preserves the current worker isolation boundary.
- The deploy validator and Veo invariant test explicitly use `load_shipped_allowlist()`, so neither caller can read an operator-edited catalog.

## Tests

- Covers live and shipped source selection, fresh app reads, and role isolation.
- Exercises the pinned Firestore `DocumentReference.get` path and verifies the retry and RPC timeouts passed to its transport.
- Covers missing, malformed, non-JSON, non-finite, missing-capabilities, and action-tampered catalog fallback.
- Covers the shared shape rules and both callers that must always use the shipped catalog.
- Runs the backend suite, action-signature check, UI compile/lint/typecheck/tests, and standalone status-viewer test.

## Risks / Notes

- During a Firestore outage, the shipped catalog is the availability floor. A model removed only from the live document can therefore be accepted again until Firestore recovers; live-only additions fail closed.
- This adds one bounded Firestore read per app-side allowlist load and deliberately does not add a cache.
