### PR TITLE
Isolate temporary files for concurrent video actions

### DIFF
--- a/actions/combine_video.py
+++ b/actions/combine_video.py
@@ -32,8 +32,8 @@ actions.
 from __future__ import annotations
 
 import json
-import os
-import uuid
+import pathlib
+import tempfile
 
 from actions_lib.ffmpeg import FFMPEG
 from common import ContentType
@@ -88,72 +88,67 @@ def execute(
     logger.error('Error decoding arrangement json: %s', ex)
     raise ex
 
-  ffmpeg = FFMPEG()
-  ffmpeg.set_resolution(resolution)
-  files_to_delete = []
+  with tempfile.TemporaryDirectory() as workdir:
+    ffmpeg = FFMPEG()
+    ffmpeg.set_resolution(resolution)
 
-  for arr in arrangement_content:
-    skip_time = arr.get('skip_time', 0)
-    duration = arr.get('duration', -1)
-    offset_x = arr.get('offset_x', 0)
-    offset_y = arr.get('offset_y', 0)
+    for index, arr in enumerate(arrangement_content):
+      skip_time = arr.get('skip_time', 0)
+      duration = arr.get('duration', -1)
+      offset_x = arr.get('offset_x', 0)
+      offset_y = arr.get('offset_y', 0)
 
-    try:
-      local_path = arr['file_path'].replace('/', '_')
-    except KeyError as ke:
-      logger.error('Arrangement entry missing file_path.')
-      raise ke
+      try:
+        object_path = arr['file_path']
+      except KeyError as ke:
+        logger.error('Arrangement entry missing file_path.')
+        raise ke
+      basename = pathlib.PurePosixPath(object_path).name or 'input'
+      local_path = pathlib.Path(workdir, f'{index:04d}_{basename}')
 
-    gcs.save_locally(arr['file_path'], local_path)
-    files_to_delete.append(local_path)
-    if 'video' == arr['file_type']:
-      transition = arr.get('transition')
-      transition_overlap = arr.get('transition_overlap')
-      if transition and not transition_overlap:
-        transition_overlap = 0.5
+      gcs.save_locally(object_path, str(local_path))
+      if 'video' == arr['file_type']:
+        transition = arr.get('transition')
+        transition_overlap = arr.get('transition_overlap')
+        if transition and not transition_overlap:
+          transition_overlap = 0.5
 
-      ffmpeg.add_video(
-          path=local_path,
-          skip_time=skip_time,
-          duration=duration,
-          transition=transition,
-          transition_overlap=transition_overlap,
-      )
-    elif 'audio' == arr['file_type']:
-      ffmpeg.add_audio(local_path, arr['start_time'], skip_time, duration)
-    elif 'image' == arr['file_type']:
-      ffmpeg.add_image(
-          path=local_path,
-          start_time=arr['start_time'],
-          duration=duration,
-          offset_x=offset_x,
-          offset_y=offset_y,
-          width=arr['width'],
-          height=arr.get('height', -1),
-      )
-    else:
-      logger.error('Unsupported file type: %s', arr['file_type'])
-      raise ValueError('Unsupported file type')
-  output_filename = uuid.uuid4().hex + '_output.mp4'
+        ffmpeg.add_video(
+            path=str(local_path),
+            skip_time=skip_time,
+            duration=duration,
+            transition=transition,
+            transition_overlap=transition_overlap,
+        )
+      elif 'audio' == arr['file_type']:
+        ffmpeg.add_audio(
+            str(local_path), arr['start_time'], skip_time, duration
+        )
+      elif 'image' == arr['file_type']:
+        ffmpeg.add_image(
+            path=str(local_path),
+            start_time=arr['start_time'],
+            duration=duration,
+            offset_x=offset_x,
+            offset_y=offset_y,
+            width=arr['width'],
+            height=arr.get('height', -1),
+        )
+      else:
+        logger.error('Unsupported file type: %s', arr['file_type'])
+        raise ValueError('Unsupported file type')
 
-  logger.info('Combining video')
-  output_file_path = ffmpeg.combine(
-      output_filename, False, encoding_speed, quality_level
-  )
-  logger.info('Done')
-  files_to_delete.append(output_file_path)
-  with open(output_file_path, 'rb') as output_file:
-    output_file_bites = output_file.read()
+    output_filename = pathlib.Path(workdir, 'output.mp4')
+    logger.info('Combining video')
+    output_file_path = ffmpeg.combine(
+        str(output_filename), False, encoding_speed, quality_level
+    )
+    logger.info('Done')
 
-  logger.info('Read contents of combined video')
-  for file in set(files_to_delete):
-    os.remove(file)
-  logger.info('Deleted component videos locally')
-
-  return {
-      'video': [{
-          Key.FILE.value: gcs.store(
-              output_file_bites, 'output.mp4', str(ContentType.MP4.value)
-          )
-      }]
-  }
+    return {
+        'video': [{
+            Key.FILE.value: gcs.store_file(
+                output_file_path, 'output.mp4', str(ContentType.MP4.value)
+            )
+        }]
+    }

--- a/actions/combine_video.py
+++ b/actions/combine_video.py
@@ -42,6 +42,7 @@ from common import logger
 from common import NodeInput
 from common import NodeOutput
 from common import Params
+from util.gcs_wrapper import download_distinct_inputs
 from util.gcs_wrapper import GCS
 
 
@@ -88,25 +89,27 @@ def execute(
     logger.error('Error decoding arrangement json: %s', ex)
     raise ex
 
+  object_paths = []
+  for arr in arrangement_content:
+    try:
+      object_paths.append(arr['file_path'])
+    except KeyError as ke:
+      logger.error('Arrangement entry missing file_path.')
+      raise ke
+
   with tempfile.TemporaryDirectory() as workdir:
+    local_paths = download_distinct_inputs(gcs, object_paths, workdir)
     ffmpeg = FFMPEG()
     ffmpeg.set_resolution(resolution)
 
-    for index, arr in enumerate(arrangement_content):
+    for arr in arrangement_content:
       skip_time = arr.get('skip_time', 0)
       duration = arr.get('duration', -1)
       offset_x = arr.get('offset_x', 0)
       offset_y = arr.get('offset_y', 0)
 
-      try:
-        object_path = arr['file_path']
-      except KeyError as ke:
-        logger.error('Arrangement entry missing file_path.')
-        raise ke
-      basename = pathlib.PurePosixPath(object_path).name or 'input'
-      local_path = pathlib.Path(workdir, f'{index:04d}_{basename}')
-
-      gcs.save_locally(object_path, str(local_path))
+      object_path = arr['file_path']
+      local_path = local_paths[object_path]
       if 'video' == arr['file_type']:
         transition = arr.get('transition')
         transition_overlap = arr.get('transition_overlap')
@@ -114,19 +117,17 @@ def execute(
           transition_overlap = 0.5
 
         ffmpeg.add_video(
-            path=str(local_path),
+            path=local_path,
             skip_time=skip_time,
             duration=duration,
             transition=transition,
             transition_overlap=transition_overlap,
         )
       elif 'audio' == arr['file_type']:
-        ffmpeg.add_audio(
-            str(local_path), arr['start_time'], skip_time, duration
-        )
+        ffmpeg.add_audio(local_path, arr['start_time'], skip_time, duration)
       elif 'image' == arr['file_type']:
         ffmpeg.add_image(
-            path=str(local_path),
+            path=local_path,
             start_time=arr['start_time'],
             duration=duration,
             offset_x=offset_x,

--- a/actions/convert_video.py
+++ b/actions/convert_video.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import pathlib
 import tempfile
 
 from actions_lib.ffmpeg import FFMPEG
@@ -25,6 +24,7 @@ from common import Key
 from common import NodeInput
 from common import NodeOutput
 from common import Params
+from util.gcs_wrapper import download_distinct_inputs
 from util.gcs_wrapper import GCS
 
 
@@ -47,14 +47,13 @@ def execute(
     A NodeOutput object containing the path to the converted video file.
   """
   file_path = file[0][Key.FILE.value]
-  basename = pathlib.PurePosixPath(file_path).name or 'input'
   with tempfile.TemporaryDirectory() as workdir:
-    local_path = pathlib.Path(workdir, f'0000_{basename}')
-    gcs.save_locally(file_path, str(local_path))
+    local_paths = download_distinct_inputs(gcs, [file_path], workdir)
+    local_path = local_paths[file_path]
 
     ffmpeg = FFMPEG().set_resolution(output_file_dimension)
     converted_video_path = ffmpeg.convert_video(
-        str(local_path), output_file_extension
+        local_path, output_file_extension
     )
 
     return {

--- a/actions/convert_video.py
+++ b/actions/convert_video.py
@@ -15,6 +15,10 @@
 """Converts a video from one format to another."""
 
 from __future__ import annotations
+
+import pathlib
+import tempfile
+
 from actions_lib.ffmpeg import FFMPEG
 from common import ContentType
 from common import Key
@@ -43,19 +47,21 @@ def execute(
     A NodeOutput object containing the path to the converted video file.
   """
   file_path = file[0][Key.FILE.value]
-  local_path = file_path.split("/")[-1]
-  gcs.save_locally(file_path, local_path)
+  basename = pathlib.PurePosixPath(file_path).name or 'input'
+  with tempfile.TemporaryDirectory() as workdir:
+    local_path = pathlib.Path(workdir, f'0000_{basename}')
+    gcs.save_locally(file_path, str(local_path))
 
-  ffmpeg = FFMPEG().set_resolution(output_file_dimension)
-  converted_video_path = ffmpeg.convert_video(local_path, output_file_extension)
+    ffmpeg = FFMPEG().set_resolution(output_file_dimension)
+    converted_video_path = ffmpeg.convert_video(
+        str(local_path), output_file_extension
+    )
 
-  with open(converted_video_path, "rb") as output_file:
-    output_file_bites = output_file.read()
     return {
-        "video": [{
-            Key.FILE.value: gcs.store(
-                output_file_bites,
-                f"output.{output_file_extension}",
+        'video': [{
+            Key.FILE.value: gcs.store_file(
+                converted_video_path,
+                f'output.{output_file_extension}',
                 ContentType.MP4.value,
             )
         }]

--- a/actions/test/test_combine_video.py
+++ b/actions/test/test_combine_video.py
@@ -17,6 +17,7 @@
 import concurrent.futures
 import json
 import pathlib
+import re
 import threading
 import unittest
 from unittest import mock
@@ -25,14 +26,16 @@ import pytest
 
 from actions import combine_video
 from common import Key
+from util.gcs_wrapper import MAX_LOCAL_INPUT_BYTES
 
 
-def test_concurrent_repeated_inputs_use_distinct_request_local_paths(
+def test_concurrent_long_same_basename_inputs_use_bounded_local_paths(
     monkeypatch, tmp_path
 ):
+  long_basename = f'{"x" * 1000}.mp4'
   arrangement = [
-      {'file_type': 'video', 'file_path': '../../clips/shared.mp4'},
-      {'file_type': 'video', 'file_path': '/absolute/shared.mp4'},
+      {'file_type': 'video', 'file_path': f'../../clips/{long_basename}'},
+      {'file_type': 'video', 'file_path': f'/absolute/{long_basename}'},
   ]
   input_groups = []
   groups_lock = threading.Lock()
@@ -64,7 +67,11 @@ def test_concurrent_repeated_inputs_use_distinct_request_local_paths(
     def load_text(self, _path):
       return json.dumps(arrangement)
 
-    def save_locally(self, _gcs_path, local_path):
+    def get_size_and_generation(self, _gcs_path):
+      return 1, 1
+
+    def save_locally(self, _gcs_path, local_path, *, if_generation_match):
+      assert if_generation_match == 1
       pathlib.Path(local_path).write_bytes(b'input')
 
     def store_file(self, source, name, _content_type):
@@ -91,6 +98,11 @@ def test_concurrent_repeated_inputs_use_distinct_request_local_paths(
   assert len(all_paths) == 4
   assert len(set(all_paths)) == 4
   assert all(pathlib.Path(path).is_absolute() for path in all_paths)
+  assert all(
+      re.fullmatch(r'input-[0-9a-f]{64}\.mp4', pathlib.Path(path).name)
+      for path in all_paths
+  )
+  assert all(len(pathlib.Path(path).name) <= 81 for path in all_paths)
   for group in input_groups:
     parents = {pathlib.Path(path).parent for path in group}
     assert len(parents) == 1
@@ -99,6 +111,105 @@ def test_concurrent_repeated_inputs_use_distinct_request_local_paths(
       {'video': [{Key.FILE.value: 'combine_video/checksum/output.mp4'}]},
       {'video': [{Key.FILE.value: 'combine_video/checksum/output.mp4'}]},
   ]
+
+
+def test_repeated_large_object_is_downloaded_once_and_reused(monkeypatch):
+  object_path = 'clips/repeated.mp4'
+  arrangement = [
+      {'file_type': 'video', 'file_path': object_path},
+      {'file_type': 'video', 'file_path': object_path},
+  ]
+  size_checks = []
+  downloads = []
+  download_generations = []
+  ffmpeg_inputs = []
+
+  class RecordingFFMPEG:
+
+    def set_resolution(self, _resolution):
+      return self
+
+    def add_video(self, *, path, **_kwargs):
+      ffmpeg_inputs.append(path)
+
+    def combine(self, output_path, *_args):
+      pathlib.Path(output_path).write_bytes(b'combined')
+      return output_path
+
+  class FakeGCS:
+
+    def load_text(self, _path):
+      return json.dumps(arrangement)
+
+    def get_size_and_generation(self, gcs_path):
+      size_checks.append(gcs_path)
+      return MAX_LOCAL_INPUT_BYTES, 37
+
+    def save_locally(self, gcs_path, local_path, *, if_generation_match):
+      downloads.append(gcs_path)
+      download_generations.append(if_generation_match)
+      pathlib.Path(local_path).write_bytes(b'input')
+
+    def store_file(self, _source, name, _content_type):
+      return f'combine_video/checksum/{name}'
+
+  monkeypatch.setattr(combine_video, 'FFMPEG', RecordingFFMPEG)
+
+  combine_video.execute(
+      FakeGCS(),
+      {},
+      [{Key.FILE.value: 'arrangement.json'}],
+      '1280:720',
+      6,
+      20,
+  )
+
+  assert size_checks == [object_path]
+  assert downloads == [object_path]
+  assert download_generations == [37]
+  assert len(ffmpeg_inputs) == 2
+  assert ffmpeg_inputs[0] == ffmpeg_inputs[1]
+
+
+def test_distinct_inputs_over_local_size_limit_fail_before_download(
+    monkeypatch,
+):
+  arrangement = [
+      {'file_type': 'video', 'file_path': 'clips/one.mp4'},
+      {'file_type': 'video', 'file_path': 'clips/two.mp4'},
+  ]
+  downloads = []
+
+  class UnexpectedFFMPEG:
+
+    def __init__(self):
+      raise AssertionError('FFmpeg must not start for oversized inputs')
+
+  class FakeGCS:
+
+    def load_text(self, _path):
+      return json.dumps(arrangement)
+
+    def get_size_and_generation(self, _gcs_path):
+      return MAX_LOCAL_INPUT_BYTES // 2 + 1, 1
+
+    def save_locally(self, gcs_path, _local_path, *, if_generation_match):
+      del if_generation_match
+      downloads.append(gcs_path)
+
+  monkeypatch.setattr(combine_video, 'FFMPEG', UnexpectedFFMPEG)
+
+  with pytest.raises(ValueError, match='8 GiB'):
+    combine_video.execute(
+        FakeGCS(),
+        {},
+        [{Key.FILE.value: 'arrangement.json'}],
+        '1280:720',
+        6,
+        20,
+    )
+
+  assert downloads == []
 
 
 def test_combine_uploads_from_file_before_workspace_cleanup(monkeypatch):
@@ -122,7 +233,11 @@ def test_combine_uploads_from_file_before_workspace_cleanup(monkeypatch):
     def load_text(self, _path):
       return json.dumps(arrangement)
 
-    def save_locally(self, _gcs_path, local_path):
+    def get_size_and_generation(self, _gcs_path):
+      return 1, 1
+
+    def save_locally(self, _gcs_path, local_path, *, if_generation_match):
+      assert if_generation_match == 1
       pathlib.Path(local_path).write_bytes(b'input')
 
     def store_file(self, source, name, content_type):
@@ -171,7 +286,11 @@ def test_combine_cleans_workspace_when_ffmpeg_fails(monkeypatch):
     def load_text(self, _path):
       return json.dumps(arrangement)
 
-    def save_locally(self, _gcs_path, local_path):
+    def get_size_and_generation(self, _gcs_path):
+      return 1, 1
+
+    def save_locally(self, _gcs_path, local_path, *, if_generation_match):
+      assert if_generation_match == 1
       pathlib.Path(local_path).write_bytes(b'input')
 
   monkeypatch.setattr(combine_video, 'FFMPEG', FailingFFMPEG)
@@ -196,6 +315,7 @@ class TestCombineVideo(unittest.TestCase):
   def setUp(self):
     super().setUp()
     self.mock_gcs = mock.Mock()
+    self.mock_gcs.get_size_and_generation.return_value = (1, 1)
     self.mock_workflow_params = {}
     self.mock_ffmpeg_cls = mock.patch('actions.combine_video.FFMPEG').start()
     self.mock_ffmpeg = self.mock_ffmpeg_cls.return_value

--- a/actions/test/test_combine_video.py
+++ b/actions/test/test_combine_video.py
@@ -14,12 +14,180 @@
 
 """Tests for combine_video action."""
 
+import concurrent.futures
 import json
+import pathlib
+import threading
 import unittest
 from unittest import mock
 
+import pytest
+
 from actions import combine_video
 from common import Key
+
+
+def test_concurrent_repeated_inputs_use_distinct_request_local_paths(
+    monkeypatch, tmp_path
+):
+  arrangement = [
+      {'file_type': 'video', 'file_path': '../../clips/shared.mp4'},
+      {'file_type': 'video', 'file_path': '/absolute/shared.mp4'},
+  ]
+  input_groups = []
+  groups_lock = threading.Lock()
+  both_calls_ready = threading.Barrier(2)
+
+  class RecordingFFMPEG:
+
+    def __init__(self):
+      self.paths = []
+
+    def set_resolution(self, _resolution):
+      return self
+
+    def add_video(self, *, path, **_kwargs):
+      self.paths.append(path)
+
+    def combine(self, _output_name, *_args):
+      with groups_lock:
+        input_groups.append(list(self.paths))
+      both_calls_ready.wait(timeout=5)
+      output_path = pathlib.Path(self.paths[0]).parent / (
+          f'{threading.get_ident()}-output.mp4'
+      )
+      output_path.write_bytes(b'combined')
+      return str(output_path)
+
+  class FakeGCS:
+
+    def load_text(self, _path):
+      return json.dumps(arrangement)
+
+    def save_locally(self, _gcs_path, local_path):
+      pathlib.Path(local_path).write_bytes(b'input')
+
+    def store_file(self, source, name, _content_type):
+      assert pathlib.Path(source).is_file()
+      return f'combine_video/checksum/{name}'
+
+  monkeypatch.chdir(tmp_path)
+  monkeypatch.setattr(combine_video, 'FFMPEG', RecordingFFMPEG)
+
+  def run_combine():
+    return combine_video.execute(
+        FakeGCS(),
+        {},
+        [{Key.FILE.value: 'arrangement.json'}],
+        '1280:720',
+        6,
+        20,
+    )
+
+  with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+    results = list(executor.map(lambda _: run_combine(), range(2)))
+
+  all_paths = [path for group in input_groups for path in group]
+  assert len(all_paths) == 4
+  assert len(set(all_paths)) == 4
+  assert all(pathlib.Path(path).is_absolute() for path in all_paths)
+  for group in input_groups:
+    parents = {pathlib.Path(path).parent for path in group}
+    assert len(parents) == 1
+    assert not parents.pop().exists()
+  assert results == [
+      {'video': [{Key.FILE.value: 'combine_video/checksum/output.mp4'}]},
+      {'video': [{Key.FILE.value: 'combine_video/checksum/output.mp4'}]},
+  ]
+
+
+def test_combine_uploads_from_file_before_workspace_cleanup(monkeypatch):
+  uploaded_sources = []
+  arrangement = [{'file_type': 'video', 'file_path': 'clips/input.mp4'}]
+
+  class FileProducingFFMPEG:
+
+    def set_resolution(self, _resolution):
+      return self
+
+    def add_video(self, **_kwargs):
+      pass
+
+    def combine(self, output_path, *_args):
+      pathlib.Path(output_path).write_bytes(b'combined')
+      return output_path
+
+  class FakeGCS:
+
+    def load_text(self, _path):
+      return json.dumps(arrangement)
+
+    def save_locally(self, _gcs_path, local_path):
+      pathlib.Path(local_path).write_bytes(b'input')
+
+    def store_file(self, source, name, content_type):
+      source_path = pathlib.Path(source)
+      assert source_path.is_file()
+      assert name == 'output.mp4'
+      assert content_type == 'video/mp4'
+      uploaded_sources.append(source_path)
+      return f'combine_video/checksum/{name}'
+
+  monkeypatch.setattr(combine_video, 'FFMPEG', FileProducingFFMPEG)
+
+  result = combine_video.execute(
+      FakeGCS(),
+      {},
+      [{Key.FILE.value: 'arrangement.json'}],
+      '1280:720',
+      6,
+      20,
+  )
+
+  assert result == {
+      'video': [{Key.FILE.value: 'combine_video/checksum/output.mp4'}]
+  }
+  assert len(uploaded_sources) == 1
+  assert not uploaded_sources[0].parent.exists()
+
+
+def test_combine_cleans_workspace_when_ffmpeg_fails(monkeypatch):
+  workspace_paths = []
+  arrangement = [{'file_type': 'video', 'file_path': 'clips/input.mp4'}]
+
+  class FailingFFMPEG:
+
+    def set_resolution(self, _resolution):
+      return self
+
+    def add_video(self, *, path, **_kwargs):
+      workspace_paths.append(pathlib.Path(path))
+
+    def combine(self, _output_path, *_args):
+      raise RuntimeError('ffmpeg failed')
+
+  class FakeGCS:
+
+    def load_text(self, _path):
+      return json.dumps(arrangement)
+
+    def save_locally(self, _gcs_path, local_path):
+      pathlib.Path(local_path).write_bytes(b'input')
+
+  monkeypatch.setattr(combine_video, 'FFMPEG', FailingFFMPEG)
+
+  with pytest.raises(RuntimeError, match='ffmpeg failed'):
+    combine_video.execute(
+        FakeGCS(),
+        {},
+        [{Key.FILE.value: 'arrangement.json'}],
+        '1280:720',
+        6,
+        20,
+    )
+
+  assert len(workspace_paths) == 1
+  assert not workspace_paths[0].parent.exists()
 
 
 class TestCombineVideo(unittest.TestCase):
@@ -52,19 +220,14 @@ class TestCombineVideo(unittest.TestCase):
     # Mock GCS load to return valid JSON
     self.mock_gcs.load_text.return_value = json.dumps(arrangement)
 
-    # Mock open and os.remove since execute tries to files
-    with mock.patch(
-        'builtins.open', mock.mock_open(read_data=b'video_data')
-    ), mock.patch('os.remove'):
-      # Execute
-      combine_video.execute(
-          self.mock_gcs,
-          self.mock_workflow_params,
-          [{Key.FILE.value: 'arrangement.json'}],
-          '1280:720',
-          6,
-          20,
-      )
+    combine_video.execute(
+        self.mock_gcs,
+        self.mock_workflow_params,
+        [{Key.FILE.value: 'arrangement.json'}],
+        '1280:720',
+        6,
+        20,
+    )
 
     # Verify add_video called with overlap=0.5
     self.mock_ffmpeg.add_video.assert_called_with(

--- a/actions/test/test_convert_video.py
+++ b/actions/test/test_convert_video.py
@@ -1,0 +1,155 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for convert_video action."""
+
+import concurrent.futures
+import pathlib
+import threading
+
+import pytest
+
+from actions import convert_video
+from common import Key
+
+
+def test_concurrent_same_basename_conversions_use_distinct_local_paths(
+    monkeypatch,
+):
+  ffmpeg_inputs = []
+  inputs_lock = threading.Lock()
+  both_calls_ready = threading.Barrier(2)
+
+  class RecordingFFMPEG:
+
+    def set_resolution(self, _resolution):
+      return self
+
+    def convert_video(self, input_path, _extension):
+      with inputs_lock:
+        ffmpeg_inputs.append(input_path)
+      both_calls_ready.wait(timeout=5)
+      output_path = pathlib.Path(input_path).parent / (
+          f'{threading.get_ident()}-output.mp4'
+      )
+      output_path.write_bytes(b'converted')
+      return str(output_path)
+
+  class FakeGCS:
+
+    def save_locally(self, _gcs_path, local_path):
+      path = pathlib.Path(local_path)
+      assert path.resolve().parent == path.parent.resolve()
+      path.write_bytes(b'input')
+
+    def store_file(self, source, name, _content_type):
+      assert pathlib.Path(source).is_file()
+      return f'convert_video/checksum/{name}'
+
+  monkeypatch.setattr(convert_video, 'FFMPEG', RecordingFFMPEG)
+
+  def run_conversion():
+    return convert_video.execute(
+        FakeGCS(),
+        {},
+        [{Key.FILE.value: '..'}],
+        '1280:720',
+        'mp4',
+    )
+
+  with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+    results = list(executor.map(lambda _: run_conversion(), range(2)))
+
+  assert len(set(ffmpeg_inputs)) == 2
+  assert all(pathlib.Path(path).name == '0000_..' for path in ffmpeg_inputs)
+  assert all(not pathlib.Path(path).parent.exists() for path in ffmpeg_inputs)
+  assert results == [
+      {'video': [{Key.FILE.value: 'convert_video/checksum/output.mp4'}]},
+      {'video': [{Key.FILE.value: 'convert_video/checksum/output.mp4'}]},
+  ]
+
+
+def test_conversion_uploads_from_file_before_workspace_cleanup(monkeypatch):
+  uploaded_sources = []
+
+  class FileProducingFFMPEG:
+
+    def set_resolution(self, _resolution):
+      return self
+
+    def convert_video(self, input_path, _extension):
+      output_path = pathlib.Path(f'{input_path}_converted.mp4')
+      output_path.write_bytes(b'converted')
+      return str(output_path)
+
+  class FakeGCS:
+
+    def save_locally(self, _gcs_path, local_path):
+      pathlib.Path(local_path).write_bytes(b'input')
+
+    def store_file(self, source, name, content_type):
+      source_path = pathlib.Path(source)
+      assert source_path.is_file()
+      assert name == 'output.mp4'
+      assert content_type == 'video/mp4'
+      uploaded_sources.append(source_path)
+      return f'convert_video/checksum/{name}'
+
+  monkeypatch.setattr(convert_video, 'FFMPEG', FileProducingFFMPEG)
+
+  result = convert_video.execute(
+      FakeGCS(),
+      {},
+      [{Key.FILE.value: 'uploads/input.mp4'}],
+      '1280:720',
+      'mp4',
+  )
+
+  assert result == {
+      'video': [{Key.FILE.value: 'convert_video/checksum/output.mp4'}]
+  }
+  assert len(uploaded_sources) == 1
+  assert not uploaded_sources[0].parent.exists()
+
+
+def test_conversion_cleans_workspace_when_ffmpeg_fails(monkeypatch):
+  workspace_paths = []
+
+  class FailingFFMPEG:
+
+    def set_resolution(self, _resolution):
+      return self
+
+    def convert_video(self, input_path, _extension):
+      workspace_paths.append(pathlib.Path(input_path))
+      raise RuntimeError('ffmpeg failed')
+
+  class FakeGCS:
+
+    def save_locally(self, _gcs_path, local_path):
+      pathlib.Path(local_path).write_bytes(b'input')
+
+  monkeypatch.setattr(convert_video, 'FFMPEG', FailingFFMPEG)
+
+  with pytest.raises(RuntimeError, match='ffmpeg failed'):
+    convert_video.execute(
+        FakeGCS(),
+        {},
+        [{Key.FILE.value: 'uploads/input.mp4'}],
+        '1280:720',
+        'mp4',
+    )
+
+  assert len(workspace_paths) == 1
+  assert not workspace_paths[0].parent.exists()

--- a/actions/test/test_convert_video.py
+++ b/actions/test/test_convert_video.py
@@ -16,12 +16,14 @@
 
 import concurrent.futures
 import pathlib
+import re
 import threading
 
 import pytest
 
 from actions import convert_video
 from common import Key
+from util.gcs_wrapper import MAX_LOCAL_INPUT_BYTES
 
 
 def test_concurrent_same_basename_conversions_use_distinct_local_paths(
@@ -48,7 +50,11 @@ def test_concurrent_same_basename_conversions_use_distinct_local_paths(
 
   class FakeGCS:
 
-    def save_locally(self, _gcs_path, local_path):
+    def get_size_and_generation(self, _gcs_path):
+      return 1, 1
+
+    def save_locally(self, _gcs_path, local_path, *, if_generation_match):
+      assert if_generation_match == 1
       path = pathlib.Path(local_path)
       assert path.resolve().parent == path.parent.resolve()
       path.write_bytes(b'input')
@@ -63,7 +69,7 @@ def test_concurrent_same_basename_conversions_use_distinct_local_paths(
     return convert_video.execute(
         FakeGCS(),
         {},
-        [{Key.FILE.value: '..'}],
+        [{Key.FILE.value: f'../../clips/{"x" * 1000}.mp4'}],
         '1280:720',
         'mp4',
     )
@@ -72,12 +78,117 @@ def test_concurrent_same_basename_conversions_use_distinct_local_paths(
     results = list(executor.map(lambda _: run_conversion(), range(2)))
 
   assert len(set(ffmpeg_inputs)) == 2
-  assert all(pathlib.Path(path).name == '0000_..' for path in ffmpeg_inputs)
+  assert all(
+      re.fullmatch(r'input-[0-9a-f]{64}\.mp4', pathlib.Path(path).name)
+      for path in ffmpeg_inputs
+  )
+  assert all(len(pathlib.Path(path).name) <= 81 for path in ffmpeg_inputs)
   assert all(not pathlib.Path(path).parent.exists() for path in ffmpeg_inputs)
   assert results == [
       {'video': [{Key.FILE.value: 'convert_video/checksum/output.mp4'}]},
       {'video': [{Key.FILE.value: 'convert_video/checksum/output.mp4'}]},
   ]
+
+
+def test_conversion_over_local_size_limit_fails_before_download(monkeypatch):
+  downloads = []
+
+  class UnexpectedFFMPEG:
+
+    def __init__(self):
+      raise AssertionError('FFmpeg must not start for oversized input')
+
+  class FakeGCS:
+
+    def get_size_and_generation(self, _gcs_path):
+      return MAX_LOCAL_INPUT_BYTES + 1, 1
+
+    def save_locally(self, gcs_path, _local_path, *, if_generation_match):
+      del if_generation_match
+      downloads.append(gcs_path)
+
+  monkeypatch.setattr(convert_video, 'FFMPEG', UnexpectedFFMPEG)
+
+  with pytest.raises(ValueError, match='8 GiB'):
+    convert_video.execute(
+        FakeGCS(),
+        {},
+        [{Key.FILE.value: 'uploads/oversize.mp4'}],
+        '1280:720',
+        'mp4',
+    )
+
+  assert downloads == []
+
+
+def test_generation_change_stops_before_ffmpeg(monkeypatch):
+
+  class UnexpectedFFMPEG:
+
+    def __init__(self):
+      raise AssertionError('FFmpeg must not start after a generation change')
+
+  class FakeGCS:
+
+    def get_size_and_generation(self, _gcs_path):
+      return 1, 29
+
+    def save_locally(self, _gcs_path, _local_path, *, if_generation_match):
+      assert if_generation_match == 29
+      raise RuntimeError('object generation changed')
+
+  monkeypatch.setattr(convert_video, 'FFMPEG', UnexpectedFFMPEG)
+
+  with pytest.raises(RuntimeError, match='generation changed'):
+    convert_video.execute(
+        FakeGCS(),
+        {},
+        [{Key.FILE.value: 'uploads/replaced.mp4'}],
+        '1280:720',
+        'mp4',
+    )
+
+
+def test_long_extension_is_not_copied_to_local_filename(monkeypatch):
+  ffmpeg_inputs = []
+
+  class RecordingFFMPEG:
+
+    def set_resolution(self, _resolution):
+      return self
+
+    def convert_video(self, input_path, _extension):
+      ffmpeg_inputs.append(input_path)
+      output_path = pathlib.Path(input_path).parent / 'converted.mp4'
+      output_path.write_bytes(b'converted')
+      return str(output_path)
+
+  class FakeGCS:
+
+    def get_size_and_generation(self, _gcs_path):
+      return 1, 1
+
+    def save_locally(self, _gcs_path, local_path, *, if_generation_match):
+      assert if_generation_match == 1
+      pathlib.Path(local_path).write_bytes(b'input')
+
+    def store_file(self, _source, name, _content_type):
+      return f'convert_video/checksum/{name}'
+
+  monkeypatch.setattr(convert_video, 'FFMPEG', RecordingFFMPEG)
+
+  convert_video.execute(
+      FakeGCS(),
+      {},
+      [{Key.FILE.value: f'uploads/clip.{"x" * 1000}'}],
+      '1280:720',
+      'mp4',
+  )
+
+  assert len(ffmpeg_inputs) == 1
+  assert re.fullmatch(
+      r'input-[0-9a-f]{64}', pathlib.Path(ffmpeg_inputs[0]).name
+  )
 
 
 def test_conversion_uploads_from_file_before_workspace_cleanup(monkeypatch):
@@ -95,7 +206,11 @@ def test_conversion_uploads_from_file_before_workspace_cleanup(monkeypatch):
 
   class FakeGCS:
 
-    def save_locally(self, _gcs_path, local_path):
+    def get_size_and_generation(self, _gcs_path):
+      return 1, 1
+
+    def save_locally(self, _gcs_path, local_path, *, if_generation_match):
+      assert if_generation_match == 1
       pathlib.Path(local_path).write_bytes(b'input')
 
     def store_file(self, source, name, content_type):
@@ -137,7 +252,11 @@ def test_conversion_cleans_workspace_when_ffmpeg_fails(monkeypatch):
 
   class FakeGCS:
 
-    def save_locally(self, _gcs_path, local_path):
+    def get_size_and_generation(self, _gcs_path):
+      return 1, 1
+
+    def save_locally(self, _gcs_path, local_path, *, if_generation_match):
+      assert if_generation_match == 1
       pathlib.Path(local_path).write_bytes(b'input')
 
   monkeypatch.setattr(convert_video, 'FFMPEG', FailingFFMPEG)

--- a/actions_lib/ffmpeg.py
+++ b/actions_lib/ffmpeg.py
@@ -25,8 +25,6 @@ from common import logger
 FFMPEG_PATH = 'ffmpeg'
 FFPROBE_PATH = 'ffprobe'
 
-properties_cache = {}
-
 
 def get_video_properties(file_path: str) -> Dict[str, Any]:
   """Gets video properties and checks for an audio stream in an ffprobe call.
@@ -37,9 +35,6 @@ def get_video_properties(file_path: str) -> Dict[str, Any]:
   Returns:
     dictionary with video properties
   """
-  if file_path in properties_cache:
-    return properties_cache[file_path]
-
   command = [
       FFPROBE_PATH,
       '-v',
@@ -79,7 +74,6 @@ def get_video_properties(file_path: str) -> Dict[str, Any]:
       elif stream.get('codec_type') == 'audio':
         video_info['has_audio'] = True
 
-  properties_cache[file_path] = video_info
   return video_info
 
 

--- a/actions_lib/test/test_ffmpeg.py
+++ b/actions_lib/test/test_ffmpeg.py
@@ -14,10 +14,12 @@
 
 """Tests for FFMPEG utility class."""
 
+import json
 import unittest
 from unittest import mock
 
 from actions_lib.ffmpeg import FFMPEG
+from actions_lib.ffmpeg import get_video_properties
 
 
 class TestFFMPEG(unittest.TestCase):
@@ -26,6 +28,41 @@ class TestFFMPEG(unittest.TestCase):
   def setUp(self):
     super().setUp()
     self.ffmpeg = FFMPEG()
+
+  @mock.patch('actions_lib.ffmpeg.subprocess.run')
+  def test_reused_local_path_is_probed_again(self, mock_run):
+    mock_run.side_effect = [
+        mock.Mock(
+            stdout=json.dumps({
+                'format': {'duration': '1.0'},
+                'streams': [{
+                    'codec_type': 'video',
+                    'width': 640,
+                    'height': 360,
+                    'r_frame_rate': '24/1',
+                }],
+            })
+        ),
+        mock.Mock(
+            stdout=json.dumps({
+                'format': {'duration': '2.0'},
+                'streams': [{
+                    'codec_type': 'video',
+                    'width': 1280,
+                    'height': 720,
+                    'r_frame_rate': '30/1',
+                }],
+            })
+        ),
+    ]
+
+    first = get_video_properties('/tmp/reused-request-path.mp4')
+    second = get_video_properties('/tmp/reused-request-path.mp4')
+
+    self.assertEqual(first['duration'], 1.0)
+    self.assertEqual(second['duration'], 2.0)
+    self.assertEqual(second['dimensions'], '1280:720')
+    self.assertEqual(mock_run.call_count, 2)
 
   @mock.patch('actions_lib.ffmpeg.get_video_properties')
   @mock.patch('subprocess.run')
@@ -36,7 +73,7 @@ class TestFFMPEG(unittest.TestCase):
         'duration': 5.0,
         'dimensions': '1280:720',
         'fps': 30.0,
-        'has_audio': True
+        'has_audio': True,
     }
 
     # Add two videos
@@ -46,7 +83,7 @@ class TestFFMPEG(unittest.TestCase):
         skip_time=0,
         duration=5.0,
         transition=None,
-        transition_overlap=0
+        transition_overlap=0,
     )
 
     # Video 2: 'circlecrop' transition, 1.0s overlap
@@ -55,7 +92,7 @@ class TestFFMPEG(unittest.TestCase):
         skip_time=0,
         duration=5.0,
         transition='circlecrop',
-        transition_overlap=1.0
+        transition_overlap=1.0,
     )
 
     # Run combine
@@ -76,6 +113,7 @@ class TestFFMPEG(unittest.TestCase):
     self.assertIn('transition=circlecrop', full_command)
     self.assertIn('duration=1.0', full_command)
     self.assertIn('offset=4.0', full_command)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_gcs_wrapper.py
+++ b/test/test_gcs_wrapper.py
@@ -17,6 +17,8 @@
 import datetime
 from unittest import mock
 
+import pytest
+
 from util.gcs_wrapper import GCS
 
 
@@ -42,3 +44,59 @@ def test_store_file_preserves_destination_ttl_and_content_type(tmp_path):
   remaining = expiry - datetime.datetime.now(datetime.timezone.utc)
   assert datetime.timedelta(days=2, hours=23) < remaining
   assert remaining <= datetime.timedelta(days=3)
+
+
+def test_get_size_and_generation_reads_object_metadata():
+  storage_client = mock.Mock()
+  bucket = storage_client.bucket.return_value
+  blob = bucket.blob.return_value
+  blob.size = 1234
+  blob.generation = 17
+
+  with mock.patch(
+      'util.gcs_wrapper.storage.Client', return_value=storage_client
+  ):
+    gcs = GCS('combine_video', 'checksum', 'bucket')
+    result = gcs.get_size_and_generation('clips/input.mp4')
+
+  assert result == (1234, 17)
+  bucket.blob.assert_called_once_with('clips/input.mp4')
+  blob.reload.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    'generation', [None, False, 0], ids=['missing', 'boolean', 'zero']
+)
+def test_get_size_and_generation_rejects_invalid_generation(generation):
+  storage_client = mock.Mock()
+  blob = storage_client.bucket.return_value.blob.return_value
+  blob.size = 1
+  blob.generation = generation
+
+  with mock.patch(
+      'util.gcs_wrapper.storage.Client', return_value=storage_client
+  ):
+    gcs = GCS('combine_video', 'checksum', 'bucket')
+    with pytest.raises(ValueError, match='generation is unavailable'):
+      gcs.get_size_and_generation('clips/input.mp4')
+
+
+def test_save_locally_pins_the_measured_generation(tmp_path):
+  storage_client = mock.Mock()
+  bucket = storage_client.bucket.return_value
+  blob = bucket.blob.return_value
+  destination = tmp_path / 'input.mp4'
+
+  with mock.patch(
+      'util.gcs_wrapper.storage.Client', return_value=storage_client
+  ):
+    gcs = GCS('combine_video', 'checksum', 'bucket')
+    gcs.save_locally(
+        'clips/input.mp4', str(destination), if_generation_match=17
+    )
+
+  bucket.blob.assert_called_once_with('clips/input.mp4', generation=17)
+  blob.reload.assert_not_called()
+  blob.download_to_file.assert_called_once_with(
+      mock.ANY, if_generation_match=17
+  )

--- a/test/test_gcs_wrapper.py
+++ b/test/test_gcs_wrapper.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Cloud Storage wrapper."""
+
+import datetime
+from unittest import mock
+
+from util.gcs_wrapper import GCS
+
+
+def test_store_file_preserves_destination_ttl_and_content_type(tmp_path):
+  storage_client = mock.Mock()
+  bucket = storage_client.bucket.return_value
+  blob = bucket.blob.return_value
+  source = tmp_path / 'result.mp4'
+  source.write_bytes(b'video')
+
+  with mock.patch(
+      'util.gcs_wrapper.storage.Client', return_value=storage_client
+  ):
+    gcs = GCS('combine_video', 'checksum', 'bucket', ttl_days=3)
+    result = gcs.store_file(str(source), 'output.mp4', 'video/mp4')
+
+  assert result == 'combine_video/checksum/output.mp4'
+  bucket.blob.assert_called_once_with('combine_video/checksum/output.mp4')
+  blob.upload_from_filename.assert_called_once_with(
+      str(source), content_type='video/mp4'
+  )
+  expiry = datetime.datetime.fromisoformat(blob.metadata['timeToDelete'])
+  remaining = expiry - datetime.datetime.now(datetime.timezone.utc)
+  assert datetime.timedelta(days=2, hours=23) < remaining
+  assert remaining <= datetime.timedelta(days=3)

--- a/util/gcs_wrapper.py
+++ b/util/gcs_wrapper.py
@@ -19,7 +19,11 @@ provides standardised access.
 """
 
 import datetime
+import hashlib
 import io
+import pathlib
+import re
+from typing import Iterable
 from typing import Union
 
 from common import logger
@@ -29,6 +33,11 @@ from google.auth.transport import requests as transport_requests
 from google.cloud import storage
 
 SIGNED_URL_TTL_HOURS = 24
+
+# Cloud Run's writable filesystem uses the worker's 16G memory allocation.
+# Keep half available for FFmpeg, output files, and the Python process.
+MAX_LOCAL_INPUT_BYTES = 8 * 1024 * 1024 * 1024
+_MAX_LOCAL_EXTENSION_LENGTH = 10
 
 
 def get_signed_url(
@@ -166,18 +175,53 @@ class GCS:
       content = buffer.read()
       return content
 
-  def save_locally(self, filepath: str, local_file: str) -> None:
+  def save_locally(
+      self,
+      filepath: str,
+      local_file: str,
+      if_generation_match: int | None = None,
+  ) -> None:
     """Load data from the named location and save it to a local file.
 
     Args:
         filepath: The GCS path to the file to be read.
         local_file: The path where to save the file to.
+        if_generation_match: Download only this immutable object generation.
+    """
+    if if_generation_match is None:
+      gcs_blob = self.gcs_bucket.blob(filepath)
+      gcs_blob.reload()
+    else:
+      gcs_blob = self.gcs_bucket.blob(filepath, generation=if_generation_match)
+    destination = open(local_file, 'wb')
+    with destination as buffer:
+      gcs_blob.download_to_file(buffer, if_generation_match=if_generation_match)
+
+  def get_size_and_generation(self, filepath: str) -> tuple[int, int]:
+    """Returns the stored size and immutable generation of an object.
+
+    Args:
+        filepath: The GCS path to inspect.
+
+    Returns:
+        The object's size in bytes and its Cloud Storage generation.
+
+    Raises:
+        ValueError: The object metadata has no usable size or generation.
     """
     gcs_blob = self.gcs_bucket.blob(filepath)
     gcs_blob.reload()
-    destination = open(local_file, 'wb')
-    with destination as buffer:
-      gcs_blob.download_to_file(buffer)
+    size = gcs_blob.size
+    if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+      raise ValueError('Cloud Storage object size is unavailable')
+    generation = gcs_blob.generation
+    if (
+        isinstance(generation, bool)
+        or not isinstance(generation, int)
+        or generation <= 0
+    ):
+      raise ValueError('Cloud Storage object generation is unavailable')
+    return size, generation
 
   def get_mime_type(self, filepath: str) -> str:
     """Returns the MIME type of the named file.
@@ -225,3 +269,72 @@ class GCS:
       logger.error('Not a valid GCS URI: %s', uri)
       raise ValueError('Not a valid GCS URI')
     return uri[len(prefix) :]
+
+
+def _local_input_path(local_directory: str, filepath: str) -> pathlib.Path:
+  digest = hashlib.sha256(filepath.encode('utf-8')).hexdigest()
+  extension = pathlib.PurePosixPath(filepath).suffix.lower()
+  if not re.fullmatch(
+      rf'\.[a-z0-9]{{1,{_MAX_LOCAL_EXTENSION_LENGTH}}}', extension
+  ):
+    extension = ''
+  return pathlib.Path(local_directory, f'input-{digest}{extension}')
+
+
+def download_distinct_inputs(
+    gcs: GCS,
+    filepaths: Iterable[str],
+    local_directory: str,
+    max_total_bytes: int = MAX_LOCAL_INPUT_BYTES,
+) -> dict[str, str]:
+  """Downloads each distinct object once within an aggregate size limit.
+
+  Args:
+      gcs: The Cloud Storage wrapper to use.
+      filepaths: Object paths to download. Repeated paths reuse one local file.
+      local_directory: Request-owned directory for the downloaded files.
+      max_total_bytes: Largest permitted sum of distinct object sizes.
+
+  Returns:
+      A mapping from each distinct object path to its local path.
+
+  Raises:
+      ValueError: A path, size, or aggregate size is invalid.
+  """
+  if (
+      isinstance(max_total_bytes, bool)
+      or not isinstance(max_total_bytes, int)
+      or max_total_bytes <= 0
+  ):
+    raise ValueError('Local input size limit must be a positive integer')
+
+  local_paths: dict[str, str] = {}
+  generations: dict[str, int] = {}
+  used_local_paths: set[str] = set()
+  total_bytes = 0
+  for filepath in filepaths:
+    if not isinstance(filepath, str) or not filepath:
+      raise ValueError('Input media path must be a non-empty string')
+    if filepath in local_paths:
+      continue
+
+    size, generation = gcs.get_size_and_generation(filepath)
+    if size > max_total_bytes - total_bytes:
+      limit_gib = max_total_bytes // (1024 * 1024 * 1024)
+      raise ValueError(f'Input media exceeds the {limit_gib} GiB local limit')
+    total_bytes += size
+    local_path = str(_local_input_path(local_directory, filepath))
+    if local_path in used_local_paths:
+      raise ValueError('Distinct input paths produced the same local filename')
+    local_paths[filepath] = local_path
+    generations[filepath] = generation
+    used_local_paths.add(local_path)
+
+  for filepath, local_path in local_paths.items():
+    gcs.save_locally(
+        filepath,
+        local_path,
+        if_generation_match=generations[filepath],
+    )
+
+  return local_paths

--- a/util/gcs_wrapper.py
+++ b/util/gcs_wrapper.py
@@ -88,6 +88,15 @@ class GCS:
     self.path = f'{action}/{checksum}/'
     self.ttl_days = ttl_days
 
+  def _storage_target(self, name: str):
+    filepath = self.path + name
+    blob = self.gcs_bucket.blob(filepath)
+    time_to_delete = datetime.datetime.now(
+        datetime.timezone.utc
+    ) + datetime.timedelta(days=self.ttl_days)
+    blob.metadata = {'timeToDelete': time_to_delete.isoformat()}
+    return filepath, blob
+
   def store(self, data: Union[str, bytes], name: str, content_type: str) -> str:
     """Stores data at the default location.
 
@@ -99,18 +108,23 @@ class GCS:
     Returns:
         The path to the file written.
     """
-    filepath = self.path + name
-    file = self.gcs_bucket.blob(filepath)
-    metadata = {
-        'timeToDelete': (
-            (
-                datetime.datetime.now(datetime.timezone.utc)
-                + datetime.timedelta(days=self.ttl_days)
-            ).isoformat()
-        )
-    }
-    file.metadata = metadata
-    file.upload_from_string(data, content_type=content_type)
+    filepath, blob = self._storage_target(name)
+    blob.upload_from_string(data, content_type=content_type)
+    return filepath
+
+  def store_file(self, source: str, name: str, content_type: str) -> str:
+    """Stores a local file at the default location.
+
+    Args:
+        source: The local path to upload.
+        name: The filename to use in Cloud Storage.
+        content_type: The MIME type of the data.
+
+    Returns:
+        The path to the file written.
+    """
+    filepath, blob = self._storage_target(name)
+    blob.upload_from_filename(source, content_type=content_type)
     return filepath
 
   def load_text(self, filepath: str) -> str:


### PR DESCRIPTION
## Summary

Give each video conversion and combination call its own temporary directory, reuse identical inputs within a request, and upload completed outputs directly from disk. Concurrent requests cannot share local filenames or reuse stale probe results, while oversized input sets fail before download.

## Behavior

- Downloads each distinct Cloud Storage object once beneath a unique request directory and reuses that file for repeated arrangement entries.
- Rejects distinct inputs whose combined stored size exceeds 8 GiB before downloading any of them.
- Pins every download to the object generation measured during the size check, so replacing an object cannot bypass the aggregate limit.
- Uses a SHA-256 name plus an optional short alphanumeric extension for local inputs; each filename is at most 81 characters and does not copy object-path segments.
- Uploads converted and combined outputs from files while preserving their destination path, content type, and expiration metadata.
- Removes request-local inputs and outputs after both successful execution and errors.
- Removes the process-wide FFprobe path cache so each file is probed from its current contents.
- Does not change FFmpeg commands, codecs, MIME choices, or queue concurrency.

## Tests

- Covers simultaneous same-basename conversions and combinations, path-escape-like object names, thousand-character names and extensions, and request-local cleanup.
- Covers repeated large object references with one metadata read and one download, aggregate and single-input size rejection before FFmpeg, and generation-pinned downloads.
- Covers file-backed upload metadata and probing reused paths again.
- A current-head container smoke at `2e048469` ran two concurrent conversions and two reversed-order combinations through real Cloud Storage and FFmpeg 7.1.5. All outputs passed media, metadata, and cleanup checks; the temporary Job, objects, and image were removed afterward.

## Risks / Notes

- The 8 GiB limit applies per request. Output files and multiple concurrent requests can still exhaust the worker instance's in-memory filesystem.
