### PR TITLE
Recover transient post-action failures without rerunning completed work

### DIFF
--- a/actions_wrapper.py
+++ b/actions_wrapper.py
@@ -33,6 +33,7 @@ from common import Key
 from common import logger
 from common import NodeOutput
 from common import TypeNames
+from google.api_core import exceptions as google_exceptions
 from google.cloud import storage
 from util import checksum as util_checksum
 from util import dimensions as util_dimensions
@@ -42,6 +43,7 @@ from util.gcs_wrapper import GCS
 
 
 ActionFunction = Callable[..., NodeOutput]
+_FORCE_EXECUTION_TOKEN_METADATA_KEY = 'forceExecutionToken'
 
 
 def get_action_by_name(action_name: str) -> ActionFunction:
@@ -142,15 +144,20 @@ def _generate_error_output(
   return util_dimensions.rename_dimensions(final_output, dimensions_mapping)
 
 
-def _update(file: storage.Blob, final_output: dict[str, Any]) -> None:
+def _update(
+    file: storage.Blob,
+    final_output: dict[str, Any],
+    force_execution_token: str | None = None,
+) -> None:
   """Update the file with the generated output.
 
   Args:
     file: the file to update
     final_output: the output to store
+    force_execution_token: stable task token proving a forced action completed
   """
   json_string = json.dumps(final_output, indent=4)
-  file.metadata = {
+  metadata = {
       'timeToDelete': (
           (
               datetime.datetime.now(datetime.timezone.utc)
@@ -158,6 +165,9 @@ def _update(file: storage.Blob, final_output: dict[str, Any]) -> None:
           ).isoformat()
       )
   }
+  if force_execution_token:
+    metadata[_FORCE_EXECUTION_TOKEN_METADATA_KEY] = force_execution_token
+  file.metadata = metadata
   file.upload_from_string(json_string, content_type=ContentType.JSON.value)
 
 
@@ -180,6 +190,8 @@ def wrapper(func: ActionFunction) -> Callable[..., NodeOutput]:
       dimensions_mapping: dict[str, str],
       force_execution: bool = False,
       forward_retryable_error: bool = False,
+      force_execution_token: str | None = None,
+      recover_forced_cache: bool = False,
   ) -> NodeOutput:
     """Returns the result of function func.
 
@@ -199,6 +211,10 @@ def wrapper(func: ActionFunction) -> Callable[..., NodeOutput]:
         forward_retryable_error: Flag deciding whether to forward errors that
           are in principle retryable. A reason not to may be that the maximal
           number of attempts has been reached.
+        force_execution_token: Stable task token used to recover output only
+          when this forced execution previously completed.
+        recover_forced_cache: Whether this is a redelivery that may recover a
+          completed forced execution from cache.
 
     Returns:
         The output of the (potentially earlier) call to func.
@@ -216,13 +232,53 @@ def wrapper(func: ActionFunction) -> Callable[..., NodeOutput]:
     )
     filepath = f'{action_name}/{input_checksum}.json'
     file = gcs.gcs_bucket.blob(filepath)
-    if not force_execution and file.exists():
+    cache_exists = False
+    reuse_cache = False
+    cache_generation = None
+    if not force_execution or recover_forced_cache:
+      try:
+        cache_exists = file.exists()
+      except Exception as e:  # pylint: disable=broad-exception-caught
+        if force_execution and util_errors.is_retryable_task_recovery_error(e):
+          raise util_errors.RetryableTaskRecoveryError(
+              f'Failed to inspect forced-action cache {filepath}'
+          ) from e
+        raise
+      reuse_cache = cache_exists and not force_execution
+    if cache_exists and force_execution and force_execution_token:
+      try:
+        file.reload()
+        cache_generation = file.generation
+        reuse_cache = bool(
+            file.metadata
+            and file.metadata.get(_FORCE_EXECUTION_TOKEN_METADATA_KEY)
+            == force_execution_token
+            and cache_generation is not None
+        )
+      except Exception as e:  # pylint: disable=broad-exception-caught
+        if isinstance(e, google_exceptions.NotFound):
+          reuse_cache = False
+        elif util_errors.is_retryable_task_recovery_error(e):
+          raise util_errors.RetryableTaskRecoveryError(
+              f'Failed to inspect forced-action cache {filepath}'
+          ) from e
+        else:
+          raise
+    if reuse_cache:
       print(f'Reading cache {filepath}')
       # In case of cache-loading errors, treat the cache as non-existent:
       try:
+        if cache_generation is not None:
+          return json.loads(
+              file.download_as_string(if_generation_match=cache_generation)
+          )
         return json.loads(file.download_as_string())
       except Exception as e:  # pylint: disable=broad-exception-caught
         logger.warning('Failed to read cache file %s: %s', filepath, e)
+        if force_execution and util_errors.is_retryable_task_recovery_error(e):
+          raise util_errors.RetryableTaskRecoveryError(
+              f'Failed to read forced-action cache {filepath}'
+          ) from e
     # Function needs to be called, so see if it works:
     try:
       output = _generic_function_caller(
@@ -251,7 +307,9 @@ def wrapper(func: ActionFunction) -> Callable[..., NodeOutput]:
     final_output = util_dimensions.rename_dimensions(
         final_output, dimensions_mapping
     )
-    _update(file, final_output)
+    _update(
+        file, final_output, force_execution_token if force_execution else None
+    )
     print(f'Wrote file {filepath}')
     return final_output
 

--- a/actions_wrapper.py
+++ b/actions_wrapper.py
@@ -33,7 +33,6 @@ from common import Key
 from common import logger
 from common import NodeOutput
 from common import TypeNames
-from google.api_core import exceptions as google_exceptions
 from google.cloud import storage
 from util import checksum as util_checksum
 from util import dimensions as util_dimensions
@@ -43,7 +42,6 @@ from util.gcs_wrapper import GCS
 
 
 ActionFunction = Callable[..., NodeOutput]
-_FORCE_EXECUTION_TOKEN_METADATA_KEY = 'forceExecutionToken'
 
 
 def get_action_by_name(action_name: str) -> ActionFunction:
@@ -144,20 +142,15 @@ def _generate_error_output(
   return util_dimensions.rename_dimensions(final_output, dimensions_mapping)
 
 
-def _update(
-    file: storage.Blob,
-    final_output: dict[str, Any],
-    force_execution_token: str | None = None,
-) -> None:
+def _update(file: storage.Blob, final_output: dict[str, Any]) -> None:
   """Update the file with the generated output.
 
   Args:
     file: the file to update
     final_output: the output to store
-    force_execution_token: stable task token proving a forced action completed
   """
   json_string = json.dumps(final_output, indent=4)
-  metadata = {
+  file.metadata = {
       'timeToDelete': (
           (
               datetime.datetime.now(datetime.timezone.utc)
@@ -165,9 +158,6 @@ def _update(
           ).isoformat()
       )
   }
-  if force_execution_token:
-    metadata[_FORCE_EXECUTION_TOKEN_METADATA_KEY] = force_execution_token
-  file.metadata = metadata
   file.upload_from_string(json_string, content_type=ContentType.JSON.value)
 
 
@@ -190,8 +180,6 @@ def wrapper(func: ActionFunction) -> Callable[..., NodeOutput]:
       dimensions_mapping: dict[str, str],
       force_execution: bool = False,
       forward_retryable_error: bool = False,
-      force_execution_token: str | None = None,
-      recover_forced_cache: bool = False,
   ) -> NodeOutput:
     """Returns the result of function func.
 
@@ -211,10 +199,6 @@ def wrapper(func: ActionFunction) -> Callable[..., NodeOutput]:
         forward_retryable_error: Flag deciding whether to forward errors that
           are in principle retryable. A reason not to may be that the maximal
           number of attempts has been reached.
-        force_execution_token: Stable task token used to recover output only
-          when this forced execution previously completed.
-        recover_forced_cache: Whether this is a redelivery that may recover a
-          completed forced execution from cache.
 
     Returns:
         The output of the (potentially earlier) call to func.
@@ -232,53 +216,13 @@ def wrapper(func: ActionFunction) -> Callable[..., NodeOutput]:
     )
     filepath = f'{action_name}/{input_checksum}.json'
     file = gcs.gcs_bucket.blob(filepath)
-    cache_exists = False
-    reuse_cache = False
-    cache_generation = None
-    if not force_execution or recover_forced_cache:
-      try:
-        cache_exists = file.exists()
-      except Exception as e:  # pylint: disable=broad-exception-caught
-        if force_execution and util_errors.is_retryable_task_recovery_error(e):
-          raise util_errors.RetryableTaskRecoveryError(
-              f'Failed to inspect forced-action cache {filepath}'
-          ) from e
-        raise
-      reuse_cache = cache_exists and not force_execution
-    if cache_exists and force_execution and force_execution_token:
-      try:
-        file.reload()
-        cache_generation = file.generation
-        reuse_cache = bool(
-            file.metadata
-            and file.metadata.get(_FORCE_EXECUTION_TOKEN_METADATA_KEY)
-            == force_execution_token
-            and cache_generation is not None
-        )
-      except Exception as e:  # pylint: disable=broad-exception-caught
-        if isinstance(e, google_exceptions.NotFound):
-          reuse_cache = False
-        elif util_errors.is_retryable_task_recovery_error(e):
-          raise util_errors.RetryableTaskRecoveryError(
-              f'Failed to inspect forced-action cache {filepath}'
-          ) from e
-        else:
-          raise
-    if reuse_cache:
+    if not force_execution and file.exists():
       print(f'Reading cache {filepath}')
       # In case of cache-loading errors, treat the cache as non-existent:
       try:
-        if cache_generation is not None:
-          return json.loads(
-              file.download_as_string(if_generation_match=cache_generation)
-          )
         return json.loads(file.download_as_string())
       except Exception as e:  # pylint: disable=broad-exception-caught
         logger.warning('Failed to read cache file %s: %s', filepath, e)
-        if force_execution and util_errors.is_retryable_task_recovery_error(e):
-          raise util_errors.RetryableTaskRecoveryError(
-              f'Failed to read forced-action cache {filepath}'
-          ) from e
     # Function needs to be called, so see if it works:
     try:
       output = _generic_function_caller(
@@ -307,9 +251,12 @@ def wrapper(func: ActionFunction) -> Callable[..., NodeOutput]:
     final_output = util_dimensions.rename_dimensions(
         final_output, dimensions_mapping
     )
-    _update(
-        file, final_output, force_execution_token if force_execution else None
-    )
+    try:
+      _update(file, final_output)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      raise util_errors.TaskCompletionWriteError(
+          'Failed to store action output cache; refusing automatic action retry'
+      ) from e
     print(f'Wrote file {filepath}')
     return final_output
 

--- a/orch.py
+++ b/orch.py
@@ -324,12 +324,44 @@ def trigger_action_handler() -> tuple[str, int]:
         node,
     )
     return 'Already Triggered', 200
+  task_data = copy.deepcopy(data)
   try:
     orchestrator.trigger_action(
-        copy.deepcopy(data),
+        task_data,
         instance,
         retry_count < _MAX_ALLOWED_RETRIES,
+        retry_count > 0,
     )
+  except util_errors.RetryableTaskRecoveryError as e:
+    if retry_count < _MAX_ALLOWED_RETRIES:
+      logger.error(
+          'Retrying forced action cache recovery for %s: %s',
+          data[Key.ACTION.value],
+          e.__cause__ or e,
+      )
+      orchestrator.db.release_task_lock(execution_id, node_id, group_id)
+      return 'Service Unavailable', 503
+    logger.error(
+        'Retry limit reached during forced action cache recovery for %s: %s',
+        data[Key.ACTION.value],
+        e.__cause__ or e,
+    )
+    return 'Internal Error', 200
+  except util_errors.RetryablePostActionError as e:
+    if retry_count < _MAX_ALLOWED_RETRIES:
+      logger.error(
+          'Retrying completed action %s after infrastructure failure: %s',
+          data[Key.ACTION.value],
+          e.__cause__ or e,
+      )
+      orchestrator.db.release_task_lock(execution_id, node_id, group_id)
+      return 'Service Unavailable', 503
+    logger.error(
+        'Retry limit reached after completed action %s: %s',
+        data[Key.ACTION.value],
+        e.__cause__ or e,
+    )
+    return 'Internal Error', 200
   except Exception as e:  # pylint: disable=broad-exception-caught
     if util_errors.is_retryable(e):
       logger.error('Retrying action %s: %s', data[Key.ACTION.value], e)

--- a/orch.py
+++ b/orch.py
@@ -308,10 +308,18 @@ def trigger_action_handler() -> tuple[str, int]:
     # Malformed task payload (e.g. missing the Cloud Tasks lock fields): reject
     # cleanly instead of raising a KeyError below and returning a 500.
     return 'Bad Request', 400
+  queue_name = flask_request.headers.get('X-CloudTasks-QueueName')
+  task_name = flask_request.headers.get('X-CloudTasks-TaskName')
+  retry_count_header = flask_request.headers.get('X-CloudTasks-TaskRetryCount')
+  task_headers = (queue_name, task_name, retry_count_header)
+  task_header_presence = tuple(value is not None for value in task_headers)
+  if _ROLE == 'worker':
+    if not all(task_headers):
+      return 'Bad Request', 400
+  elif any(task_header_presence) and not all(task_headers):
+    return 'Bad Request', 400
   try:
-    retry_count = int(
-        flask_request.headers.get('X-CloudTasks-TaskRetryCount', 0)
-    )
+    retry_count = int(retry_count_header or 0)
   except (TypeError, ValueError):
     return 'Bad Request', 400
   if retry_count < 0:
@@ -324,10 +332,6 @@ def trigger_action_handler() -> tuple[str, int]:
   node_id = data[Key.NODE_ID.value]
   group_id = data[Key.GROUP_ID.value]
   node = data[Key.WORKFLOW_DEF.value][node_id]
-  queue_name = flask_request.headers.get('X-CloudTasks-QueueName')
-  task_name = flask_request.headers.get('X-CloudTasks-TaskName')
-  if bool(queue_name) != bool(task_name):
-    return 'Bad Request', 400
   task_identity = (
       ['cloud-tasks', queue_name, task_name]
       if queue_name and task_name
@@ -487,6 +491,7 @@ def trigger_action_handler() -> tuple[str, int]:
         data[Key.ACTION.value],
         e,
     )
+    mark_retryable(e, True)
     return 'Service Unavailable', 503
   if not task_succeeded:
     logger.error(

--- a/orch.py
+++ b/orch.py
@@ -43,6 +43,7 @@ optional; the defaults reproduce the single-service behavior exactly):
 
 import copy
 import datetime
+import hashlib
 import json
 import logging
 import os
@@ -70,8 +71,8 @@ from util import errors as util_errors
 from util import submission_validation
 from werkzeug.security import safe_join
 
-# At most the queue's allowed attempts minus one, so the workflow proceeds:
-_MAX_ALLOWED_RETRIES = 10
+# deploy.sh configures every worker queue with 30 total attempts.
+_MAX_TASK_ATTEMPTS = 30
 
 _ROLE = os.environ.get('ROLE', 'all')
 _AUTH_MODE = os.environ.get('AUTH_MODE', 'none')
@@ -307,14 +308,62 @@ def trigger_action_handler() -> tuple[str, int]:
     # Malformed task payload (e.g. missing the Cloud Tasks lock fields): reject
     # cleanly instead of raising a KeyError below and returning a 500.
     return 'Bad Request', 400
-  retry_count = int(flask_request.headers.get('X-CloudTasks-TaskRetryCount', 0))
+  try:
+    retry_count = int(
+        flask_request.headers.get('X-CloudTasks-TaskRetryCount', 0)
+    )
+  except (TypeError, ValueError):
+    return 'Bad Request', 400
+  if retry_count < 0:
+    return 'Bad Request', 400
   if retry_count > 0:
     logger.info('Retried %s %s times', data[Key.ACTION.value], retry_count)
+  attempt = retry_count + 1
+  can_retry = attempt < _MAX_TASK_ATTEMPTS
   execution_id = data[Key.EXECUTION_ID.value]
   node_id = data[Key.NODE_ID.value]
   group_id = data[Key.GROUP_ID.value]
   node = data[Key.WORKFLOW_DEF.value][node_id]
-  if not orchestrator.db.acquire_task_lock(execution_id, node_id, group_id):
+  queue_name = flask_request.headers.get('X-CloudTasks-QueueName')
+  task_name = flask_request.headers.get('X-CloudTasks-TaskName')
+  if bool(queue_name) != bool(task_name):
+    return 'Bad Request', 400
+  task_identity = (
+      ['cloud-tasks', queue_name, task_name]
+      if queue_name and task_name
+      else ['local']
+  )
+  task_identity.extend([execution_id, node_id, str(group_id)])
+  task_token = hashlib.sha256(
+      json.dumps(
+          task_identity, ensure_ascii=True, separators=(',', ':')
+      ).encode('utf-8')
+  ).hexdigest()
+  owner_token = uuid.uuid4().hex
+  try:
+    lock_outcome = orchestrator.db.acquire_task_lock(
+        execution_id,
+        node_id,
+        group_id,
+        task_token,
+        owner_token,
+        attempt,
+    )
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logger.error('Failed to claim action %s: %s', data[Key.ACTION.value], e)
+    return 'Service Unavailable', 503
+  if lock_outcome == util_database.TASK_LOCK_BUSY:
+    logger.warning(
+        '[%s] Node %s (group %s) is still running. Requesting redelivery.',
+        execution_id,
+        node_id,
+        group_id,
+    )
+    return 'Service Unavailable', 503
+  if lock_outcome not in (
+      util_database.TASK_LOCK_ACQUIRED,
+      util_database.TASK_LOCK_ACQUIRED_RECOVERY,
+  ):
     logger.warning(
         '[%s] Node %s (group %s) was already triggered. Skipping execution.'
         ' (%s)',
@@ -324,53 +373,123 @@ def trigger_action_handler() -> tuple[str, int]:
         node,
     )
     return 'Already Triggered', 200
+  recovery_only = lock_outcome == util_database.TASK_LOCK_ACQUIRED_RECOVERY
+
+  def error_summary(error: Exception) -> str:
+    cause = error.__cause__ or error
+    return f'{type(cause).__name__}: {cause}'[:1000]
+
+  def mark_retryable(
+      error: Exception, recovery_only: bool = False
+  ) -> bool:
+    try:
+      return orchestrator.db.mark_task_retryable(
+          execution_id,
+          node_id,
+          group_id,
+          task_token,
+          owner_token,
+          attempt,
+          error_summary(error),
+          recovery_only,
+      )
+    except Exception as state_error:  # pylint: disable=broad-exception-caught
+      logger.error(
+          'Failed to record retryable task state for %s: %s',
+          data[Key.ACTION.value],
+          state_error,
+      )
+      return False
+
+  def mark_failed(error: Exception) -> bool:
+    try:
+      return orchestrator.db.mark_task_failed(
+          execution_id,
+          node_id,
+          group_id,
+          task_token,
+          owner_token,
+          attempt,
+          error_summary(error),
+      )
+    except Exception as state_error:  # pylint: disable=broad-exception-caught
+      logger.error(
+          'Failed to record terminal task state for %s: %s',
+          data[Key.ACTION.value],
+          state_error,
+      )
+      return False
+
   task_data = copy.deepcopy(data)
   try:
     orchestrator.trigger_action(
         task_data,
         instance,
-        retry_count < _MAX_ALLOWED_RETRIES,
-        retry_count > 0,
+        can_retry,
+        task_token,
+        recovery_only,
     )
-  except util_errors.RetryableTaskRecoveryError as e:
-    if retry_count < _MAX_ALLOWED_RETRIES:
+  except (
+      util_errors.RetryableTaskRecoveryError,
+      util_errors.RetryablePostActionError,
+  ) as e:
+    if can_retry:
       logger.error(
-          'Retrying forced action cache recovery for %s: %s',
+          'Retrying task %s after infrastructure failure: %s',
           data[Key.ACTION.value],
           e.__cause__ or e,
       )
-      orchestrator.db.release_task_lock(execution_id, node_id, group_id)
+      mark_retryable(e, True)
       return 'Service Unavailable', 503
     logger.error(
-        'Retry limit reached during forced action cache recovery for %s: %s',
+        'Retry limit reached for task %s after infrastructure failure: %s',
         data[Key.ACTION.value],
         e.__cause__ or e,
     )
-    return 'Internal Error', 200
-  except util_errors.RetryablePostActionError as e:
-    if retry_count < _MAX_ALLOWED_RETRIES:
-      logger.error(
-          'Retrying completed action %s after infrastructure failure: %s',
-          data[Key.ACTION.value],
-          e.__cause__ or e,
-      )
-      orchestrator.db.release_task_lock(execution_id, node_id, group_id)
-      return 'Service Unavailable', 503
-    logger.error(
-        'Retry limit reached after completed action %s: %s',
-        data[Key.ACTION.value],
-        e.__cause__ or e,
-    )
-    return 'Internal Error', 200
+    if mark_failed(e):
+      return 'Internal Error', 200
+    return 'Service Unavailable', 503
   except Exception as e:  # pylint: disable=broad-exception-caught
     if util_errors.is_retryable(e):
-      logger.error('Retrying action %s: %s', data[Key.ACTION.value], e)
-      # Release the lock so that the retry can proceed
-      orchestrator.db.release_task_lock(execution_id, node_id, group_id)
-      return 'Quota Exceeded', 429  # Cloud Tasks may retry this
+      if can_retry:
+        logger.error('Retrying action %s: %s', data[Key.ACTION.value], e)
+        if mark_retryable(e):
+          return 'Quota Exceeded', 429
+        return 'Service Unavailable', 503
+      logger.error(
+          'Retry limit reached for action %s: %s',
+          data[Key.ACTION.value],
+          e,
+      )
+      if mark_failed(e):
+        return 'Internal Error', 200
+      return 'Service Unavailable', 503
     else:
       logger.error('Fatal error for action %s: %s', data[Key.ACTION.value], e)
+      mark_failed(e)
       return 'Internal Error', 200  # Cloud Tasks will NOT retry this
+  try:
+    task_succeeded = orchestrator.db.mark_task_succeeded(
+        execution_id,
+        node_id,
+        group_id,
+        task_token,
+        owner_token,
+        attempt,
+    )
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logger.error(
+        'Failed to record completed task state for %s: %s',
+        data[Key.ACTION.value],
+        e,
+    )
+    return 'Service Unavailable', 503
+  if not task_succeeded:
+    logger.error(
+        'Task ownership changed before completion was recorded for %s',
+        data[Key.ACTION.value],
+    )
+    return 'Service Unavailable', 503
   return (
       (
           f'Action {data[Key.ACTION.value]} triggered for'

--- a/orch.py
+++ b/orch.py
@@ -430,6 +430,7 @@ def trigger_action_handler() -> tuple[str, int]:
         recovery_only,
     )
   except (
+      util_errors.RetryablePreActionProbeError,
       util_errors.RetryableTaskRecoveryError,
       util_errors.RetryablePostActionError,
   ) as e:
@@ -439,7 +440,10 @@ def trigger_action_handler() -> tuple[str, int]:
           data[Key.ACTION.value],
           e.__cause__ or e,
       )
-      mark_retryable(e, True)
+      mark_retryable(
+          e,
+          not isinstance(e, util_errors.RetryablePreActionProbeError),
+      )
       return 'Service Unavailable', 503
     logger.error(
         'Retry limit reached for task %s after infrastructure failure: %s',

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -52,7 +52,6 @@ _TASKS_QUEUE_CLASS_DEFAULT = 'Other'
 _TASK_DISPATCH_DEADLINE_SECONDS = 1800
 _GCS_HOST = 'https://storage.mtls.cloud.google.com/'
 _TASK_COMPLETION_PREFIX = '_task-completions'
-_TASK_COMPLETION_TTL_DAYS = 14
 
 
 if os.environ.get('K_SERVICE'):
@@ -304,7 +303,6 @@ def _task_completion_blob(data: dict[str, Any], task_token: str):
       _TASK_COMPLETION_PREFIX,
       task_token,
       bucket_name,
-      _TASK_COMPLETION_TTL_DAYS,
   )
   return gcs.gcs_bucket.blob(f'{_TASK_COMPLETION_PREFIX}/{task_token}.json')
 
@@ -315,7 +313,7 @@ def _load_task_completion(
   """Loads an immutable task output without falling back to execution."""
   blob = _task_completion_blob(data, task_token)
   try:
-    blob.reload()
+    manifest = blob.download_as_bytes()
   except google_exceptions.NotFound:
     if recovery_only:
       raise util_errors.RetryableTaskRecoveryError(
@@ -324,20 +322,10 @@ def _load_task_completion(
     return None
   except Exception as e:  # pylint: disable=broad-exception-caught
     raise util_errors.RetryableTaskRecoveryError(
-        'Failed to inspect task completion output'
+        'Failed to read task completion output'
     ) from e
-
-  generation = blob.generation
-  if (
-      isinstance(generation, bool)
-      or not isinstance(generation, int)
-      or generation <= 0
-  ):
-    raise util_errors.RetryableTaskRecoveryError(
-        'Task completion output has an invalid generation'
-    )
   try:
-    output = json.loads(blob.download_as_string(if_generation_match=generation))
+    output = json.loads(manifest)
     if not isinstance(output, dict):
       raise TypeError('Task completion output must be a JSON object')
     return output
@@ -352,14 +340,6 @@ def _store_task_completion(
 ) -> dict[str, Any]:
   """Creates the immutable output used by later task deliveries."""
   blob = _task_completion_blob(data, task_token)
-  blob.metadata = {
-      'timeToDelete': (
-          (
-              datetime.datetime.now(datetime.timezone.utc)
-              + datetime.timedelta(days=_TASK_COMPLETION_TTL_DAYS)
-          ).isoformat()
-      )
-  }
   try:
     blob.upload_from_string(
         json.dumps(output),

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -414,7 +414,14 @@ def trigger_action(
   else:  # For pass action, simply forward
     func = lambda input_files, *_: input_files
   task_token = task_token or _local_task_token(data)
-  output = _load_task_completion(data, task_token, recovery_only)
+  try:
+    output = _load_task_completion(data, task_token, recovery_only)
+  except util_errors.RetryableTaskRecoveryError as e:
+    if recovery_only:
+      raise
+    raise util_errors.RetryablePreActionProbeError(str(e)) from (
+        e.__cause__ or e
+    )
   if output is None:
     output = func(
         data[Key.INPUT_FILES.value],

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -16,6 +16,7 @@
 
 import copy
 import datetime
+import hashlib
 import json
 import logging
 import os
@@ -35,6 +36,7 @@ import google.oauth2.id_token
 import requests
 from util import database
 from util import dimensions as util_dimensions
+from util import errors as util_errors
 from util import gcs_wrapper
 from util import group_input
 from util import workflow as util_workflow
@@ -280,6 +282,7 @@ def trigger_action(
     data: dict[str, Any],
     instance: str | None = None,
     can_still_retry: bool = False,
+    recover_forced_cache: bool = False,
 ) -> None:
   """Triggers an action's execution.
 
@@ -287,6 +290,8 @@ def trigger_action(
     data: The workfload description.
     instance: The address of the Cloud Run instance to use.
     can_still_retry: Flag specifying whether failure would be final.
+    recover_forced_cache: Whether a redelivery may reuse this forced task's
+      completed cache output.
   """
   action = data[Key.ACTION.value]
   node_id = data[Key.NODE_ID.value]
@@ -305,6 +310,13 @@ def trigger_action(
     func = actwrap.wrapper(actwrap.get_action_by_name(action))
   else:  # For pass action, simply forward
     func = lambda input_files, *_: input_files
+  force_execution_token = hashlib.sha256(
+      json.dumps(
+          [execution_id, node_id, group_id],
+          ensure_ascii=True,
+          separators=(',', ':'),
+      ).encode('utf-8')
+  ).hexdigest()
   output = func(
       data[Key.INPUT_FILES.value],
       data.get(Key.PARAMETERS.value, {}),
@@ -313,11 +325,20 @@ def trigger_action(
       node.get(Key.DIMENSIONS_MAPPING.value, {}),
       data[Key.FORCE_EXECUTION.value],
       can_still_retry,
+      force_execution_token,
+      recover_forced_cache,
   )
 
-  db.store_output(execution_id, node_id, group_id, output)
-  logger.info((execution_id, 'PERFORMED', node, action, output))
-  _inform_successors(instance, data, output)
+  try:
+    db.store_output(execution_id, node_id, group_id, output)
+    logger.info((execution_id, 'PERFORMED', node, action, output))
+    _inform_successors(instance, data, output)
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    if util_errors.is_transient_infrastructure_error(e):
+      raise util_errors.RetryablePostActionError(
+          'Transient infrastructure failure after action completion'
+      ) from e
+    raise
 
 
 def get_status(

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -29,6 +29,7 @@ import uuid
 import actions_wrapper as actwrap
 from common import ContentType
 from common import Key
+from google.api_core import exceptions as google_exceptions
 import google.auth.transport.requests
 from google.cloud import tasks_v2
 import google.cloud.logging
@@ -48,7 +49,10 @@ ENDPOINT_SUPPLY_NODE = 'supplyNode'
 ENDPOINT_TRIGGER_ACTION = 'triggerAction'
 
 _TASKS_QUEUE_CLASS_DEFAULT = 'Other'
+_TASK_DISPATCH_DEADLINE_SECONDS = 1800
 _GCS_HOST = 'https://storage.mtls.cloud.google.com/'
+_TASK_COMPLETION_PREFIX = '_task-completions'
+_TASK_COMPLETION_TTL_DAYS = 14
 
 
 if os.environ.get('K_SERVICE'):
@@ -211,7 +215,7 @@ def supply_node(
                     service_account_email=service_account_email
                 ),
             ),
-            dispatch_deadline={'seconds': 1800},
+            dispatch_deadline={'seconds': _TASK_DISPATCH_DEADLINE_SECONDS},
         )
         client.create_task(parent=queue_path, task=task)
       else:
@@ -270,7 +274,7 @@ def _inform_successors(
                   service_account_email=service_account_email
               ),
           ),
-          dispatch_deadline={'seconds': 1800},
+          dispatch_deadline={'seconds': _TASK_DISPATCH_DEADLINE_SECONDS},
       )
       client.create_task(parent=queue_path, task=task)
     else:
@@ -278,11 +282,110 @@ def _inform_successors(
       thread.start()
 
 
+def _local_task_token(data: dict[str, Any]) -> str:
+  """Builds a stable task identity for the in-process development path."""
+  return hashlib.sha256(
+      json.dumps(
+          [
+              'local',
+              data[Key.EXECUTION_ID.value],
+              data[Key.NODE_ID.value],
+              str(data[Key.GROUP_ID.value]),
+          ],
+          ensure_ascii=True,
+          separators=(',', ':'),
+      ).encode('utf-8')
+  ).hexdigest()
+
+
+def _task_completion_blob(data: dict[str, Any], task_token: str):
+  bucket_name = data[Key.WORKFLOW_PARAMS.value][Key.GCS_BUCKET.value]
+  gcs = gcs_wrapper.GCS(
+      _TASK_COMPLETION_PREFIX,
+      task_token,
+      bucket_name,
+      _TASK_COMPLETION_TTL_DAYS,
+  )
+  return gcs.gcs_bucket.blob(f'{_TASK_COMPLETION_PREFIX}/{task_token}.json')
+
+
+def _load_task_completion(
+    data: dict[str, Any], task_token: str, recovery_only: bool = False
+) -> dict[str, Any] | None:
+  """Loads an immutable task output without falling back to execution."""
+  blob = _task_completion_blob(data, task_token)
+  try:
+    blob.reload()
+  except google_exceptions.NotFound:
+    if recovery_only:
+      raise util_errors.RetryableTaskRecoveryError(
+          'Required task completion output is missing'
+      )
+    return None
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    raise util_errors.RetryableTaskRecoveryError(
+        'Failed to inspect task completion output'
+    ) from e
+
+  generation = blob.generation
+  if (
+      isinstance(generation, bool)
+      or not isinstance(generation, int)
+      or generation <= 0
+  ):
+    raise util_errors.RetryableTaskRecoveryError(
+        'Task completion output has an invalid generation'
+    )
+  try:
+    output = json.loads(blob.download_as_string(if_generation_match=generation))
+    if not isinstance(output, dict):
+      raise TypeError('Task completion output must be a JSON object')
+    return output
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    raise util_errors.RetryableTaskRecoveryError(
+        'Failed to read task completion output'
+    ) from e
+
+
+def _store_task_completion(
+    data: dict[str, Any], task_token: str, output: dict[str, Any]
+) -> dict[str, Any]:
+  """Creates the immutable output used by later task deliveries."""
+  blob = _task_completion_blob(data, task_token)
+  blob.metadata = {
+      'timeToDelete': (
+          (
+              datetime.datetime.now(datetime.timezone.utc)
+              + datetime.timedelta(days=_TASK_COMPLETION_TTL_DAYS)
+          ).isoformat()
+      )
+  }
+  try:
+    blob.upload_from_string(
+        json.dumps(output),
+        content_type=ContentType.JSON.value,
+        if_generation_match=0,
+    )
+    return output
+  except google_exceptions.PreconditionFailed:
+    existing = _load_task_completion(data, task_token)
+    if existing is None:
+      raise util_errors.RetryableTaskRecoveryError(
+          'Task completion output disappeared after create conflict'
+      )
+    return existing
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    raise util_errors.TaskCompletionWriteError(
+        'Failed to prove task completion; refusing automatic action retry'
+    ) from e
+
+
 def trigger_action(
     data: dict[str, Any],
     instance: str | None = None,
     can_still_retry: bool = False,
-    recover_forced_cache: bool = False,
+    task_token: str | None = None,
+    recovery_only: bool = False,
 ) -> None:
   """Triggers an action's execution.
 
@@ -290,8 +393,8 @@ def trigger_action(
     data: The workfload description.
     instance: The address of the Cloud Run instance to use.
     can_still_retry: Flag specifying whether failure would be final.
-    recover_forced_cache: Whether a redelivery may reuse this forced task's
-      completed cache output.
+    task_token: Stable identity shared by deliveries of one Cloud Task.
+    recovery_only: Whether executing the action is forbidden for this delivery.
   """
   action = data[Key.ACTION.value]
   node_id = data[Key.NODE_ID.value]
@@ -310,24 +413,19 @@ def trigger_action(
     func = actwrap.wrapper(actwrap.get_action_by_name(action))
   else:  # For pass action, simply forward
     func = lambda input_files, *_: input_files
-  force_execution_token = hashlib.sha256(
-      json.dumps(
-          [execution_id, node_id, group_id],
-          ensure_ascii=True,
-          separators=(',', ':'),
-      ).encode('utf-8')
-  ).hexdigest()
-  output = func(
-      data[Key.INPUT_FILES.value],
-      data.get(Key.PARAMETERS.value, {}),
-      data[Key.WORKFLOW_PARAMS.value],
-      node.get(Key.DIMENSIONS_CONSUMED.value, []),
-      node.get(Key.DIMENSIONS_MAPPING.value, {}),
-      data[Key.FORCE_EXECUTION.value],
-      can_still_retry,
-      force_execution_token,
-      recover_forced_cache,
-  )
+  task_token = task_token or _local_task_token(data)
+  output = _load_task_completion(data, task_token, recovery_only)
+  if output is None:
+    output = func(
+        data[Key.INPUT_FILES.value],
+        data.get(Key.PARAMETERS.value, {}),
+        data[Key.WORKFLOW_PARAMS.value],
+        node.get(Key.DIMENSIONS_CONSUMED.value, []),
+        node.get(Key.DIMENSIONS_MAPPING.value, {}),
+        data[Key.FORCE_EXECUTION.value],
+        can_still_retry,
+    )
+    output = _store_task_completion(data, task_token, output)
 
   try:
     db.store_output(execution_id, node_id, group_id, output)

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -310,7 +310,7 @@ def _task_completion_blob(data: dict[str, Any], task_token: str):
 def _load_task_completion(
     data: dict[str, Any], task_token: str, recovery_only: bool = False
 ) -> dict[str, Any] | None:
-  """Loads an immutable task output without falling back to execution."""
+  """Loads a task-specific output without falling back to execution."""
   blob = _task_completion_blob(data, task_token)
   try:
     manifest = blob.download_as_bytes()
@@ -321,14 +321,28 @@ def _load_task_completion(
       )
     return None
   except Exception as e:  # pylint: disable=broad-exception-caught
-    raise util_errors.RetryableTaskRecoveryError(
-        'Failed to read task completion output'
-    ) from e
+    retryable_error = (
+        util_errors.RetryableTaskRecoveryError
+        if recovery_only
+        else util_errors.RetryablePreActionProbeError
+    )
+    raise retryable_error('Failed to read task completion output') from e
   try:
     output = json.loads(manifest)
     if not isinstance(output, dict):
       raise TypeError('Task completion output must be a JSON object')
     return output
+  # Known content failures repeat for the same object. Unexpected local parser
+  # failures may be transient, so only the known failures are terminal.
+  except (ValueError, TypeError, RecursionError) as e:
+    logger.error(
+        'Invalid task completion output at gs://%s/%s/%s.json: %s',
+        data[Key.WORKFLOW_PARAMS.value][Key.GCS_BUCKET.value],
+        _TASK_COMPLETION_PREFIX,
+        task_token,
+        e,
+    )
+    raise
   except Exception as e:  # pylint: disable=broad-exception-caught
     raise util_errors.RetryableTaskRecoveryError(
         'Failed to read task completion output'
@@ -338,7 +352,7 @@ def _load_task_completion(
 def _store_task_completion(
     data: dict[str, Any], task_token: str, output: dict[str, Any]
 ) -> dict[str, Any]:
-  """Creates the immutable output used by later task deliveries."""
+  """Creates the task-specific output used by later task deliveries."""
   blob = _task_completion_blob(data, task_token)
   try:
     blob.upload_from_string(
@@ -348,12 +362,7 @@ def _store_task_completion(
     )
     return output
   except google_exceptions.PreconditionFailed:
-    existing = _load_task_completion(data, task_token)
-    if existing is None:
-      raise util_errors.RetryableTaskRecoveryError(
-          'Task completion output disappeared after create conflict'
-      )
-    return existing
+    return _load_task_completion(data, task_token, recovery_only=True)
   except Exception as e:  # pylint: disable=broad-exception-caught
     raise util_errors.TaskCompletionWriteError(
         'Failed to prove task completion; refusing automatic action retry'
@@ -394,14 +403,7 @@ def trigger_action(
   else:  # For pass action, simply forward
     func = lambda input_files, *_: input_files
   task_token = task_token or _local_task_token(data)
-  try:
-    output = _load_task_completion(data, task_token, recovery_only)
-  except util_errors.RetryableTaskRecoveryError as e:
-    if recovery_only:
-      raise
-    raise util_errors.RetryablePreActionProbeError(str(e)) from (
-        e.__cause__ or e
-    )
+  output = _load_task_completion(data, task_token, recovery_only)
   if output is None:
     output = func(
         data[Key.INPUT_FILES.value],

--- a/test/test_engine_characterization.py
+++ b/test/test_engine_characterization.py
@@ -110,6 +110,10 @@ class _FakeBlob:
       raise google_exceptions.PreconditionFailed('generation changed')
     return self.objects[self.path]
 
+  def download_as_bytes(self):
+    data = self.download_as_string()
+    return data.encode('utf-8') if isinstance(data, str) else data
+
 
 class _FakeGCS:
   """Stand-in for util.gcs_wrapper.GCS in the action wrapper."""

--- a/test/test_engine_characterization.py
+++ b/test/test_engine_characterization.py
@@ -40,14 +40,15 @@ import copy
 import importlib
 import json
 import pathlib
-import threading
 import time
 from typing import Any
 from unittest import mock
 
+from google.api_core import exceptions as google_exceptions
 import pytest
 
 from test import firestore_fake
+from util import errors as util_errors
 
 _REPO = pathlib.Path(__file__).resolve().parent.parent
 _CONFIG_PATH = _REPO / 'ui' / 'definitions' / 'config.json'
@@ -62,8 +63,6 @@ _WORKFLOW_PARAMS = {
 # Generous deadline for thread-driven flows; tests poll and fail fast on
 # success, so the full deadline is only ever consumed by a real regression.
 _DEADLINE_SECONDS = 15.0
-# Deadline used when asserting that something does NOT happen.
-_QUIET_SECONDS = 1.5
 
 
 def _wait_for(predicate, timeout=_DEADLINE_SECONDS, interval=0.02):
@@ -414,54 +413,39 @@ def test_join_seal_rejects_late_arrivals(engine):
 
 
 # ---------------------------------------------------------------------------
-# CHARACTERIZATION: join-token loss (findings §1.5, manifest ORC-11) — when a
-# failure escapes the action wrapper's containment (here: db.store_output
-# raising), the group's join token is silently dropped and the downstream
-# node waits forever. There is no watchdog. This pins the CURRENT behavior;
-# the intended fix (containment around the orchestration layer) is a
-# deliberate, separately-reviewed change.
+# INVARIANT: once an action has returned, a transient output-write failure is
+# marked for the HTTP handler to release the task lock and request redelivery.
+# Local mode has no Cloud Tasks retry loop, so this test pins the orchestration
+# boundary; handler-driven recovery is covered in test_frontdoor.py.
 # ---------------------------------------------------------------------------
-@pytest.mark.filterwarnings(
-    'ignore::pytest.PytestUnhandledThreadExceptionWarning'
-)
-def test_token_loss_on_store_output_failure_stalls_downstream(
+def test_store_output_deadline_is_marked_after_action_completion(
     engine, monkeypatch
 ):
-  # The injected store_output failure escapes inside a worker thread by
-  # design (that escape IS the behavior under test), so the unhandled-
-  # thread-exception warning is expected here and suppressed.
-  storyboard_calls = []
-  _register_outpaint(engine)
-  _register_storyboard(engine, storyboard_calls)
+  action_calls = []
+  _register_outpaint(engine, calls=action_calls)
 
-  real_store_output = engine.db.store_output
-  failed = threading.Event()
+  def unavailable(*_args, **_kwargs):
+    raise google_exceptions.DeadlineExceeded('Firestore deadline exceeded')
 
-  def flaky_store_output(execution_id, node_id, group_id, output):
-    if node_id == 'n_outpaint' and str(group_id) == '0' and not failed.is_set():
-      failed.set()
-      raise RuntimeError('simulated Firestore outage')
-    return real_store_output(execution_id, node_id, group_id, output)
+  monkeypatch.setattr(engine.db, 'store_output', unavailable)
+  data = {
+      'action': 'outpaint_image',
+      'executionId': 'store-output-retry',
+      'nodeId': 'n_outpaint',
+      'groupId': 0,
+      'inputFiles': {'image': _images(1)},
+      'parameters': {},
+      'workflowDefinition': _outpaint_dag(),
+      'workflowParams': dict(_WORKFLOW_PARAMS),
+      'forceExecution': True,
+      'siblingActions': 1,
+  }
 
-  monkeypatch.setattr(engine.db, 'store_output', flaky_store_output)
+  with pytest.raises(util_errors.RetryablePostActionError) as raised:
+    engine.orchestrator.trigger_action(data)
 
-  execution_id = engine.run(
-      _payload(
-          _storyboard_dag(),
-          {
-              'images': _images(2),
-              'user_prompt': [{'file': 'uploads/brief.txt'}],
-          },
-      )
-  )
-
-  assert _wait_for(failed.is_set)
-  # The successor never fires and the sink never produces output: the
-  # workflow is permanently stalled (current behavior — no watchdog).
-  assert not _wait_for(
-      lambda: storyboard_calls or engine.sink_output(execution_id),
-      timeout=_QUIET_SECONDS,
-  )
+  assert isinstance(raised.value.__cause__, google_exceptions.DeadlineExceeded)
+  assert len(action_calls) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_engine_characterization.py
+++ b/test/test_engine_characterization.py
@@ -76,27 +76,52 @@ def _wait_for(predicate, timeout=_DEADLINE_SECONDS, interval=0.02):
 
 
 class _FakeBlob:
-  """Cache blob that never exists and swallows writes."""
+  """In-memory blob with create-only and generation-match behavior."""
 
-  def __init__(self):
+  def __init__(self, path, objects, generations):
+    self.path = path
+    self.objects = objects
+    self.generations = generations
     self.metadata = None
+    self.generation = None
 
   def exists(self):
-    return False
+    return self.path in self.objects
 
-  def upload_from_string(self, *_args, **_kwargs):
-    pass
+  def reload(self):
+    if self.path not in self.objects:
+      raise google_exceptions.NotFound('object not found')
+    self.generation = self.generations[self.path]
 
-  def download_as_string(self):
-    raise AssertionError('cache read attempted on a non-existent fake blob')
+  def upload_from_string(self, data, if_generation_match=None, **_kwargs):
+    if if_generation_match == 0 and self.path in self.objects:
+      raise google_exceptions.PreconditionFailed('object already exists')
+    self.objects[self.path] = data
+    self.generations[self.path] = self.generations.get(self.path, 0) + 1
+    self.generation = self.generations[self.path]
+
+  def download_as_string(self, if_generation_match=None):
+    if self.path not in self.objects:
+      raise google_exceptions.NotFound('object not found')
+    if (
+        if_generation_match is not None
+        and if_generation_match != self.generations[self.path]
+    ):
+      raise google_exceptions.PreconditionFailed('generation changed')
+    return self.objects[self.path]
 
 
 class _FakeGCS:
   """Stand-in for util.gcs_wrapper.GCS in the action wrapper."""
 
+  objects = {}
+  generations = {}
+
   def __init__(self, *_args, **_kwargs):
     self.gcs_bucket = mock.Mock()
-    self.gcs_bucket.blob = lambda _path: _FakeBlob()
+    self.gcs_bucket.blob = lambda path: _FakeBlob(
+        path, self.objects, self.generations
+    )
 
 
 @pytest.fixture(scope='module')
@@ -148,6 +173,8 @@ def engine(orch, monkeypatch):
   actions_wrapper_module = importlib.import_module('actions_wrapper')
 
   fresh_db = database_module.Database('characterization-test')
+  _FakeGCS.objects = {}
+  _FakeGCS.generations = {}
   monkeypatch.setattr(orch, 'db', fresh_db)
   monkeypatch.setattr(gcs_wrapper_module, 'GCS', _FakeGCS)
 
@@ -412,12 +439,6 @@ def test_join_seal_rejects_late_arrivals(engine):
   assert files == {}
 
 
-# ---------------------------------------------------------------------------
-# INVARIANT: once an action has returned, a transient output-write failure is
-# marked for the HTTP handler to release the task lock and request redelivery.
-# Local mode has no Cloud Tasks retry loop, so this test pins the orchestration
-# boundary; handler-driven recovery is covered in test_frontdoor.py.
-# ---------------------------------------------------------------------------
 def test_store_output_deadline_is_marked_after_action_completion(
     engine, monkeypatch
 ):

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -22,6 +22,8 @@ import google.api_core.exceptions as google_exceptions
 from google.genai import errors as genai_errors
 
 from util.errors import is_retryable
+from util.errors import is_retryable_task_recovery_error
+from util.errors import is_transient_infrastructure_error
 
 
 def _genai_error(status_code):
@@ -56,6 +58,15 @@ def test_genai_400_is_not_retryable():
   assert is_retryable(_genai_error(400)) is False
 
 
+def test_genai_500_is_not_retryable():
+  e = genai_errors.ServerError(
+      500,
+      {'error': {'code': 500, 'status': 'INTERNAL', 'message': 'failed'}},
+      None,
+  )
+  assert is_retryable(e) is False
+
+
 def test_api_core_resource_exhausted_is_retryable():
   assert is_retryable(google_exceptions.ResourceExhausted('quota')) is True
 
@@ -70,3 +81,31 @@ def test_api_core_too_many_requests_is_retryable():
 
 def test_plain_exception_is_not_retryable():
   assert is_retryable(ValueError('nope')) is False
+
+
+def test_api_core_server_errors_are_transient_infrastructure():
+  for error in (
+      google_exceptions.DeadlineExceeded('deadline'),
+      google_exceptions.InternalServerError('internal'),
+      google_exceptions.ServiceUnavailable('unavailable'),
+  ):
+    assert is_transient_infrastructure_error(error) is True
+
+
+def test_api_core_retry_error_unwraps_transient_cause():
+  error = google_exceptions.RetryError(
+      'retry deadline exceeded',
+      cause=google_exceptions.ServiceUnavailable('unavailable'),
+  )
+  assert is_transient_infrastructure_error(error) is True
+
+
+def test_task_recovery_retries_exhausted_client_retries():
+  for cause in (
+      google_exceptions.TooManyRequests('quota'),
+      ConnectionError('connection reset'),
+  ):
+    error = google_exceptions.RetryError('retry deadline exceeded', cause=cause)
+    assert is_retryable_task_recovery_error(error) is True
+
+  assert is_retryable_task_recovery_error(ValueError('invalid cache')) is False

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -100,6 +100,15 @@ def test_api_core_retry_error_unwraps_transient_cause():
   assert is_transient_infrastructure_error(error) is True
 
 
+def test_api_core_retry_error_unwraps_resource_exhausted():
+  error = google_exceptions.RetryError(
+      'retry deadline exceeded',
+      cause=google_exceptions.ResourceExhausted('quota'),
+  )
+  assert is_transient_infrastructure_error(error) is True
+  assert is_retryable(error) is True
+
+
 def test_task_recovery_retries_exhausted_client_retries():
   for cause in (
       google_exceptions.TooManyRequests('quota'),

--- a/test/test_frontdoor.py
+++ b/test/test_frontdoor.py
@@ -263,63 +263,61 @@ def _task_payload(
   }
 
 
+def _task_headers(
+    queue_name='queue-test', task_name='task-test', retry_count=0
+):
+  return {
+      'X-CloudTasks-QueueName': queue_name,
+      'X-CloudTasks-TaskName': task_name,
+      'X-CloudTasks-TaskRetryCount': str(retry_count),
+  }
+
+
 def _install_action_cache(
     monkeypatch,
     orch,
     cache,
     *,
     exists_errors=None,
-    reload_errors=None,
     download_errors=None,
-    download_overwrite=None,
     action_upload_errors=None,
     completion_upload_errors=None,
 ):
   """Installs an in-memory action cache for trigger-action tests."""
   cache_metadata = {}
-  cache_generations = {}
+  completion_downloads = []
   pending_exists_errors = list(exists_errors or [])
-  pending_reload_errors = list(reload_errors or [])
   pending_download_errors = list(download_errors or [])
   pending_action_upload_errors = list(action_upload_errors or [])
   pending_completion_upload_errors = list(completion_upload_errors or [])
-  overwrite_pending = download_overwrite is not None
 
   class CacheBlob:
 
     def __init__(self, path):
       self.path = path
       self.metadata = None
-      self.generation = None
 
     def exists(self):
       if pending_exists_errors:
         raise pending_exists_errors.pop(0)
       return self.path in cache
 
-    def reload(self):
-      if pending_reload_errors:
-        raise pending_reload_errors.pop(0)
-      if self.path not in cache:
-        raise google_exceptions.NotFound('cache object not found')
-      self.metadata = cache_metadata.get(self.path)
-      self.generation = cache_generations.get(self.path)
-
-    def download_as_string(self, if_generation_match=None, **_kwargs):
-      nonlocal overwrite_pending
+    def _download(self):
       if pending_download_errors:
         raise pending_download_errors.pop(0)
-      if overwrite_pending:
-        cache[self.path] = json.dumps(download_overwrite)
-        cache_metadata[self.path] = {}
-        cache_generations[self.path] = cache_generations.get(self.path, 0) + 1
-        overwrite_pending = False
-      if (
-          if_generation_match is not None
-          and if_generation_match != cache_generations.get(self.path)
-      ):
-        raise google_exceptions.PreconditionFailed('generation changed')
+      if self.path not in cache:
+        raise google_exceptions.NotFound('cache object not found')
       return cache[self.path]
+
+    def download_as_string(self, **_kwargs):
+      if self.path.startswith('_task-completions/'):
+        raise AssertionError('completion manifests must use download_as_bytes')
+      return self._download()
+
+    def download_as_bytes(self, **_kwargs):
+      completion_downloads.append(self.path)
+      data = self._download()
+      return data.encode('utf-8') if isinstance(data, str) else data
 
     def upload_from_string(self, data, if_generation_match=None, **_kwargs):
       if (
@@ -336,7 +334,6 @@ def _install_action_cache(
         raise google_exceptions.PreconditionFailed('object already exists')
       cache[self.path] = data
       cache_metadata[self.path] = self.metadata
-      cache_generations[self.path] = cache_generations.get(self.path, 0) + 1
 
   class CacheBucket:
 
@@ -350,8 +347,8 @@ def _install_action_cache(
 
   monkeypatch.setattr(orch.orchestrator.actwrap.gcs_wrapper, 'GCS', CacheGcs)
   return {
+      'completion_downloads': completion_downloads,
       'metadata': cache_metadata,
-      'generations': cache_generations,
   }
 
 
@@ -461,7 +458,7 @@ def test_task_state_ambiguous_retryable_state_is_recovery_only(
   )
 
 
-def test_task_completion_is_create_only_and_generation_pinned(
+def test_task_completion_is_create_only_without_false_expiry_metadata(
     monkeypatch, orchestrator_module
 ):
   del orchestrator_module
@@ -477,12 +474,10 @@ def test_task_completion_is_create_only_and_generation_pinned(
       == output
   )
   completion_path = f'_task-completions/{task_token}.json'
-  first_generation = cache_state['generations'][completion_path]
   assert (
       orch.orchestrator._store_task_completion(payload, task_token, output)
       == output
   )
-  assert cache_state['generations'][completion_path] == first_generation
   competing_output = {'video': [{'file': 'generated/other.mp4'}]}
   assert (
       orch.orchestrator._store_task_completion(
@@ -490,11 +485,12 @@ def test_task_completion_is_create_only_and_generation_pinned(
       )
       == output
   )
-  assert cache_state['generations'][completion_path] == first_generation
-
-  cache_state['generations'][completion_path] = True
-  with pytest.raises(orch.util_errors.RetryableTaskRecoveryError):
-    orch.orchestrator._load_task_completion(payload, task_token)
+  assert json.loads(cache[completion_path]) == output
+  assert cache_state['completion_downloads'] == [
+      completion_path,
+      completion_path,
+  ]
+  assert cache_state['metadata'][completion_path] is None
 
 
 def test_task_completion_upload_error_refuses_automatic_action_retry(
@@ -554,10 +550,7 @@ def test_manifest_upload_failure_records_terminal_without_rerunning_action(
       action='outpaint_image',
       force_execution=True,
   )
-  headers = {
-      'X-CloudTasks-QueueName': 'queue-upload',
-      'X-CloudTasks-TaskName': 'task-upload',
-  }
+  headers = _task_headers('queue-upload', 'task-upload')
   client = orch.app.test_client()
 
   first = client.post('/triggerAction', json=payload, headers=headers)
@@ -618,10 +611,7 @@ def test_action_cache_upload_failure_records_terminal_without_rerunning_action(
       action='outpaint_image',
       force_execution=True,
   )
-  headers = {
-      'X-CloudTasks-QueueName': 'queue-action-cache',
-      'X-CloudTasks-TaskName': 'task-action-cache',
-  }
+  headers = _task_headers('queue-action-cache', 'task-action-cache')
   client = orch.app.test_client()
 
   first = client.post('/triggerAction', json=payload, headers=headers)
@@ -648,67 +638,6 @@ def test_action_cache_upload_failure_records_terminal_without_rerunning_action(
   assert 'GCS write quota exhausted' in state['error']
 
 
-def test_task_completion_generation_race_retries_without_running_action(
-    monkeypatch, orchestrator_module
-):
-  del orchestrator_module
-  orch = _load_orch(monkeypatch, ROLE='worker')
-  payload = _task_payload(
-      execution_id='completion-generation-race',
-      action='outpaint_image',
-      force_execution=True,
-  )
-  headers = {
-      'X-CloudTasks-QueueName': 'queue-generation',
-      'X-CloudTasks-TaskName': 'task-generation',
-  }
-  task_token = hashlib.sha256(
-      json.dumps(
-          [
-              'cloud-tasks',
-              'queue-generation',
-              'task-generation',
-              'completion-generation-race',
-              'node-1',
-              'group-1',
-          ],
-          ensure_ascii=True,
-          separators=(',', ':'),
-      ).encode('utf-8')
-  ).hexdigest()
-  completion_path = f'_task-completions/{task_token}.json'
-  original_output = {'outpainted_image': [{'file': 'generated/first.png'}]}
-  cache = {completion_path: json.dumps(original_output)}
-  cache_state = _install_action_cache(
-      monkeypatch,
-      orch,
-      cache,
-      download_overwrite={
-          'outpainted_image': [{'file': 'generated/replaced.png'}]
-      },
-  )
-  cache_state['generations'][completion_path] = 1
-  action_calls = []
-
-  def paid_action(_gcs, _workflow_params):
-    action_calls.append('called')
-    return original_output
-
-  paid_action.__module__ = 'actions.outpaint_image'
-  monkeypatch.setattr(
-      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
-  )
-  transitions = _install_task_state(monkeypatch, orch)
-
-  response = orch.app.test_client().post(
-      '/triggerAction', json=payload, headers=headers
-  )
-
-  assert response.status_code == 503
-  assert action_calls == []
-  assert [state for state, _args in transitions] == ['retryable']
-
-
 def test_worker_url_overrides_host_for_trigger_action(
     monkeypatch, orchestrator_module
 ):
@@ -728,7 +657,11 @@ def test_worker_url_overrides_host_for_trigger_action(
   monkeypatch.setattr(orch.orchestrator, 'trigger_action', fake_trigger_action)
   transitions = _install_task_state(monkeypatch, orch)
   client = orch.app.test_client()
-  response = client.post('/triggerAction', json=_task_payload())
+  response = client.post(
+      '/triggerAction',
+      json=_task_payload(),
+      headers=_task_headers('queue-worker-url', 'task-worker-url'),
+  )
   assert response.status_code == 200
   assert captured['instance'] == worker_url
   assert captured['recovery_only'] is False
@@ -755,7 +688,11 @@ def test_trigger_action_duplicate_delivery_is_skipped(
       monkeypatch, orch, outcome=orch.util_database.TASK_LOCK_TERMINAL
   )
   client = orch.app.test_client()
-  response = client.post('/triggerAction', json=_task_payload())
+  response = client.post(
+      '/triggerAction',
+      json=_task_payload(),
+      headers=_task_headers('queue-duplicate', 'task-duplicate'),
+  )
   assert response.status_code == 200
   assert response.get_data(as_text=True) == 'Already Triggered'
   assert called['trigger'] is False
@@ -774,7 +711,11 @@ def test_trigger_action_retryable_error_records_retryable_state(
   monkeypatch.setattr(orch.orchestrator, 'trigger_action', boom)
   monkeypatch.setattr(orch.util_errors, 'is_retryable', lambda _e: True)
   client = orch.app.test_client()
-  response = client.post('/triggerAction', json=_task_payload())
+  response = client.post(
+      '/triggerAction',
+      json=_task_payload(),
+      headers=_task_headers('queue-retryable', 'task-retryable'),
+  )
   assert response.status_code == 429
   assert [state for state, _args in transitions] == ['retryable']
   assert transitions[0][1][-1] is False
@@ -794,7 +735,11 @@ def test_trigger_action_post_action_deadline_records_retryable_state(
 
   monkeypatch.setattr(orch.orchestrator.db, 'store_output', unavailable)
 
-  response = orch.app.test_client().post('/triggerAction', json=_task_payload())
+  response = orch.app.test_client().post(
+      '/triggerAction',
+      json=_task_payload(),
+      headers=_task_headers('queue-post-action', 'task-post-action'),
+  )
 
   assert response.status_code == 503
   assert [state for state, _args in transitions] == ['retryable']
@@ -827,11 +772,11 @@ def test_fresh_manifest_probe_retry_rechecks_before_action(
   monkeypatch.setattr(
       orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
   )
-  cache_state = _install_action_cache(
+  _install_action_cache(
       monkeypatch,
       orch,
       cache,
-      reload_errors=[google_exceptions.ServiceUnavailable('GCS unavailable')],
+      download_errors=[google_exceptions.ServiceUnavailable('GCS unavailable')],
   )
   monkeypatch.setattr(
       orch.orchestrator.db,
@@ -843,10 +788,7 @@ def test_fresh_manifest_probe_retry_rechecks_before_action(
       action='outpaint_image',
       force_execution=True,
   )
-  headers = {
-      'X-CloudTasks-QueueName': 'queue-fresh-probe',
-      'X-CloudTasks-TaskName': f'task-{manifest_on_retry}',
-  }
+  headers = _task_headers('queue-fresh-probe', f'task-{manifest_on_retry}')
   client = orch.app.test_client()
 
   first = client.post('/triggerAction', json=payload, headers=headers)
@@ -857,7 +799,6 @@ def test_fresh_manifest_probe_retry_rechecks_before_action(
   completion_path = f'_task-completions/{retryable_state["taskToken"]}.json'
   if manifest_on_retry:
     cache[completion_path] = json.dumps(output)
-    cache_state['generations'][completion_path] = 1
   retry = client.post(
       '/triggerAction',
       json=payload,
@@ -896,10 +837,7 @@ def test_fatal_action_is_acknowledged_without_retrying_paid_work(
       orch.orchestrator.db, 'mark_task_failed', fail_terminal_transition
   )
   payload = _task_payload(execution_id=f'fatal-{transition_failure}')
-  headers = {
-      'X-CloudTasks-QueueName': 'queue-fatal',
-      'X-CloudTasks-TaskName': f'task-fatal-{transition_failure}',
-  }
+  headers = _task_headers('queue-fatal', f'task-fatal-{transition_failure}')
   client = orch.app.test_client()
 
   first = client.post('/triggerAction', json=payload, headers=headers)
@@ -967,10 +905,7 @@ def test_failed_retryable_transition_never_drops_or_releases_new_owner(
       action='outpaint_image',
       force_execution=True,
   )
-  headers = {
-      'X-CloudTasks-QueueName': 'queue-state',
-      'X-CloudTasks-TaskName': 'task-state',
-  }
+  headers = _task_headers('queue-state', 'task-state')
   client = orch.app.test_client()
 
   first = client.post('/triggerAction', json=payload, headers=headers)
@@ -1019,9 +954,8 @@ def test_failed_retryable_transition_never_drops_or_releases_new_owner(
   assert late_transition is False
 
 
-@pytest.mark.parametrize('transition_failure', ('exception', 'lost-owner'))
-def test_failed_success_transition_redelivers_and_recovers_manifest(
-    monkeypatch, orchestrator_module, transition_failure
+def test_success_transition_error_marks_task_recovery_only(
+    monkeypatch, orchestrator_module
 ):
   del orchestrator_module
   orch = _load_orch(monkeypatch, ROLE='worker')
@@ -1046,23 +980,139 @@ def test_failed_success_transition_redelivers_and_recovers_manifest(
     nonlocal transition_attempts
     transition_attempts += 1
     if transition_attempts == 1:
-      if transition_failure == 'exception':
-        raise google_exceptions.DeadlineExceeded('Firestore unavailable')
-      return False
+      raise google_exceptions.DeadlineExceeded('Firestore unavailable')
     return real_mark_succeeded(*args, **kwargs)
 
   monkeypatch.setattr(
       orch.orchestrator.db, 'mark_task_succeeded', fail_first_transition
   )
   payload = _task_payload(
-      execution_id=f'success-transition-{transition_failure}',
+      execution_id='success-transition-error',
       action='outpaint_image',
       force_execution=True,
   )
-  headers = {
-      'X-CloudTasks-QueueName': 'queue-success-state',
-      'X-CloudTasks-TaskName': f'task-success-{transition_failure}',
-  }
+  headers = _task_headers('queue-success-state', 'task-success-error')
+  client = orch.app.test_client()
+
+  first = client.post('/triggerAction', json=payload, headers=headers)
+  lock_ref = orch.orchestrator.db._get_task_lock_ref(
+      payload['executionId'], 'node-1', 'group-1'
+  )
+  retryable_state = lock_ref.get().to_dict()
+  recovered = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={**headers, 'X-CloudTasks-TaskRetryCount': '1'},
+  )
+  final_state = lock_ref.get().to_dict()
+
+  assert first.status_code == 503
+  assert recovered.status_code == 200
+  assert action_calls == ['called']
+  assert transition_attempts == 2
+  assert retryable_state['state'] == 'retryable'
+  assert retryable_state['recoveryOnly'] is True
+  assert final_state['state'] == 'succeeded'
+
+
+def test_ambiguous_success_commit_cannot_reopen_succeeded_task(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  cache = {}
+  action_calls = []
+  output = {'outpainted_image': [{'file': 'generated/one.png'}]}
+
+  def paid_action(_gcs, _workflow_params):
+    action_calls.append('called')
+    return output
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  _install_action_cache(monkeypatch, orch, cache)
+  monkeypatch.setattr(orch.orchestrator.db, 'store_output', lambda *_args: None)
+  real_mark_succeeded = orch.orchestrator.db.mark_task_succeeded
+  transition_attempts = 0
+
+  def commit_then_raise(*args, **kwargs):
+    nonlocal transition_attempts
+    transition_attempts += 1
+    result = real_mark_succeeded(*args, **kwargs)
+    if transition_attempts == 1:
+      raise google_exceptions.DeadlineExceeded('response lost after commit')
+    return result
+
+  monkeypatch.setattr(
+      orch.orchestrator.db, 'mark_task_succeeded', commit_then_raise
+  )
+  payload = _task_payload(
+      execution_id='success-transition-ambiguous',
+      action='outpaint_image',
+      force_execution=True,
+  )
+  headers = _task_headers('queue-success-state', 'task-success-ambiguous')
+  client = orch.app.test_client()
+
+  first = client.post('/triggerAction', json=payload, headers=headers)
+  redelivery = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={**headers, 'X-CloudTasks-TaskRetryCount': '1'},
+  )
+  lock_ref = orch.orchestrator.db._get_task_lock_ref(
+      payload['executionId'], 'node-1', 'group-1'
+  )
+  final_state = lock_ref.get().to_dict()
+
+  assert first.status_code == 503
+  assert redelivery.status_code == 200
+  assert redelivery.get_data(as_text=True) == 'Already Triggered'
+  assert action_calls == ['called']
+  assert transition_attempts == 1
+  assert final_state['state'] == 'succeeded'
+
+
+def test_lost_success_transition_recovers_manifest_after_lease(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  cache = {}
+  action_calls = []
+  output = {'outpainted_image': [{'file': 'generated/one.png'}]}
+
+  def paid_action(_gcs, _workflow_params):
+    action_calls.append('called')
+    return output
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  _install_action_cache(monkeypatch, orch, cache)
+  monkeypatch.setattr(orch.orchestrator.db, 'store_output', lambda *_args: None)
+  real_mark_succeeded = orch.orchestrator.db.mark_task_succeeded
+  transition_attempts = 0
+
+  def lose_first_transition(*args, **kwargs):
+    nonlocal transition_attempts
+    transition_attempts += 1
+    if transition_attempts == 1:
+      return False
+    return real_mark_succeeded(*args, **kwargs)
+
+  monkeypatch.setattr(
+      orch.orchestrator.db, 'mark_task_succeeded', lose_first_transition
+  )
+  payload = _task_payload(
+      execution_id='success-transition-lost-owner',
+      action='outpaint_image',
+      force_execution=True,
+  )
+  headers = _task_headers('queue-success-state', 'task-success-lost-owner')
   client = orch.app.test_client()
 
   first = client.post('/triggerAction', json=payload, headers=headers)
@@ -1270,10 +1320,7 @@ def test_trigger_action_completed_manifest_read_failure_never_regenerates(
   monkeypatch.setattr(orch.orchestrator.db, 'store_output', store_once)
   payload = _task_payload(action='outpaint_image', force_execution=True)
   client = orch.app.test_client()
-  headers = {
-      'X-CloudTasks-QueueName': 'queue-a',
-      'X-CloudTasks-TaskName': 'task-a',
-  }
+  headers = _task_headers('queue-a', 'task-a')
   responses = [client.post('/triggerAction', json=payload, headers=headers)]
   for retry_count in (1, 2):
     responses.append(
@@ -1335,10 +1382,7 @@ def test_recovery_only_state_never_regenerates_a_missing_manifest(
       action='outpaint_image',
       force_execution=True,
   )
-  headers = {
-      'X-CloudTasks-QueueName': 'queue-recovery-only',
-      'X-CloudTasks-TaskName': 'task-recovery-only',
-  }
+  headers = _task_headers('queue-recovery-only', 'task-recovery-only')
   client = orch.app.test_client()
 
   first = client.post('/triggerAction', json=payload, headers=headers)
@@ -1404,10 +1448,7 @@ def test_trigger_action_redelivery_reruns_failed_forced_action(
   cache_path = f'outpaint_image/{checksum}.json'
   cache[cache_path] = json.dumps(stale_output)
   client = orch.app.test_client()
-  task_headers = {
-      'X-CloudTasks-QueueName': 'queue-rerun',
-      'X-CloudTasks-TaskName': 'task-rerun',
-  }
+  task_headers = _task_headers('queue-rerun', 'task-rerun')
 
   first = client.post('/triggerAction', json=payload, headers=task_headers)
   retry = client.post(
@@ -1506,7 +1547,11 @@ def test_trigger_action_non_forced_reuses_legacy_cache(
   )
   cache[f'outpaint_image/{checksum}.json'] = json.dumps(legacy_output)
 
-  response = orch.app.test_client().post('/triggerAction', json=payload)
+  response = orch.app.test_client().post(
+      '/triggerAction',
+      json=payload,
+      headers=_task_headers('queue-legacy-cache', 'task-legacy-cache'),
+  )
 
   assert response.status_code == 200
   assert action_calls == []
@@ -1569,12 +1614,13 @@ def test_trigger_action_enqueue_retry_completes_successor_once(
       },
   })
   client = orch.app.test_client()
+  headers = _task_headers('queue-enqueue-retry', 'task-enqueue-retry')
 
-  first = client.post('/triggerAction', json=payload)
+  first = client.post('/triggerAction', json=payload, headers=headers)
   retry = client.post(
       '/triggerAction',
       json=payload,
-      headers={'X-CloudTasks-TaskRetryCount': '1'},
+      headers={**headers, 'X-CloudTasks-TaskRetryCount': '1'},
   )
   for successor_payload in successor_deliveries:
     assert client.post('/supplyNode', json=successor_payload).status_code == 200
@@ -1604,7 +1650,11 @@ def test_trigger_action_non_retryable_error_records_failed_state(
   monkeypatch.setattr(orch.orchestrator, 'trigger_action', boom)
   monkeypatch.setattr(orch.util_errors, 'is_retryable', lambda _e: False)
   client = orch.app.test_client()
-  response = client.post('/triggerAction', json=_task_payload())
+  response = client.post(
+      '/triggerAction',
+      json=_task_payload(),
+      headers=_task_headers('queue-fatal-state', 'task-fatal-state'),
+  )
   assert response.status_code == 200
   assert response.get_data(as_text=True) == 'Internal Error'
   assert [state for state, _args in transitions] == ['failed']
@@ -1624,7 +1674,11 @@ def test_trigger_action_rejects_malformed_payload(
       lambda *a, **k: called.__setitem__('trigger', True),
   )
   client = orch.app.test_client()
-  response = client.post('/triggerAction', json={'action': 'pass'})
+  response = client.post(
+      '/triggerAction',
+      json={'action': 'pass'},
+      headers=_task_headers('queue-malformed', 'task-malformed'),
+  )
   assert response.status_code == 400
   assert called['trigger'] is False
 
@@ -1632,10 +1686,19 @@ def test_trigger_action_rejects_malformed_payload(
 @pytest.mark.parametrize(
     'headers',
     (
+        {},
         {'X-CloudTasks-QueueName': 'queue-only'},
         {'X-CloudTasks-TaskName': 'task-only'},
-        {'X-CloudTasks-TaskRetryCount': 'not-an-integer'},
-        {'X-CloudTasks-TaskRetryCount': '-1'},
+        {
+            'X-CloudTasks-QueueName': 'queue-without-retry',
+            'X-CloudTasks-TaskName': 'task-without-retry',
+        },
+        {'X-CloudTasks-TaskRetryCount': '0'},
+        _task_headers(queue_name=''),
+        _task_headers(task_name=''),
+        _task_headers(retry_count=''),
+        _task_headers(retry_count='not-an-integer'),
+        _task_headers(retry_count=-1),
     ),
 )
 def test_trigger_action_rejects_incomplete_task_headers(
@@ -1644,6 +1707,12 @@ def test_trigger_action_rejects_incomplete_task_headers(
   del orchestrator_module
   orch = _load_orch(monkeypatch, ROLE='worker')
   called = []
+  lock_calls = []
+  monkeypatch.setattr(
+      orch.orchestrator.db,
+      'acquire_task_lock',
+      lambda *_args, **_kwargs: lock_calls.append(True),
+  )
   monkeypatch.setattr(
       orch.orchestrator,
       'trigger_action',
@@ -1655,7 +1724,28 @@ def test_trigger_action_rejects_incomplete_task_headers(
   )
 
   assert response.status_code == 400
+  assert lock_calls == []
   assert called == []
+
+
+def test_role_all_allows_headerless_local_trigger_action(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='all')
+  action_calls = []
+  monkeypatch.setattr(
+      orch.orchestrator,
+      'trigger_action',
+      lambda *_args, **_kwargs: action_calls.append(True),
+  )
+  transitions = _install_task_state(monkeypatch, orch)
+
+  response = orch.app.test_client().post('/triggerAction', json=_task_payload())
+
+  assert response.status_code == 200
+  assert action_calls == [True]
+  assert [state for state, _args in transitions] == ['succeeded']
 
 
 def test_trigger_action_attempt_limit_matches_deploy_queue(

--- a/test/test_frontdoor.py
+++ b/test/test_frontdoor.py
@@ -801,6 +801,79 @@ def test_trigger_action_post_action_deadline_records_retryable_state(
   assert transitions[0][1][-1] is True
 
 
+@pytest.mark.parametrize(
+    ('manifest_on_retry', 'expected_action_calls'),
+    ((False, ['called']), (True, [])),
+    ids=('manifest-missing-executes-once', 'manifest-present-skips-action'),
+)
+def test_fresh_manifest_probe_retry_rechecks_before_action(
+    monkeypatch,
+    orchestrator_module,
+    manifest_on_retry,
+    expected_action_calls,
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  cache = {}
+  output = {'outpainted_image': [{'file': 'generated/image.png'}]}
+  action_calls = []
+  stored_outputs = []
+
+  def paid_action(_gcs, _workflow_params):
+    action_calls.append('called')
+    return output
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  cache_state = _install_action_cache(
+      monkeypatch,
+      orch,
+      cache,
+      reload_errors=[google_exceptions.ServiceUnavailable('GCS unavailable')],
+  )
+  monkeypatch.setattr(
+      orch.orchestrator.db,
+      'store_output',
+      lambda *args: stored_outputs.append(args[-1]),
+  )
+  payload = _task_payload(
+      execution_id=f'fresh-probe-{manifest_on_retry}',
+      action='outpaint_image',
+      force_execution=True,
+  )
+  headers = {
+      'X-CloudTasks-QueueName': 'queue-fresh-probe',
+      'X-CloudTasks-TaskName': f'task-{manifest_on_retry}',
+  }
+  client = orch.app.test_client()
+
+  first = client.post('/triggerAction', json=payload, headers=headers)
+  lock_ref = orch.orchestrator.db._get_task_lock_ref(
+      payload['executionId'], 'node-1', 'group-1'
+  )
+  retryable_state = lock_ref.get().to_dict()
+  completion_path = f'_task-completions/{retryable_state["taskToken"]}.json'
+  if manifest_on_retry:
+    cache[completion_path] = json.dumps(output)
+    cache_state['generations'][completion_path] = 1
+  retry = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={**headers, 'X-CloudTasks-TaskRetryCount': '1'},
+  )
+  final_state = lock_ref.get().to_dict()
+
+  assert first.status_code == 503
+  assert retry.status_code == 200
+  assert action_calls == expected_action_calls
+  assert stored_outputs == [output]
+  assert retryable_state['state'] == 'retryable'
+  assert retryable_state['recoveryOnly'] is False
+  assert final_state['state'] == 'succeeded'
+
+
 @pytest.mark.parametrize('transition_failure', ('exception', 'lost-owner'))
 def test_fatal_action_is_acknowledged_without_retrying_paid_work(
     monkeypatch, orchestrator_module, transition_failure

--- a/test/test_frontdoor.py
+++ b/test/test_frontdoor.py
@@ -31,6 +31,7 @@ import json
 import pathlib
 import sys
 
+from google.api_core import exceptions as google_exceptions
 import pytest
 
 from test import firestore_fake
@@ -240,18 +241,90 @@ def test_worker_url_overrides_host_for_supply_node(
 
 
 def _task_payload(
-    execution_id='exec-worker', node_id='node-1', group_id='group-1'
+    execution_id='exec-worker',
+    node_id='node-1',
+    group_id='group-1',
+    action='pass',
+    force_execution=False,
 ):
   """A valid Cloud Tasks /triggerAction payload, including the PR #113 lock
   fields (executionId / nodeId / groupId / workflowDefinition)."""
   return {
-      'action': 'pass',
+      'action': action,
       'inputFiles': {},
       'executionId': execution_id,
       'nodeId': node_id,
       'groupId': group_id,
-      'workflowDefinition': {node_id: {'action': 'pass'}},
+      'workflowDefinition': {node_id: {'action': action}},
+      'workflowParams': {'gcsBucket': 'test-bucket'},
+      'forceExecution': force_execution,
   }
+
+
+def _install_action_cache(
+    monkeypatch,
+    orch,
+    cache,
+    *,
+    exists_errors=None,
+    download_errors=None,
+    download_overwrite=None,
+):
+  """Installs an in-memory action cache for trigger-action tests."""
+  cache_metadata = {}
+  cache_generations = {}
+  pending_exists_errors = list(exists_errors or [])
+  pending_download_errors = list(download_errors or [])
+  overwrite_pending = download_overwrite is not None
+
+  class CacheBlob:
+
+    def __init__(self, path):
+      self.path = path
+      self.metadata = None
+      self.generation = None
+
+    def exists(self):
+      if pending_exists_errors:
+        raise pending_exists_errors.pop(0)
+      return self.path in cache
+
+    def reload(self):
+      self.metadata = cache_metadata.get(self.path)
+      self.generation = cache_generations.get(self.path)
+
+    def download_as_string(self, if_generation_match=None, **_kwargs):
+      nonlocal overwrite_pending
+      if pending_download_errors:
+        raise pending_download_errors.pop(0)
+      if overwrite_pending:
+        cache[self.path] = json.dumps(download_overwrite)
+        cache_metadata[self.path] = {}
+        cache_generations[self.path] = cache_generations.get(self.path, 0) + 1
+        overwrite_pending = False
+      if (
+          if_generation_match is not None
+          and if_generation_match != cache_generations.get(self.path)
+      ):
+        raise google_exceptions.PreconditionFailed('generation changed')
+      return cache[self.path]
+
+    def upload_from_string(self, data, **_kwargs):
+      cache[self.path] = data
+      cache_metadata[self.path] = self.metadata
+      cache_generations[self.path] = cache_generations.get(self.path, 0) + 1
+
+  class CacheBucket:
+
+    def blob(self, path):
+      return CacheBlob(path)
+
+  class CacheGcs:
+
+    def __init__(self, *_args, **_kwargs):
+      self.gcs_bucket = CacheBucket()
+
+  monkeypatch.setattr(orch.orchestrator.actwrap.gcs_wrapper, 'GCS', CacheGcs)
 
 
 def test_worker_url_overrides_host_for_trigger_action(
@@ -263,10 +336,11 @@ def test_worker_url_overrides_host_for_trigger_action(
 
   captured = {}
 
-  def fake_trigger_action(data, instance, may_retry):
+  def fake_trigger_action(data, instance, may_retry, recover_forced_cache):
     captured['data'] = data
     captured['instance'] = instance
     captured['may_retry'] = may_retry
+    captured['recover_forced_cache'] = recover_forced_cache
 
   monkeypatch.setattr(orch.orchestrator, 'trigger_action', fake_trigger_action)
   # First valid delivery acquires the PR #113 Cloud Tasks lock and runs.
@@ -278,6 +352,7 @@ def test_worker_url_overrides_host_for_trigger_action(
   assert response.status_code == 200
   assert captured['instance'] == worker_url
   assert captured['may_retry'] is True
+  assert captured['recover_forced_cache'] is False
 
 
 def test_trigger_action_duplicate_delivery_is_skipped(
@@ -331,6 +406,330 @@ def test_trigger_action_retryable_error_releases_lock(
   response = client.post('/triggerAction', json=_task_payload())
   assert response.status_code == 429
   assert len(released) == 1
+
+
+def test_trigger_action_post_action_deadline_releases_lock(
+    monkeypatch, orchestrator_module
+):
+  """A transient output-write failure is retried after the action completes."""
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  released = []
+  monkeypatch.setattr(
+      orch.orchestrator.db, 'acquire_task_lock', lambda *a, **k: True
+  )
+  monkeypatch.setattr(
+      orch.orchestrator.db,
+      'release_task_lock',
+      lambda *a, **k: released.append(a),
+  )
+
+  def unavailable(*_args, **_kwargs):
+    raise google_exceptions.DeadlineExceeded('Firestore deadline exceeded')
+
+  monkeypatch.setattr(orch.orchestrator.db, 'store_output', unavailable)
+
+  response = orch.app.test_client().post('/triggerAction', json=_task_payload())
+
+  assert response.status_code == 503
+  assert released == [('exec-worker', 'node-1', 'group-1')]
+
+
+@pytest.mark.parametrize(
+    'scenario',
+    ('normal', 'lookup_error', 'download_error', 'generation_race'),
+)
+def test_trigger_action_redelivery_recovers_forced_action_cache(
+    monkeypatch, orchestrator_module, scenario
+):
+  """Forced recovery is task-scoped, race-safe, and retryable."""
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  first_output = {'outpainted_image': [{'file': 'generated/first.png'}]}
+  rerun_output = {'outpainted_image': [{'file': 'generated/rerun.png'}]}
+  concurrent_output = {'outpainted_image': [{'file': 'other/task.png'}]}
+  cache = {}
+  action_calls = []
+  released = []
+  stored_outputs = []
+  store_attempts = 0
+
+  def paid_action(_gcs, _workflow_params):
+    action_calls.append('called')
+    return first_output if len(action_calls) == 1 else rerun_output
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  _install_action_cache(
+      monkeypatch,
+      orch,
+      cache,
+      exists_errors=(
+          [
+              google_exceptions.RetryError(
+                  'GCS retry deadline exhausted',
+                  google_exceptions.TooManyRequests('GCS quota exhausted'),
+              )
+          ]
+          if scenario == 'lookup_error'
+          else None
+      ),
+      download_errors=(
+          [
+              google_exceptions.RetryError(
+                  'GCS retry deadline exhausted',
+                  ConnectionError('GCS connection reset'),
+              )
+          ]
+          if scenario == 'download_error'
+          else None
+      ),
+      download_overwrite=(
+          concurrent_output if scenario == 'generation_race' else None
+      ),
+  )
+  monkeypatch.setattr(
+      orch.orchestrator.db, 'acquire_task_lock', lambda *_a, **_k: True
+  )
+  monkeypatch.setattr(
+      orch.orchestrator.db,
+      'release_task_lock',
+      lambda *args, **_kwargs: released.append(args),
+  )
+
+  def store_once(*args):
+    nonlocal store_attempts
+    store_attempts += 1
+    if store_attempts == 1:
+      raise google_exceptions.DeadlineExceeded('Firestore deadline exceeded')
+    stored_outputs.append(args[-1])
+
+  monkeypatch.setattr(orch.orchestrator.db, 'store_output', store_once)
+  payload = _task_payload(action='outpaint_image', force_execution=True)
+  checksum = orch.orchestrator.actwrap.util_checksum.compute_object_checksum(
+      (payload['inputFiles'], payload.get('parameters', {}))
+  )
+  cache_path = f'outpaint_image/{checksum}.json'
+  client = orch.app.test_client()
+
+  recovery_error = scenario in ('lookup_error', 'download_error')
+  delivery_count = 3 if recovery_error else 2
+  responses = []
+  for retry_count in range(delivery_count):
+    headers = (
+        {'X-CloudTasks-TaskRetryCount': str(retry_count)}
+        if retry_count
+        else None
+    )
+    responses.append(
+        client.post('/triggerAction', json=payload, headers=headers)
+    )
+
+  expected_statuses = [503, 503, 200] if recovery_error else [503, 200]
+  expected_output = (
+      rerun_output if scenario == 'generation_race' else first_output
+  )
+  expected_action_calls = 2 if scenario == 'generation_race' else 1
+
+  assert [response.status_code for response in responses] == expected_statuses
+  assert released == [('exec-worker', 'node-1', 'group-1')] * (
+      len(expected_statuses) - 1
+  )
+  assert action_calls == ['called'] * expected_action_calls
+  assert store_attempts == 2
+  assert stored_outputs == [expected_output]
+  assert json.loads(cache[cache_path]) == expected_output
+
+
+def test_trigger_action_redelivery_reruns_failed_forced_action(
+    monkeypatch, orchestrator_module
+):
+  """A forced attempt that fails mid-action cannot expose stale cache."""
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  stale_output = {'outpainted_image': [{'file': 'stale/image.png'}]}
+  fresh_output = {'outpainted_image': [{'file': 'generated/image.png'}]}
+  cache = {}
+  action_calls = []
+  released = []
+  stored_outputs = []
+
+  def paid_action(_gcs, _workflow_params):
+    action_calls.append('called')
+    if len(action_calls) == 1:
+      raise google_exceptions.ResourceExhausted('temporary quota exhaustion')
+    return fresh_output
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  _install_action_cache(monkeypatch, orch, cache)
+  monkeypatch.setattr(
+      orch.orchestrator.db, 'acquire_task_lock', lambda *_a, **_k: True
+  )
+  monkeypatch.setattr(
+      orch.orchestrator.db,
+      'release_task_lock',
+      lambda *args, **_kwargs: released.append(args),
+  )
+  monkeypatch.setattr(
+      orch.orchestrator.db,
+      'store_output',
+      lambda *args: stored_outputs.append(args[-1]),
+  )
+
+  payload = _task_payload(action='outpaint_image', force_execution=True)
+  checksum = orch.orchestrator.actwrap.util_checksum.compute_object_checksum(
+      (payload['inputFiles'], payload.get('parameters', {}))
+  )
+  cache_path = f'outpaint_image/{checksum}.json'
+  cache[cache_path] = json.dumps(stale_output)
+  client = orch.app.test_client()
+
+  first = client.post('/triggerAction', json=payload)
+  retry = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={'X-CloudTasks-TaskRetryCount': '1'},
+  )
+
+  assert first.status_code == 429
+  assert retry.status_code == 200
+  assert released == [('exec-worker', 'node-1', 'group-1')]
+  assert action_calls == ['called', 'called']
+  assert stored_outputs == [fresh_output]
+  assert json.loads(cache[cache_path]) == fresh_output
+
+
+def test_trigger_action_non_forced_reuses_legacy_cache(
+    monkeypatch, orchestrator_module
+):
+  """Cache entries written before task tokens remain reusable."""
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  legacy_output = {'outpainted_image': [{'file': 'legacy/image.png'}]}
+  cache = {}
+  action_calls = []
+  stored_outputs = []
+
+  def paid_action(_gcs, _workflow_params):
+    action_calls.append('called')
+    return {'outpainted_image': [{'file': 'unexpected/image.png'}]}
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  _install_action_cache(monkeypatch, orch, cache)
+  monkeypatch.setattr(
+      orch.orchestrator.db, 'acquire_task_lock', lambda *_a, **_k: True
+  )
+  monkeypatch.setattr(
+      orch.orchestrator.db,
+      'store_output',
+      lambda *args: stored_outputs.append(args[-1]),
+  )
+
+  payload = _task_payload(action='outpaint_image')
+  checksum = orch.orchestrator.actwrap.util_checksum.compute_object_checksum(
+      (payload['inputFiles'], payload.get('parameters', {}))
+  )
+  cache[f'outpaint_image/{checksum}.json'] = json.dumps(legacy_output)
+
+  response = orch.app.test_client().post('/triggerAction', json=payload)
+
+  assert response.status_code == 200
+  assert action_calls == []
+  assert stored_outputs == [legacy_output]
+
+
+def test_trigger_action_enqueue_retry_completes_successor_once(
+    monkeypatch, orchestrator_module
+):
+  """An ambiguous successor enqueue is contained by the existing join seal."""
+  del orchestrator_module
+  orch = _load_orch(monkeypatch)
+  successor_deliveries = []
+  action_deliveries = []
+  locks = set()
+
+  class FakeTasksClient:
+
+    def queue_path(self, *_args):
+      return 'projects/test/locations/test/queues/test'
+
+    def create_task(self, *, parent, task):
+      del parent
+      payload = json.loads(bytes(task.http_request.body))
+      if task.http_request.url.endswith('/supplyNode'):
+        successor_deliveries.append(payload)
+        if len(successor_deliveries) == 1:
+          raise google_exceptions.ServiceUnavailable(
+              'task accepted before response failed'
+          )
+      else:
+        action_deliveries.append(payload)
+
+  def acquire_lock(execution_id, node_id, group_id):
+    key = (execution_id, node_id, str(group_id))
+    if key in locks:
+      return False
+    locks.add(key)
+    return True
+
+  def release_lock(execution_id, node_id, group_id):
+    locks.discard((execution_id, node_id, str(group_id)))
+
+  monkeypatch.setattr(
+      orch.orchestrator.tasks_v2, 'CloudTasksClient', FakeTasksClient
+  )
+  monkeypatch.setattr(
+      orch.orchestrator, 'service_account_email', 'worker@example.com'
+  )
+  monkeypatch.setattr(orch.orchestrator.db, 'acquire_task_lock', acquire_lock)
+  monkeypatch.setattr(orch.orchestrator.db, 'release_task_lock', release_lock)
+
+  payload = _task_payload(execution_id='enqueue-retry', node_id='source')
+  payload.update({
+      'inputFiles': {'image': [{'file': 'uploads/source.png'}]},
+      'siblingActions': 1,
+      'workflowDefinition': {
+          'source': {'action': 'pass', 'input': {'image': None}},
+          'sink': {
+              'action': 'pass',
+              'input': {
+                  'image': {'node': 'source', 'output': 'image'},
+              },
+          },
+      },
+      'workflowParams': {
+          'gcpProject': 'test-project',
+          'gcpLocation': 'us-central1',
+          'gcsBucket': 'test-bucket',
+          'tasksQueuePrefix': 'test-',
+      },
+  })
+  client = orch.app.test_client()
+
+  first = client.post('/triggerAction', json=payload)
+  retry = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={'X-CloudTasks-TaskRetryCount': '1'},
+  )
+  for successor_payload in successor_deliveries:
+    assert client.post('/supplyNode', json=successor_payload).status_code == 200
+  assert len(action_deliveries) == 1
+  assert client.post('/triggerAction', json=action_deliveries[0]).status_code == 200
+  status = client.get('/getStatus?executionId=enqueue-retry').get_json()
+
+  assert first.status_code == 503
+  assert retry.status_code == 200
+  assert len(successor_deliveries) == 2
+  assert list(status['sink']['output']) == ['0']
 
 
 def test_trigger_action_non_retryable_error_keeps_lock(

--- a/test/test_frontdoor.py
+++ b/test/test_frontdoor.py
@@ -273,6 +273,24 @@ def _task_headers(
   }
 
 
+def _task_completion_path(execution_id, queue_name, task_name):
+  task_token = hashlib.sha256(
+      json.dumps(
+          [
+              'cloud-tasks',
+              queue_name,
+              task_name,
+              execution_id,
+              'node-1',
+              'group-1',
+          ],
+          ensure_ascii=True,
+          separators=(',', ':'),
+      ).encode('utf-8')
+  ).hexdigest()
+  return f'_task-completions/{task_token}.json'
+
+
 def _install_action_cache(
     monkeypatch,
     orch,
@@ -491,6 +509,160 @@ def test_task_completion_is_create_only_without_false_expiry_metadata(
       completion_path,
   ]
   assert cache_state['metadata'][completion_path] is None
+
+
+def test_create_conflict_read_failure_requires_recovery_only_retry(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  task_token = 'b' * 64
+  completion_path = f'_task-completions/{task_token}.json'
+  _install_action_cache(
+      monkeypatch,
+      orch,
+      {completion_path: json.dumps({'video': []})},
+      download_errors=[google_exceptions.ServiceUnavailable('GCS unavailable')],
+  )
+
+  with pytest.raises(orch.util_errors.RetryableTaskRecoveryError) as error:
+    orch.orchestrator._store_task_completion(
+        _task_payload(execution_id='completion-create-conflict'),
+        task_token,
+        {'video': [{'file': 'generated/video.mp4'}]},
+    )
+
+  assert type(error.value) is orch.util_errors.RetryableTaskRecoveryError
+
+
+@pytest.mark.parametrize(
+    ('manifest', 'error_type'),
+    (
+        (b'{', 'JSONDecodeError'),
+        (b'[]', 'TypeError'),
+        (b'\xff', 'UnicodeDecodeError'),
+        (b'[' * 10_000, 'RecursionError'),
+    ),
+    ids=(
+        'malformed-json',
+        'non-object-json',
+        'invalid-utf8',
+        'excessive-nesting',
+    ),
+)
+def test_invalid_task_completion_is_terminal_without_running_action(
+    monkeypatch, orchestrator_module, manifest, error_type
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  action_calls = []
+  stored_outputs = []
+  execution_id = f'invalid-completion-{error_type.lower()}'
+  queue_name = f'queue-{error_type.lower()}'
+  task_name = f'task-{error_type.lower()}'
+  completion_path = _task_completion_path(execution_id, queue_name, task_name)
+  cache_state = _install_action_cache(
+      monkeypatch, orch, {completion_path: manifest}
+  )
+
+  def paid_action(*_args, **_kwargs):
+    action_calls.append('called')
+    return {'outpainted_image': [{'file': 'generated/image.png'}]}
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  monkeypatch.setattr(
+      orch.orchestrator.db,
+      'store_output',
+      lambda *args: stored_outputs.append(args[-1]),
+  )
+  payload = _task_payload(
+      execution_id=execution_id,
+      action='outpaint_image',
+      force_execution=True,
+  )
+
+  response = orch.app.test_client().post(
+      '/triggerAction',
+      json=payload,
+      headers=_task_headers(queue_name, task_name),
+  )
+  state = (
+      orch.orchestrator.db._get_task_lock_ref(execution_id, 'node-1', 'group-1')
+      .get()
+      .to_dict()
+  )
+
+  assert response.status_code == 200
+  assert state['state'] == 'failed'
+  assert state['attempt'] == 1
+  assert state['error'].startswith(f'{error_type}:')
+  assert action_calls == []
+  assert stored_outputs == []
+  assert cache_state['completion_downloads'] == [completion_path]
+
+
+def test_unexpected_completion_parse_failure_stays_recovery_only(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  action_calls = []
+  execution_id = 'unexpected-completion-parse-failure'
+  queue_name = 'queue-unexpected-parse'
+  task_name = 'task-unexpected-parse'
+  completion_path = _task_completion_path(execution_id, queue_name, task_name)
+
+  class UnexpectedParseFailure(bytes):
+
+    def decode(self, *_args, **_kwargs):
+      raise MemoryError('transient parser failure')
+
+  cache = {completion_path: UnexpectedParseFailure(b'{}')}
+  cache_state = _install_action_cache(monkeypatch, orch, cache)
+
+  def paid_action(*_args, **_kwargs):
+    action_calls.append('called')
+    return {'outpainted_image': [{'file': 'generated/image.png'}]}
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  payload = _task_payload(
+      execution_id=execution_id,
+      action='outpaint_image',
+      force_execution=True,
+  )
+  headers = _task_headers(queue_name, task_name)
+  client = orch.app.test_client()
+
+  first = client.post('/triggerAction', json=payload, headers=headers)
+  lock_ref = orch.orchestrator.db._get_task_lock_ref(
+      execution_id, 'node-1', 'group-1'
+  )
+  first_state = lock_ref.get().to_dict()
+  cache.pop(completion_path)
+  redelivery = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={**headers, 'X-CloudTasks-TaskRetryCount': '1'},
+  )
+  redelivery_state = lock_ref.get().to_dict()
+
+  assert first.status_code == 503
+  assert redelivery.status_code == 503
+  assert first_state['state'] == 'retryable'
+  assert first_state['recoveryOnly'] is True
+  assert redelivery_state['state'] == 'retryable'
+  assert redelivery_state['recoveryOnly'] is True
+  assert action_calls == []
+  assert cache_state['completion_downloads'] == [
+      completion_path,
+      completion_path,
+  ]
 
 
 def test_task_completion_upload_error_refuses_automatic_action_retry(

--- a/test/test_frontdoor.py
+++ b/test/test_frontdoor.py
@@ -27,6 +27,8 @@ No test performs network I/O.
 """
 
 import importlib
+import datetime
+import hashlib
 import json
 import pathlib
 import sys
@@ -267,14 +269,20 @@ def _install_action_cache(
     cache,
     *,
     exists_errors=None,
+    reload_errors=None,
     download_errors=None,
     download_overwrite=None,
+    action_upload_errors=None,
+    completion_upload_errors=None,
 ):
   """Installs an in-memory action cache for trigger-action tests."""
   cache_metadata = {}
   cache_generations = {}
   pending_exists_errors = list(exists_errors or [])
+  pending_reload_errors = list(reload_errors or [])
   pending_download_errors = list(download_errors or [])
+  pending_action_upload_errors = list(action_upload_errors or [])
+  pending_completion_upload_errors = list(completion_upload_errors or [])
   overwrite_pending = download_overwrite is not None
 
   class CacheBlob:
@@ -290,6 +298,10 @@ def _install_action_cache(
       return self.path in cache
 
     def reload(self):
+      if pending_reload_errors:
+        raise pending_reload_errors.pop(0)
+      if self.path not in cache:
+        raise google_exceptions.NotFound('cache object not found')
       self.metadata = cache_metadata.get(self.path)
       self.generation = cache_generations.get(self.path)
 
@@ -309,7 +321,19 @@ def _install_action_cache(
         raise google_exceptions.PreconditionFailed('generation changed')
       return cache[self.path]
 
-    def upload_from_string(self, data, **_kwargs):
+    def upload_from_string(self, data, if_generation_match=None, **_kwargs):
+      if (
+          not self.path.startswith('_task-completions/')
+          and pending_action_upload_errors
+      ):
+        raise pending_action_upload_errors.pop(0)
+      if (
+          self.path.startswith('_task-completions/')
+          and pending_completion_upload_errors
+      ):
+        raise pending_completion_upload_errors.pop(0)
+      if if_generation_match == 0 and self.path in cache:
+        raise google_exceptions.PreconditionFailed('object already exists')
       cache[self.path] = data
       cache_metadata[self.path] = self.metadata
       cache_generations[self.path] = cache_generations.get(self.path, 0) + 1
@@ -325,6 +349,364 @@ def _install_action_cache(
       self.gcs_bucket = CacheBucket()
 
   monkeypatch.setattr(orch.orchestrator.actwrap.gcs_wrapper, 'GCS', CacheGcs)
+  return {
+      'metadata': cache_metadata,
+      'generations': cache_generations,
+  }
+
+
+def _install_task_state(monkeypatch, orch, *, outcome=None):
+  """Installs successful task-state operations and returns transition calls."""
+  if outcome is None:
+    outcome = orch.util_database.TASK_LOCK_ACQUIRED
+  transitions = []
+  monkeypatch.setattr(
+      orch.orchestrator.db,
+      'acquire_task_lock',
+      lambda *_args, **_kwargs: outcome,
+  )
+
+  def mark(state):
+    def record(*args, **_kwargs):
+      transitions.append((state, args))
+      return True
+
+    return record
+
+  monkeypatch.setattr(
+      orch.orchestrator.db, 'mark_task_retryable', mark('retryable')
+  )
+  monkeypatch.setattr(orch.orchestrator.db, 'mark_task_failed', mark('failed'))
+  monkeypatch.setattr(
+      orch.orchestrator.db, 'mark_task_succeeded', mark('succeeded')
+  )
+  return transitions
+
+
+def test_task_state_claims_are_owner_checked(monkeypatch, orchestrator_module):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  db = orch.orchestrator.db
+  key = ('task-state-claims', 'node', 'group')
+
+  assert db.acquire_task_lock(*key, 'task-a', 'owner-1', 1) == 'acquired'
+  assert db.acquire_task_lock(*key, 'task-a', 'owner-2', 2) == 'busy'
+  assert db.acquire_task_lock(*key, 'task-b', 'owner-2', 1) == 'duplicate'
+  assert (
+      db.mark_task_retryable(*key, 'task-a', 'wrong-owner', 1, 'error') is False
+  )
+  assert db.mark_task_retryable(*key, 'task-a', 'owner-1', 1, 'error') is True
+  assert db.acquire_task_lock(*key, 'task-a', 'owner-2', 2) == 'acquired'
+  assert db.mark_task_succeeded(*key, 'task-a', 'owner-1', 1) is False
+  assert db.mark_task_succeeded(*key, 'task-a', 'owner-2', 2) is True
+  assert db.acquire_task_lock(*key, 'task-a', 'owner-3', 3) == 'terminal'
+
+  malformed_key = ('task-state-malformed', 'node', 'group')
+  db._get_task_lock_ref(*malformed_key).set({
+      'taskToken': 'task-a',
+      'ownerToken': 'owner-1',
+      'state': 'unexpected',
+  })
+  assert (
+      db.acquire_task_lock(*malformed_key, 'task-a', 'owner-2', 2) == 'terminal'
+  )
+
+
+def test_task_state_expired_lease_can_be_reclaimed(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  db = orch.orchestrator.db
+  key = ('task-state-expiry', 'node', 'group')
+  assert db.acquire_task_lock(*key, 'task-a', 'owner-1', 1) == 'acquired'
+  db._get_task_lock_ref(*key).set(
+      {
+          'leaseExpiresAt': (
+              datetime.datetime.now(datetime.timezone.utc)
+              - datetime.timedelta(seconds=1)
+          )
+      },
+      merge=True,
+  )
+
+  assert (
+      db.acquire_task_lock(*key, 'task-a', 'owner-2', 2) == 'acquired-recovery'
+  )
+  state = db._get_task_lock_ref(*key).get().to_dict()
+  assert state['ownerToken'] == 'owner-2'
+  assert state['attempt'] == 2
+  assert state['recoveryOnly'] is True
+
+
+@pytest.mark.parametrize('recovery_value', ('missing', None, 0, 'false'))
+def test_task_state_ambiguous_retryable_state_is_recovery_only(
+    monkeypatch, orchestrator_module, recovery_value
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  db = orch.orchestrator.db
+  key = (f'task-state-ambiguous-{recovery_value}', 'node', 'group')
+  state = {
+      'taskToken': 'task-a',
+      'ownerToken': 'owner-1',
+      'state': 'retryable',
+  }
+  if recovery_value != 'missing':
+    state['recoveryOnly'] = recovery_value
+  db._get_task_lock_ref(*key).set(state)
+
+  assert (
+      db.acquire_task_lock(*key, 'task-a', 'owner-2', 2) == 'acquired-recovery'
+  )
+
+
+def test_task_completion_is_create_only_and_generation_pinned(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  cache = {}
+  cache_state = _install_action_cache(monkeypatch, orch, cache)
+  payload = _task_payload(execution_id='completion-create-only')
+  output = {'video': [{'file': 'generated/video.mp4'}]}
+  task_token = 'a' * 64
+
+  assert (
+      orch.orchestrator._store_task_completion(payload, task_token, output)
+      == output
+  )
+  completion_path = f'_task-completions/{task_token}.json'
+  first_generation = cache_state['generations'][completion_path]
+  assert (
+      orch.orchestrator._store_task_completion(payload, task_token, output)
+      == output
+  )
+  assert cache_state['generations'][completion_path] == first_generation
+  competing_output = {'video': [{'file': 'generated/other.mp4'}]}
+  assert (
+      orch.orchestrator._store_task_completion(
+          payload, task_token, competing_output
+      )
+      == output
+  )
+  assert cache_state['generations'][completion_path] == first_generation
+
+  cache_state['generations'][completion_path] = True
+  with pytest.raises(orch.util_errors.RetryableTaskRecoveryError):
+    orch.orchestrator._load_task_completion(payload, task_token)
+
+
+def test_task_completion_upload_error_refuses_automatic_action_retry(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  _install_action_cache(
+      monkeypatch,
+      orch,
+      {},
+      completion_upload_errors=[
+          google_exceptions.RetryError(
+              'upload retry deadline exhausted',
+              cause=ConnectionError('connection reset'),
+          )
+      ],
+  )
+
+  with pytest.raises(orch.util_errors.TaskCompletionWriteError):
+    orch.orchestrator._store_task_completion(
+        _task_payload(execution_id='completion-upload'),
+        'b' * 64,
+        {'video': [{'file': 'generated/video.mp4'}]},
+    )
+
+
+def test_manifest_upload_failure_records_terminal_without_rerunning_action(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  action_calls = []
+  cache = {}
+
+  def paid_action(_gcs, _workflow_params):
+    action_calls.append('called')
+    return {'outpainted_image': [{'file': 'generated/image.png'}]}
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  _install_action_cache(
+      monkeypatch,
+      orch,
+      cache,
+      completion_upload_errors=[
+          google_exceptions.RetryError(
+              'upload retry deadline exhausted',
+              cause=ConnectionError('connection reset'),
+          )
+      ],
+  )
+  payload = _task_payload(
+      execution_id='completion-upload-terminal',
+      action='outpaint_image',
+      force_execution=True,
+  )
+  headers = {
+      'X-CloudTasks-QueueName': 'queue-upload',
+      'X-CloudTasks-TaskName': 'task-upload',
+  }
+  client = orch.app.test_client()
+
+  first = client.post('/triggerAction', json=payload, headers=headers)
+  redelivery = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={**headers, 'X-CloudTasks-TaskRetryCount': '1'},
+  )
+  state = (
+      orch.orchestrator.db._get_task_lock_ref(
+          'completion-upload-terminal', 'node-1', 'group-1'
+      )
+      .get()
+      .to_dict()
+  )
+
+  assert first.status_code == 200
+  assert redelivery.status_code == 200
+  assert action_calls == ['called']
+  checksum = orch.orchestrator.actwrap.util_checksum.compute_object_checksum(
+      (payload['inputFiles'], payload.get('parameters', {}))
+  )
+  assert f'outpaint_image/{checksum}.json' in cache
+  assert not any(path.startswith('_task-completions/') for path in cache)
+  assert state['state'] == 'failed'
+  assert state['attempt'] == 1
+  assert state['error'].startswith(
+      'RetryError: upload retry deadline exhausted'
+  )
+
+
+def test_action_cache_upload_failure_records_terminal_without_rerunning_action(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  action_calls = []
+  cache = {}
+
+  def paid_action(_gcs, _workflow_params):
+    action_calls.append('called')
+    return {'outpainted_image': [{'file': 'generated/image.png'}]}
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  _install_action_cache(
+      monkeypatch,
+      orch,
+      cache,
+      action_upload_errors=[
+          google_exceptions.ResourceExhausted('GCS write quota exhausted')
+      ],
+  )
+  payload = _task_payload(
+      execution_id='action-cache-upload-terminal',
+      action='outpaint_image',
+      force_execution=True,
+  )
+  headers = {
+      'X-CloudTasks-QueueName': 'queue-action-cache',
+      'X-CloudTasks-TaskName': 'task-action-cache',
+  }
+  client = orch.app.test_client()
+
+  first = client.post('/triggerAction', json=payload, headers=headers)
+  redelivery = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={**headers, 'X-CloudTasks-TaskRetryCount': '1'},
+  )
+  state = (
+      orch.orchestrator.db._get_task_lock_ref(
+          'action-cache-upload-terminal', 'node-1', 'group-1'
+      )
+      .get()
+      .to_dict()
+  )
+
+  assert first.status_code == 200
+  assert redelivery.status_code == 200
+  assert action_calls == ['called']
+  assert cache == {}
+  assert state['state'] == 'failed'
+  assert state['attempt'] == 1
+  assert state['error'].startswith('ResourceExhausted: ')
+  assert 'GCS write quota exhausted' in state['error']
+
+
+def test_task_completion_generation_race_retries_without_running_action(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  payload = _task_payload(
+      execution_id='completion-generation-race',
+      action='outpaint_image',
+      force_execution=True,
+  )
+  headers = {
+      'X-CloudTasks-QueueName': 'queue-generation',
+      'X-CloudTasks-TaskName': 'task-generation',
+  }
+  task_token = hashlib.sha256(
+      json.dumps(
+          [
+              'cloud-tasks',
+              'queue-generation',
+              'task-generation',
+              'completion-generation-race',
+              'node-1',
+              'group-1',
+          ],
+          ensure_ascii=True,
+          separators=(',', ':'),
+      ).encode('utf-8')
+  ).hexdigest()
+  completion_path = f'_task-completions/{task_token}.json'
+  original_output = {'outpainted_image': [{'file': 'generated/first.png'}]}
+  cache = {completion_path: json.dumps(original_output)}
+  cache_state = _install_action_cache(
+      monkeypatch,
+      orch,
+      cache,
+      download_overwrite={
+          'outpainted_image': [{'file': 'generated/replaced.png'}]
+      },
+  )
+  cache_state['generations'][completion_path] = 1
+  action_calls = []
+
+  def paid_action(_gcs, _workflow_params):
+    action_calls.append('called')
+    return original_output
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  transitions = _install_task_state(monkeypatch, orch)
+
+  response = orch.app.test_client().post(
+      '/triggerAction', json=payload, headers=headers
+  )
+
+  assert response.status_code == 503
+  assert action_calls == []
+  assert [state for state, _args in transitions] == ['retryable']
 
 
 def test_worker_url_overrides_host_for_trigger_action(
@@ -336,23 +718,23 @@ def test_worker_url_overrides_host_for_trigger_action(
 
   captured = {}
 
-  def fake_trigger_action(data, instance, may_retry, recover_forced_cache):
+  def fake_trigger_action(data, instance, may_retry, task_token, recovery_only):
     captured['data'] = data
     captured['instance'] = instance
     captured['may_retry'] = may_retry
-    captured['recover_forced_cache'] = recover_forced_cache
+    captured['task_token'] = task_token
+    captured['recovery_only'] = recovery_only
 
   monkeypatch.setattr(orch.orchestrator, 'trigger_action', fake_trigger_action)
-  # First valid delivery acquires the PR #113 Cloud Tasks lock and runs.
-  monkeypatch.setattr(
-      orch.orchestrator.db, 'acquire_task_lock', lambda *a, **k: True
-  )
+  transitions = _install_task_state(monkeypatch, orch)
   client = orch.app.test_client()
   response = client.post('/triggerAction', json=_task_payload())
   assert response.status_code == 200
   assert captured['instance'] == worker_url
+  assert captured['recovery_only'] is False
   assert captured['may_retry'] is True
-  assert captured['recover_forced_cache'] is False
+  assert len(captured['task_token']) == 64
+  assert [state for state, _args in transitions] == ['succeeded']
 
 
 def test_trigger_action_duplicate_delivery_is_skipped(
@@ -369,9 +751,8 @@ def test_trigger_action_duplicate_delivery_is_skipped(
       'trigger_action',
       lambda *a, **k: called.__setitem__('trigger', True),
   )
-  # The lock is already held by another delivery.
-  monkeypatch.setattr(
-      orch.orchestrator.db, 'acquire_task_lock', lambda *a, **k: False
+  _install_task_state(
+      monkeypatch, orch, outcome=orch.util_database.TASK_LOCK_TERMINAL
   )
   client = orch.app.test_client()
   response = client.post('/triggerAction', json=_task_payload())
@@ -380,22 +761,12 @@ def test_trigger_action_duplicate_delivery_is_skipped(
   assert called['trigger'] is False
 
 
-def test_trigger_action_retryable_error_releases_lock(
+def test_trigger_action_retryable_error_records_retryable_state(
     monkeypatch, orchestrator_module
 ):
-  """PR #113: a retryable failure releases the lock (so Cloud Tasks can retry)
-  and returns 429."""
   del orchestrator_module
   orch = _load_orch(monkeypatch, ROLE='worker')
-  released = []
-  monkeypatch.setattr(
-      orch.orchestrator.db, 'acquire_task_lock', lambda *a, **k: True
-  )
-  monkeypatch.setattr(
-      orch.orchestrator.db,
-      'release_task_lock',
-      lambda *a, **k: released.append(a),
-  )
+  transitions = _install_task_state(monkeypatch, orch)
 
   def boom(*_a, **_k):
     raise RuntimeError('quota exceeded')
@@ -405,24 +776,18 @@ def test_trigger_action_retryable_error_releases_lock(
   client = orch.app.test_client()
   response = client.post('/triggerAction', json=_task_payload())
   assert response.status_code == 429
-  assert len(released) == 1
+  assert [state for state, _args in transitions] == ['retryable']
+  assert transitions[0][1][-1] is False
 
 
-def test_trigger_action_post_action_deadline_releases_lock(
+def test_trigger_action_post_action_deadline_records_retryable_state(
     monkeypatch, orchestrator_module
 ):
   """A transient output-write failure is retried after the action completes."""
   del orchestrator_module
   orch = _load_orch(monkeypatch, ROLE='worker')
-  released = []
-  monkeypatch.setattr(
-      orch.orchestrator.db, 'acquire_task_lock', lambda *a, **k: True
-  )
-  monkeypatch.setattr(
-      orch.orchestrator.db,
-      'release_task_lock',
-      lambda *a, **k: released.append(a),
-  )
+  transitions = _install_task_state(monkeypatch, orch)
+  _install_action_cache(monkeypatch, orch, {})
 
   def unavailable(*_args, **_kwargs):
     raise google_exceptions.DeadlineExceeded('Firestore deadline exceeded')
@@ -432,31 +797,378 @@ def test_trigger_action_post_action_deadline_releases_lock(
   response = orch.app.test_client().post('/triggerAction', json=_task_payload())
 
   assert response.status_code == 503
-  assert released == [('exec-worker', 'node-1', 'group-1')]
+  assert [state for state, _args in transitions] == ['retryable']
+  assert transitions[0][1][-1] is True
 
 
-@pytest.mark.parametrize(
-    'scenario',
-    ('normal', 'lookup_error', 'download_error', 'generation_race'),
-)
-def test_trigger_action_redelivery_recovers_forced_action_cache(
-    monkeypatch, orchestrator_module, scenario
+@pytest.mark.parametrize('transition_failure', ('exception', 'lost-owner'))
+def test_fatal_action_is_acknowledged_without_retrying_paid_work(
+    monkeypatch, orchestrator_module, transition_failure
 ):
-  """Forced recovery is task-scoped, race-safe, and retryable."""
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  action_calls = []
+
+  def fail_action(*_args, **_kwargs):
+    action_calls.append('called')
+    raise ValueError('fatal model failure')
+
+  def fail_terminal_transition(*_args, **_kwargs):
+    if transition_failure == 'exception':
+      raise google_exceptions.DeadlineExceeded('Firestore unavailable')
+    return False
+
+  monkeypatch.setattr(orch.orchestrator, 'trigger_action', fail_action)
+  monkeypatch.setattr(
+      orch.orchestrator.db, 'mark_task_failed', fail_terminal_transition
+  )
+  payload = _task_payload(execution_id=f'fatal-{transition_failure}')
+  headers = {
+      'X-CloudTasks-QueueName': 'queue-fatal',
+      'X-CloudTasks-TaskName': f'task-fatal-{transition_failure}',
+  }
+  client = orch.app.test_client()
+
+  first = client.post('/triggerAction', json=payload, headers=headers)
+  active_redelivery = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={**headers, 'X-CloudTasks-TaskRetryCount': '1'},
+  )
+
+  assert first.status_code == 200
+  assert active_redelivery.status_code == 503
+  assert action_calls == ['called']
+
+
+def test_failed_retryable_transition_never_drops_or_releases_new_owner(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  cache = {}
+  action_calls = []
+  output = {'outpainted_image': [{'file': 'generated/one.png'}]}
+
+  def paid_action(_gcs, _workflow_params):
+    action_calls.append('called')
+    return output
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  _install_action_cache(monkeypatch, orch, cache)
+  store_attempts = 0
+
+  def store_once(*_args):
+    nonlocal store_attempts
+    store_attempts += 1
+    if store_attempts == 1:
+      raise google_exceptions.DeadlineExceeded('Firestore unavailable')
+
+  monkeypatch.setattr(orch.orchestrator.db, 'store_output', store_once)
+  real_mark_retryable = orch.orchestrator.db.mark_task_retryable
+  transition_attempts = 0
+
+  def fail_first_transition(*args, **kwargs):
+    nonlocal transition_attempts
+    transition_attempts += 1
+    if transition_attempts == 1:
+      raise google_exceptions.DeadlineExceeded('Firestore unavailable')
+    return real_mark_retryable(*args, **kwargs)
+
+  monkeypatch.setattr(
+      orch.orchestrator.db, 'mark_task_retryable', fail_first_transition
+  )
+
+  class Owner:
+
+    def __init__(self, value):
+      self.hex = value
+
+  owners = iter((Owner('owner-1'), Owner('owner-2'), Owner('owner-3')))
+  monkeypatch.setattr(orch.uuid, 'uuid4', lambda: next(owners))
+  payload = _task_payload(
+      execution_id='state-transition-failure',
+      action='outpaint_image',
+      force_execution=True,
+  )
+  headers = {
+      'X-CloudTasks-QueueName': 'queue-state',
+      'X-CloudTasks-TaskName': 'task-state',
+  }
+  client = orch.app.test_client()
+
+  first = client.post('/triggerAction', json=payload, headers=headers)
+  held = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={**headers, 'X-CloudTasks-TaskRetryCount': '1'},
+  )
+  lock_ref = orch.orchestrator.db._get_task_lock_ref(
+      'state-transition-failure', 'node-1', 'group-1'
+  )
+  first_owner_state = lock_ref.get().to_dict()
+  lock_ref.set(
+      {
+          'leaseExpiresAt': (
+              datetime.datetime.now(datetime.timezone.utc)
+              - datetime.timedelta(seconds=1)
+          )
+      },
+      merge=True,
+  )
+  recovered = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={**headers, 'X-CloudTasks-TaskRetryCount': '2'},
+  )
+  recovered_state = lock_ref.get().to_dict()
+  late_transition = real_mark_retryable(
+      'state-transition-failure',
+      'node-1',
+      'group-1',
+      recovered_state['taskToken'],
+      first_owner_state['ownerToken'],
+      1,
+      'late transition',
+  )
+
+  assert first.status_code == 503
+  assert held.status_code == 503
+  assert recovered.status_code == 200
+  assert action_calls == ['called']
+  assert first_owner_state['state'] == 'running'
+  assert first_owner_state['ownerToken'] == 'owner-1'
+  assert recovered_state['state'] == 'succeeded'
+  assert recovered_state['ownerToken'] == 'owner-3'
+  assert late_transition is False
+
+
+@pytest.mark.parametrize('transition_failure', ('exception', 'lost-owner'))
+def test_failed_success_transition_redelivers_and_recovers_manifest(
+    monkeypatch, orchestrator_module, transition_failure
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  cache = {}
+  action_calls = []
+  output = {'outpainted_image': [{'file': 'generated/one.png'}]}
+
+  def paid_action(_gcs, _workflow_params):
+    action_calls.append('called')
+    return output
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  _install_action_cache(monkeypatch, orch, cache)
+  monkeypatch.setattr(orch.orchestrator.db, 'store_output', lambda *_args: None)
+  real_mark_succeeded = orch.orchestrator.db.mark_task_succeeded
+  transition_attempts = 0
+
+  def fail_first_transition(*args, **kwargs):
+    nonlocal transition_attempts
+    transition_attempts += 1
+    if transition_attempts == 1:
+      if transition_failure == 'exception':
+        raise google_exceptions.DeadlineExceeded('Firestore unavailable')
+      return False
+    return real_mark_succeeded(*args, **kwargs)
+
+  monkeypatch.setattr(
+      orch.orchestrator.db, 'mark_task_succeeded', fail_first_transition
+  )
+  payload = _task_payload(
+      execution_id=f'success-transition-{transition_failure}',
+      action='outpaint_image',
+      force_execution=True,
+  )
+  headers = {
+      'X-CloudTasks-QueueName': 'queue-success-state',
+      'X-CloudTasks-TaskName': f'task-success-{transition_failure}',
+  }
+  client = orch.app.test_client()
+
+  first = client.post('/triggerAction', json=payload, headers=headers)
+  active_redelivery = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={**headers, 'X-CloudTasks-TaskRetryCount': '1'},
+  )
+  lock_ref = orch.orchestrator.db._get_task_lock_ref(
+      payload['executionId'], 'node-1', 'group-1'
+  )
+  lock_ref.set(
+      {
+          'leaseExpiresAt': (
+              datetime.datetime.now(datetime.timezone.utc)
+              - datetime.timedelta(seconds=1)
+          )
+      },
+      merge=True,
+  )
+  recovered = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={**headers, 'X-CloudTasks-TaskRetryCount': '2'},
+  )
+  final_state = lock_ref.get().to_dict()
+
+  assert first.status_code == 503
+  assert active_redelivery.status_code == 503
+  assert recovered.status_code == 200
+  assert action_calls == ['called']
+  assert transition_attempts == 2
+  assert final_state['state'] == 'succeeded'
+  assert final_state['recoveryOnly'] is True
+
+
+def test_last_queue_attempt_persists_terminal_failure(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+
+  def fail_recovery(*_args, **_kwargs):
+    try:
+      raise ValueError('completion cache unavailable')
+    except ValueError as cause:
+      raise orch.util_errors.RetryableTaskRecoveryError(
+          'recovery failed'
+      ) from cause
+
+  monkeypatch.setattr(orch.orchestrator, 'trigger_action', fail_recovery)
+  payload = _task_payload(execution_id='terminal-task')
+  headers = {
+      'X-CloudTasks-QueueName': 'queue-terminal',
+      'X-CloudTasks-TaskName': 'task-terminal',
+      'X-CloudTasks-TaskRetryCount': '29',
+  }
+
+  response = orch.app.test_client().post(
+      '/triggerAction', json=payload, headers=headers
+  )
+  state = (
+      orch.orchestrator.db._get_task_lock_ref(
+          'terminal-task', 'node-1', 'group-1'
+      )
+      .get()
+      .to_dict()
+  )
+  expected_token = hashlib.sha256(
+      json.dumps(
+          [
+              'cloud-tasks',
+              'queue-terminal',
+              'task-terminal',
+              'terminal-task',
+              'node-1',
+              'group-1',
+          ],
+          ensure_ascii=True,
+          separators=(',', ':'),
+      ).encode('utf-8')
+  ).hexdigest()
+
+  assert response.status_code == 200
+  assert state['state'] == 'failed'
+  assert state['attempt'] == 30
+  assert state['taskToken'] == expected_token
+  assert state['error'] == 'ValueError: completion cache unavailable'
+
+
+@pytest.mark.parametrize('transition_failure', ('exception', 'lost-owner'))
+def test_last_queue_attempt_is_not_acknowledged_without_terminal_state(
+    monkeypatch, orchestrator_module, transition_failure
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+
+  def fail_recovery(*_args, **_kwargs):
+    raise orch.util_errors.RetryableTaskRecoveryError('recovery failed')
+
+  def fail_terminal_transition(*_args, **_kwargs):
+    if transition_failure == 'exception':
+      raise google_exceptions.DeadlineExceeded('Firestore unavailable')
+    return False
+
+  monkeypatch.setattr(orch.orchestrator, 'trigger_action', fail_recovery)
+  monkeypatch.setattr(
+      orch.orchestrator.db, 'mark_task_failed', fail_terminal_transition
+  )
+  payload = _task_payload(execution_id=f'terminal-state-{transition_failure}')
+  response = orch.app.test_client().post(
+      '/triggerAction',
+      json=payload,
+      headers={
+          'X-CloudTasks-QueueName': 'queue-terminal-state',
+          'X-CloudTasks-TaskName': f'task-terminal-{transition_failure}',
+          'X-CloudTasks-TaskRetryCount': '29',
+      },
+  )
+  state = (
+      orch.orchestrator.db._get_task_lock_ref(
+          payload['executionId'], 'node-1', 'group-1'
+      )
+      .get()
+      .to_dict()
+  )
+
+  assert response.status_code == 503
+  assert state['state'] == 'running'
+  assert state['attempt'] == 30
+
+
+def test_penultimate_queue_attempt_remains_retryable(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+
+  def fail_recovery(*_args, **_kwargs):
+    raise orch.util_errors.RetryableTaskRecoveryError('recovery failed')
+
+  monkeypatch.setattr(orch.orchestrator, 'trigger_action', fail_recovery)
+  payload = _task_payload(execution_id='penultimate-task')
+  response = orch.app.test_client().post(
+      '/triggerAction',
+      json=payload,
+      headers={
+          'X-CloudTasks-QueueName': 'queue-terminal',
+          'X-CloudTasks-TaskName': 'task-penultimate',
+          'X-CloudTasks-TaskRetryCount': '28',
+      },
+  )
+  state = (
+      orch.orchestrator.db._get_task_lock_ref(
+          'penultimate-task', 'node-1', 'group-1'
+      )
+      .get()
+      .to_dict()
+  )
+
+  assert response.status_code == 503
+  assert state['state'] == 'retryable'
+  assert state['attempt'] == 29
+
+
+def test_trigger_action_completed_manifest_read_failure_never_regenerates(
+    monkeypatch, orchestrator_module
+):
   del orchestrator_module
   orch = _load_orch(monkeypatch, ROLE='worker')
   first_output = {'outpainted_image': [{'file': 'generated/first.png'}]}
-  rerun_output = {'outpainted_image': [{'file': 'generated/rerun.png'}]}
-  concurrent_output = {'outpainted_image': [{'file': 'other/task.png'}]}
   cache = {}
   action_calls = []
-  released = []
   stored_outputs = []
   store_attempts = 0
 
   def paid_action(_gcs, _workflow_params):
     action_calls.append('called')
-    return first_output if len(action_calls) == 1 else rerun_output
+    return first_output
 
   paid_action.__module__ = 'actions.outpaint_image'
   monkeypatch.setattr(
@@ -466,38 +1178,14 @@ def test_trigger_action_redelivery_recovers_forced_action_cache(
       monkeypatch,
       orch,
       cache,
-      exists_errors=(
-          [
-              google_exceptions.RetryError(
-                  'GCS retry deadline exhausted',
-                  google_exceptions.TooManyRequests('GCS quota exhausted'),
-              )
-          ]
-          if scenario == 'lookup_error'
-          else None
-      ),
-      download_errors=(
-          [
-              google_exceptions.RetryError(
-                  'GCS retry deadline exhausted',
-                  ConnectionError('GCS connection reset'),
-              )
-          ]
-          if scenario == 'download_error'
-          else None
-      ),
-      download_overwrite=(
-          concurrent_output if scenario == 'generation_race' else None
-      ),
+      download_errors=[
+          google_exceptions.RetryError(
+              'GCS retry deadline exhausted',
+              ConnectionError('GCS connection reset'),
+          )
+      ],
   )
-  monkeypatch.setattr(
-      orch.orchestrator.db, 'acquire_task_lock', lambda *_a, **_k: True
-  )
-  monkeypatch.setattr(
-      orch.orchestrator.db,
-      'release_task_lock',
-      lambda *args, **_kwargs: released.append(args),
-  )
+  transitions = _install_task_state(monkeypatch, orch)
 
   def store_once(*args):
     nonlocal store_attempts
@@ -508,39 +1196,102 @@ def test_trigger_action_redelivery_recovers_forced_action_cache(
 
   monkeypatch.setattr(orch.orchestrator.db, 'store_output', store_once)
   payload = _task_payload(action='outpaint_image', force_execution=True)
-  checksum = orch.orchestrator.actwrap.util_checksum.compute_object_checksum(
-      (payload['inputFiles'], payload.get('parameters', {}))
+  client = orch.app.test_client()
+  headers = {
+      'X-CloudTasks-QueueName': 'queue-a',
+      'X-CloudTasks-TaskName': 'task-a',
+  }
+  responses = [client.post('/triggerAction', json=payload, headers=headers)]
+  for retry_count in (1, 2):
+    responses.append(
+        client.post(
+            '/triggerAction',
+            json=payload,
+            headers={
+                **headers,
+                'X-CloudTasks-TaskRetryCount': str(retry_count),
+            },
+        )
+    )
+
+  assert [response.status_code for response in responses] == [503, 503, 200]
+  assert action_calls == ['called']
+  assert store_attempts == 2
+  assert stored_outputs == [first_output]
+  assert [state for state, _args in transitions] == [
+      'retryable',
+      'retryable',
+      'succeeded',
+  ]
+  completion_paths = [
+      path for path in cache if path.startswith('_task-completions/')
+  ]
+  assert len(completion_paths) == 1
+  assert json.loads(cache[completion_paths[0]]) == first_output
+
+
+def test_recovery_only_state_never_regenerates_a_missing_manifest(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  output = {'outpainted_image': [{'file': 'generated/first.png'}]}
+  cache = {}
+  action_calls = []
+  store_attempts = 0
+
+  def paid_action(_gcs, _workflow_params):
+    action_calls.append('called')
+    return output
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
   )
-  cache_path = f'outpaint_image/{checksum}.json'
+  _install_action_cache(monkeypatch, orch, cache)
+
+  def fail_first_store(*_args):
+    nonlocal store_attempts
+    store_attempts += 1
+    if store_attempts == 1:
+      raise google_exceptions.DeadlineExceeded('Firestore deadline exceeded')
+
+  monkeypatch.setattr(orch.orchestrator.db, 'store_output', fail_first_store)
+  payload = _task_payload(
+      execution_id='missing-recovery-manifest',
+      action='outpaint_image',
+      force_execution=True,
+  )
+  headers = {
+      'X-CloudTasks-QueueName': 'queue-recovery-only',
+      'X-CloudTasks-TaskName': 'task-recovery-only',
+  }
   client = orch.app.test_client()
 
-  recovery_error = scenario in ('lookup_error', 'download_error')
-  delivery_count = 3 if recovery_error else 2
-  responses = []
-  for retry_count in range(delivery_count):
-    headers = (
-        {'X-CloudTasks-TaskRetryCount': str(retry_count)}
-        if retry_count
-        else None
-    )
-    responses.append(
-        client.post('/triggerAction', json=payload, headers=headers)
-    )
-
-  expected_statuses = [503, 503, 200] if recovery_error else [503, 200]
-  expected_output = (
-      rerun_output if scenario == 'generation_race' else first_output
+  first = client.post('/triggerAction', json=payload, headers=headers)
+  lock_ref = orch.orchestrator.db._get_task_lock_ref(
+      'missing-recovery-manifest', 'node-1', 'group-1'
   )
-  expected_action_calls = 2 if scenario == 'generation_race' else 1
-
-  assert [response.status_code for response in responses] == expected_statuses
-  assert released == [('exec-worker', 'node-1', 'group-1')] * (
-      len(expected_statuses) - 1
+  first_state = lock_ref.get().to_dict()
+  completion_path = next(
+      path for path in cache if path.startswith('_task-completions/')
   )
-  assert action_calls == ['called'] * expected_action_calls
-  assert store_attempts == 2
-  assert stored_outputs == [expected_output]
-  assert json.loads(cache[cache_path]) == expected_output
+  cache.pop(completion_path)
+  redelivery = client.post(
+      '/triggerAction',
+      json=payload,
+      headers={**headers, 'X-CloudTasks-TaskRetryCount': '1'},
+  )
+  recovered_state = lock_ref.get().to_dict()
+
+  assert first.status_code == 503
+  assert redelivery.status_code == 503
+  assert action_calls == ['called']
+  assert store_attempts == 1
+  assert first_state['state'] == 'retryable'
+  assert first_state['recoveryOnly'] is True
+  assert recovered_state['state'] == 'retryable'
+  assert recovered_state['recoveryOnly'] is True
 
 
 def test_trigger_action_redelivery_reruns_failed_forced_action(
@@ -553,7 +1304,6 @@ def test_trigger_action_redelivery_reruns_failed_forced_action(
   fresh_output = {'outpainted_image': [{'file': 'generated/image.png'}]}
   cache = {}
   action_calls = []
-  released = []
   stored_outputs = []
 
   def paid_action(_gcs, _workflow_params):
@@ -567,14 +1317,7 @@ def test_trigger_action_redelivery_reruns_failed_forced_action(
       orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
   )
   _install_action_cache(monkeypatch, orch, cache)
-  monkeypatch.setattr(
-      orch.orchestrator.db, 'acquire_task_lock', lambda *_a, **_k: True
-  )
-  monkeypatch.setattr(
-      orch.orchestrator.db,
-      'release_task_lock',
-      lambda *args, **_kwargs: released.append(args),
-  )
+  transitions = _install_task_state(monkeypatch, orch)
   monkeypatch.setattr(
       orch.orchestrator.db,
       'store_output',
@@ -588,20 +1331,73 @@ def test_trigger_action_redelivery_reruns_failed_forced_action(
   cache_path = f'outpaint_image/{checksum}.json'
   cache[cache_path] = json.dumps(stale_output)
   client = orch.app.test_client()
+  task_headers = {
+      'X-CloudTasks-QueueName': 'queue-rerun',
+      'X-CloudTasks-TaskName': 'task-rerun',
+  }
 
-  first = client.post('/triggerAction', json=payload)
+  first = client.post('/triggerAction', json=payload, headers=task_headers)
   retry = client.post(
       '/triggerAction',
       json=payload,
-      headers={'X-CloudTasks-TaskRetryCount': '1'},
+      headers={**task_headers, 'X-CloudTasks-TaskRetryCount': '1'},
   )
 
   assert first.status_code == 429
   assert retry.status_code == 200
-  assert released == [('exec-worker', 'node-1', 'group-1')]
+  assert [state for state, _args in transitions] == [
+      'retryable',
+      'succeeded',
+  ]
+  assert transitions[0][1][-1] is False
   assert action_calls == ['called', 'called']
   assert stored_outputs == [fresh_output]
   assert json.loads(cache[cache_path]) == fresh_output
+
+
+def test_retry_header_without_completion_does_not_bypass_forced_action(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  stale_output = {'outpainted_image': [{'file': 'stale/image.png'}]}
+  fresh_output = {'outpainted_image': [{'file': 'fresh/image.png'}]}
+  cache = {}
+  action_calls = []
+
+  def paid_action(_gcs, _workflow_params):
+    action_calls.append('called')
+    return fresh_output
+
+  paid_action.__module__ = 'actions.outpaint_image'
+  monkeypatch.setattr(
+      orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
+  )
+  _install_action_cache(monkeypatch, orch, cache)
+  transitions = _install_task_state(monkeypatch, orch)
+  monkeypatch.setattr(orch.orchestrator.db, 'store_output', lambda *_args: None)
+  payload = _task_payload(action='outpaint_image', force_execution=True)
+  checksum = orch.orchestrator.actwrap.util_checksum.compute_object_checksum(
+      (payload['inputFiles'], payload.get('parameters', {}))
+  )
+  cache_path = f'outpaint_image/{checksum}.json'
+  cache[cache_path] = json.dumps(stale_output)
+
+  response = orch.app.test_client().post(
+      '/triggerAction',
+      json=payload,
+      headers={
+          'X-CloudTasks-QueueName': 'queue-header',
+          'X-CloudTasks-TaskName': 'task-header',
+          'X-CloudTasks-TaskRetryCount': '7',
+      },
+  )
+
+  assert response.status_code == 200
+  assert action_calls == ['called']
+  assert json.loads(cache[cache_path]) == fresh_output
+  assert transitions[0][0] == 'succeeded'
+  assert transitions[0][1][-1] == 8
 
 
 def test_trigger_action_non_forced_reuses_legacy_cache(
@@ -624,9 +1420,7 @@ def test_trigger_action_non_forced_reuses_legacy_cache(
       orch.orchestrator.actwrap, 'get_action_by_name', lambda _name: paid_action
   )
   _install_action_cache(monkeypatch, orch, cache)
-  monkeypatch.setattr(
-      orch.orchestrator.db, 'acquire_task_lock', lambda *_a, **_k: True
-  )
+  transitions = _install_task_state(monkeypatch, orch)
   monkeypatch.setattr(
       orch.orchestrator.db,
       'store_output',
@@ -644,6 +1438,7 @@ def test_trigger_action_non_forced_reuses_legacy_cache(
   assert response.status_code == 200
   assert action_calls == []
   assert stored_outputs == [legacy_output]
+  assert [state for state, _args in transitions] == ['succeeded']
 
 
 def test_trigger_action_enqueue_retry_completes_successor_once(
@@ -654,7 +1449,7 @@ def test_trigger_action_enqueue_retry_completes_successor_once(
   orch = _load_orch(monkeypatch)
   successor_deliveries = []
   action_deliveries = []
-  locks = set()
+  _install_action_cache(monkeypatch, orch, {})
 
   class FakeTasksClient:
 
@@ -673,24 +1468,12 @@ def test_trigger_action_enqueue_retry_completes_successor_once(
       else:
         action_deliveries.append(payload)
 
-  def acquire_lock(execution_id, node_id, group_id):
-    key = (execution_id, node_id, str(group_id))
-    if key in locks:
-      return False
-    locks.add(key)
-    return True
-
-  def release_lock(execution_id, node_id, group_id):
-    locks.discard((execution_id, node_id, str(group_id)))
-
   monkeypatch.setattr(
       orch.orchestrator.tasks_v2, 'CloudTasksClient', FakeTasksClient
   )
   monkeypatch.setattr(
       orch.orchestrator, 'service_account_email', 'worker@example.com'
   )
-  monkeypatch.setattr(orch.orchestrator.db, 'acquire_task_lock', acquire_lock)
-  monkeypatch.setattr(orch.orchestrator.db, 'release_task_lock', release_lock)
 
   payload = _task_payload(execution_id='enqueue-retry', node_id='source')
   payload.update({
@@ -723,7 +1506,10 @@ def test_trigger_action_enqueue_retry_completes_successor_once(
   for successor_payload in successor_deliveries:
     assert client.post('/supplyNode', json=successor_payload).status_code == 200
   assert len(action_deliveries) == 1
-  assert client.post('/triggerAction', json=action_deliveries[0]).status_code == 200
+  assert (
+      client.post('/triggerAction', json=action_deliveries[0]).status_code
+      == 200
+  )
   status = client.get('/getStatus?executionId=enqueue-retry').get_json()
 
   assert first.status_code == 503
@@ -732,22 +1518,12 @@ def test_trigger_action_enqueue_retry_completes_successor_once(
   assert list(status['sink']['output']) == ['0']
 
 
-def test_trigger_action_non_retryable_error_keeps_lock(
+def test_trigger_action_non_retryable_error_records_failed_state(
     monkeypatch, orchestrator_module
 ):
-  """PR #113: a non-retryable failure does NOT release the lock (no retry) and
-  returns the existing non-retry response."""
   del orchestrator_module
   orch = _load_orch(monkeypatch, ROLE='worker')
-  released = []
-  monkeypatch.setattr(
-      orch.orchestrator.db, 'acquire_task_lock', lambda *a, **k: True
-  )
-  monkeypatch.setattr(
-      orch.orchestrator.db,
-      'release_task_lock',
-      lambda *a, **k: released.append(a),
-  )
+  transitions = _install_task_state(monkeypatch, orch)
 
   def boom(*_a, **_k):
     raise RuntimeError('fatal')
@@ -758,7 +1534,7 @@ def test_trigger_action_non_retryable_error_keeps_lock(
   response = client.post('/triggerAction', json=_task_payload())
   assert response.status_code == 200
   assert response.get_data(as_text=True) == 'Internal Error'
-  assert released == []
+  assert [state for state, _args in transitions] == ['failed']
 
 
 def test_trigger_action_rejects_malformed_payload(
@@ -778,6 +1554,62 @@ def test_trigger_action_rejects_malformed_payload(
   response = client.post('/triggerAction', json={'action': 'pass'})
   assert response.status_code == 400
   assert called['trigger'] is False
+
+
+@pytest.mark.parametrize(
+    'headers',
+    (
+        {'X-CloudTasks-QueueName': 'queue-only'},
+        {'X-CloudTasks-TaskName': 'task-only'},
+        {'X-CloudTasks-TaskRetryCount': 'not-an-integer'},
+        {'X-CloudTasks-TaskRetryCount': '-1'},
+    ),
+)
+def test_trigger_action_rejects_incomplete_task_headers(
+    monkeypatch, orchestrator_module, headers
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  called = []
+  monkeypatch.setattr(
+      orch.orchestrator,
+      'trigger_action',
+      lambda *_args, **_kwargs: called.append(True),
+  )
+
+  response = orch.app.test_client().post(
+      '/triggerAction', json=_task_payload(), headers=headers
+  )
+
+  assert response.status_code == 400
+  assert called == []
+
+
+def test_trigger_action_attempt_limit_matches_deploy_queue(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  deploy_script = (_REPO / 'deploy.sh').read_text(encoding='utf-8')
+
+  assert orch._MAX_TASK_ATTEMPTS == 30
+  assert '--max-attempts=30' in deploy_script
+
+
+def test_task_lease_outlives_production_request_deadline(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch = _load_orch(monkeypatch, ROLE='worker')
+  deploy_script = (_REPO / 'deploy.sh').read_text(encoding='utf-8')
+
+  assert (
+      orch.util_database.TASK_LEASE_SECONDS
+      > orch.orchestrator._TASK_DISPATCH_DEADLINE_SECONDS
+  )
+  assert orch.util_database.TASK_LEASE_SECONDS > 1830
+  assert '--timeout=1800' in deploy_script
+  assert 'GUNICORN_TIMEOUT=1830' in deploy_script
 
 
 def test_app_worker_url_feeds_api_supply_node(monkeypatch, orchestrator_module):
@@ -1011,7 +1843,8 @@ def test_app_rejects_rogue_model(monkeypatch, orchestrator_module):
   del orchestrator_module
   orch = _load_orch(monkeypatch, ROLE='app', WORKER_URL='https://w.a.run.app')
   response, captured = _app_submit(
-      monkeypatch, orch, _video_node('rogue', 'global'))
+      monkeypatch, orch, _video_node('rogue', 'global')
+  )
   assert response.status_code == 400
   assert response.get_json()['code'] == 'MODEL_NOT_ALLOWED'
   assert captured == {}  # nothing stored, no task scheduled
@@ -1021,7 +1854,8 @@ def test_app_rejects_disallowed_location(monkeypatch, orchestrator_module):
   del orchestrator_module
   orch = _load_orch(monkeypatch, ROLE='app', WORKER_URL='https://w.a.run.app')
   response, captured = _app_submit(
-      monkeypatch, orch, _video_node('veo-3.1-generate-001', 'europe-west4'))
+      monkeypatch, orch, _video_node('veo-3.1-generate-001', 'europe-west4')
+  )
   assert response.status_code == 400
   assert response.get_json()['code'] == 'MODEL_LOCATION_PAIR_INVALID'
   assert captured == {}
@@ -1042,7 +1876,8 @@ def test_app_accepts_valid_submission(monkeypatch, orchestrator_module):
   del orchestrator_module
   orch = _load_orch(monkeypatch, ROLE='app', WORKER_URL='https://w.a.run.app')
   response, captured = _app_submit(
-      monkeypatch, orch, _video_node('veo-3.1-generate-001', 'global'))
+      monkeypatch, orch, _video_node('veo-3.1-generate-001', 'global')
+  )
   assert response.status_code == 200
   assert 'data' in captured  # the node reached orchestrator.supply_node
 
@@ -1051,10 +1886,13 @@ def test_worker_route_does_not_validate(monkeypatch, orchestrator_module):
   # Leak detector: a rogue model on the worker route is NOT rejected --
   # validation runs only on the app role.
   del orchestrator_module
-  orch = _load_orch(monkeypatch, ROLE='worker', WORKER_URL='https://w.a.run.app')
+  orch = _load_orch(
+      monkeypatch, ROLE='worker', WORKER_URL='https://w.a.run.app'
+  )
   captured = _capture_supply_node(monkeypatch, orch)
   response = orch.app.test_client().post(
-      '/supplyNode', json=_video_node('rogue', 'global'))
+      '/supplyNode', json=_video_node('rogue', 'global')
+  )
   assert response.status_code == 200
   assert 'data' in captured
 

--- a/util/database.py
+++ b/util/database.py
@@ -26,6 +26,18 @@ from google.cloud.firestore import DocumentSnapshot
 
 MAX_ATTEMPTS = 75
 TASK_LOCK_EXPIRATION_HOURS = 12
+TASK_LEASE_SECONDS = 1860
+
+TASK_LOCK_ACQUIRED = 'acquired'
+TASK_LOCK_ACQUIRED_RECOVERY = 'acquired-recovery'
+TASK_LOCK_BUSY = 'busy'
+TASK_LOCK_DUPLICATE = 'duplicate'
+TASK_LOCK_TERMINAL = 'terminal'
+
+_TASK_STATE_RUNNING = 'running'
+_TASK_STATE_RETRYABLE = 'retryable'
+_TASK_STATE_SUCCEEDED = 'succeeded'
+_TASK_STATE_FAILED = 'failed'
 
 
 def firestore_to_json_serialisable(data: Any) -> Any:
@@ -386,55 +398,222 @@ class Database:
       execution_id: str,
       node_id: str,
       group_id: typing.Union[str, int],
-  ) -> bool:
-    """Acquires a lock for a task transactionally.
+      task_token: str,
+      owner_token: str,
+      attempt: int,
+  ) -> str:
+    """Claims a task for one delivery transactionally.
 
     Args:
       execution_id: The workflow's execution ID.
       node_id: The node ID.
       group_id: The group ID.
+      task_token: Stable identity shared by redeliveries of one Cloud Task.
+      owner_token: Unique identity for this delivery.
+      attempt: One-based Cloud Tasks delivery attempt.
 
     Returns:
-      True if the lock was successfully acquired (first to trigger),
-      False otherwise.
+      One of the TASK_LOCK_* outcomes defined in this module.
     """
     doc_ref = self._get_task_lock_ref(execution_id, node_id, group_id)
-    expires_at = datetime.datetime.now(
-        datetime.timezone.utc
-    ) + datetime.timedelta(hours=TASK_LOCK_EXPIRATION_HOURS)
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     @firestore.transactional
-    def create_if_not_exists(
+    def claim_if_available(
         transaction: firestore.Transaction,
         doc_ref: firestore.DocumentReference,
-        expires_at: datetime.datetime,
-    ) -> bool:
+        now: datetime.datetime,
+    ) -> str:
       snapshot = doc_ref.get(transaction=transaction)
+      current = snapshot.to_dict() or {}
+      recovery_only = False
       if snapshot.exists:
-        return False
-      transaction.set(doc_ref, {'expiresAt': expires_at})
-      return True
+        current_task_token = current.get('taskToken')
+        current_state = current.get('state')
+        # Locks written by older releases have no ownership or state. Treat
+        # them as terminal rather than risk repeating completed paid work.
+        if not current_task_token or not current_state:
+          return TASK_LOCK_TERMINAL
+        if current_task_token != task_token:
+          return TASK_LOCK_DUPLICATE
+        if current_state not in (
+            _TASK_STATE_RUNNING,
+            _TASK_STATE_RETRYABLE,
+            _TASK_STATE_SUCCEEDED,
+            _TASK_STATE_FAILED,
+        ):
+          return TASK_LOCK_TERMINAL
+        if current_state in (_TASK_STATE_SUCCEEDED, _TASK_STATE_FAILED):
+          return TASK_LOCK_TERMINAL
+        lease_expires_at = current.get('leaseExpiresAt')
+        lease_expired = (
+            isinstance(lease_expires_at, datetime.datetime)
+            and lease_expires_at <= now
+        )
+        if current_state != _TASK_STATE_RETRYABLE and not lease_expired:
+          return TASK_LOCK_BUSY
+        if current_state == _TASK_STATE_RETRYABLE:
+          # Only an explicit boolean false proves the prior failure happened
+          # before paid work. Missing or malformed values fail cost-first.
+          recovery_only = current.get('recoveryOnly') is not False
+        else:
+          recovery_only = lease_expired
 
-    return create_if_not_exists(
+      transaction.set(
+          doc_ref,
+          {
+              'taskToken': task_token,
+              'ownerToken': owner_token,
+              'attempt': attempt,
+              'state': _TASK_STATE_RUNNING,
+              'recoveryOnly': recovery_only,
+              'leaseExpiresAt': (
+                  now + datetime.timedelta(seconds=TASK_LEASE_SECONDS)
+              ),
+              'updatedAt': now,
+              'expiresAt': (
+                  now + datetime.timedelta(hours=TASK_LOCK_EXPIRATION_HOURS)
+              ),
+          },
+      )
+      return (
+          TASK_LOCK_ACQUIRED_RECOVERY if recovery_only else TASK_LOCK_ACQUIRED
+      )
+
+    return claim_if_available(
         self.db.transaction(max_attempts=MAX_ATTEMPTS),
         doc_ref,
-        expires_at,
+        now,
     )
 
-  def release_task_lock(
+  def _transition_task_lock(
       self,
       execution_id: str,
       node_id: str,
       group_id: typing.Union[str, int],
-  ) -> None:
-    """Releases the lock for a task.
+      task_token: str,
+      owner_token: str,
+      state: str,
+      attempt: int,
+      error: str | None = None,
+      recovery_only: bool | None = None,
+  ) -> bool:
+    """Moves a task owned by this delivery to another durable state.
 
     Args:
       execution_id: The workflow's execution ID.
       node_id: The node ID.
       group_id: The group ID.
+      task_token: Stable identity shared by redeliveries of one Cloud Task.
+      owner_token: Unique identity for this delivery.
+      state: Destination state.
+      attempt: One-based Cloud Tasks delivery attempt.
+      error: Optional compact failure description.
+      recovery_only: Whether later deliveries must only recover saved output.
+
+    Returns:
+      Whether this delivery still owned the task and changed its state.
     """
-    self._get_task_lock_ref(execution_id, node_id, group_id).delete()
+    doc_ref = self._get_task_lock_ref(execution_id, node_id, group_id)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    @firestore.transactional
+    def transition_if_owner(
+        transaction: firestore.Transaction,
+        doc_ref: firestore.DocumentReference,
+    ) -> bool:
+      snapshot = doc_ref.get(transaction=transaction)
+      current = snapshot.to_dict() or {}
+      if (
+          current.get('taskToken') != task_token
+          or current.get('ownerToken') != owner_token
+          or current.get('state') != _TASK_STATE_RUNNING
+      ):
+        return False
+      update = {
+          'attempt': attempt,
+          'state': state,
+          'updatedAt': now,
+          'expiresAt': (
+              now + datetime.timedelta(hours=TASK_LOCK_EXPIRATION_HOURS)
+          ),
+      }
+      if error is not None:
+        update['error'] = error
+      if recovery_only is not None:
+        update['recoveryOnly'] = recovery_only
+      transaction.set(doc_ref, update, merge=True)
+      return True
+
+    return transition_if_owner(
+        self.db.transaction(max_attempts=MAX_ATTEMPTS), doc_ref
+    )
+
+  def mark_task_retryable(
+      self,
+      execution_id: str,
+      node_id: str,
+      group_id: typing.Union[str, int],
+      task_token: str,
+      owner_token: str,
+      attempt: int,
+      error: str,
+      recovery_only: bool = False,
+  ) -> bool:
+    """Makes a task claimable by its next delivery."""
+    return self._transition_task_lock(
+        execution_id,
+        node_id,
+        group_id,
+        task_token,
+        owner_token,
+        _TASK_STATE_RETRYABLE,
+        attempt,
+        error,
+        recovery_only,
+    )
+
+  def mark_task_succeeded(
+      self,
+      execution_id: str,
+      node_id: str,
+      group_id: typing.Union[str, int],
+      task_token: str,
+      owner_token: str,
+      attempt: int,
+  ) -> bool:
+    """Records that this delivery completed the task."""
+    return self._transition_task_lock(
+        execution_id,
+        node_id,
+        group_id,
+        task_token,
+        owner_token,
+        _TASK_STATE_SUCCEEDED,
+        attempt,
+    )
+
+  def mark_task_failed(
+      self,
+      execution_id: str,
+      node_id: str,
+      group_id: typing.Union[str, int],
+      task_token: str,
+      owner_token: str,
+      attempt: int,
+      error: str,
+  ) -> bool:
+    """Records that no delivery will retry the task."""
+    return self._transition_task_lock(
+        execution_id,
+        node_id,
+        group_id,
+        task_token,
+        owner_token,
+        _TASK_STATE_FAILED,
+        attempt,
+        error,
+    )
 
   def get_documents(self, execution_id: str) -> typing.Iterable[typing.Any]:
     """Gets all node state documents within the specified workflow execution.

--- a/util/errors.py
+++ b/util/errors.py
@@ -24,6 +24,21 @@ from google.api_core import exceptions as google_exceptions
 TOO_MANY_REQUESTS = 429
 
 
+class RetryablePostActionError(Exception):
+  """Marks a transient infrastructure failure after an action completed."""
+
+
+class RetryableTaskRecoveryError(Exception):
+  """Marks a transient failure while recovering a prior task delivery."""
+
+
+def is_transient_infrastructure_error(e: Exception) -> bool:
+  """Returns whether an infrastructure error is safe to retry by its stage."""
+  if isinstance(e, google_exceptions.RetryError):
+    e = e.cause
+  return isinstance(e, google_exceptions.ServerError)
+
+
 def get_compact_callstack(start_function_name: str) -> str:
   """Returns a compact version of the current call stack.
 
@@ -70,3 +85,17 @@ def is_retryable(e: Exception) -> bool:
       # Removed because this would need to be retried much later:
       # isinstance(e, RuntimeError) and 'try again later' in repr(e).lower(),
   ])
+
+
+def is_retryable_task_recovery_error(e: Exception) -> bool:
+  """Returns whether a cache-recovery failure is safe to redeliver.
+
+  Unlike action execution, cache inspection has not started paid work in the
+  current delivery. Exhausted client-library retries are therefore safe to
+  retry regardless of their final transport cause.
+  """
+  return (
+      isinstance(e, google_exceptions.RetryError)
+      or is_transient_infrastructure_error(e)
+      or is_retryable(e)
+  )

--- a/util/errors.py
+++ b/util/errors.py
@@ -32,11 +32,18 @@ class RetryableTaskRecoveryError(Exception):
   """Marks a transient failure while recovering a prior task delivery."""
 
 
+class TaskCompletionWriteError(Exception):
+  """Marks an unproven completion that must not rerun paid work."""
+
+
 def is_transient_infrastructure_error(e: Exception) -> bool:
   """Returns whether an infrastructure error is safe to retry by its stage."""
   if isinstance(e, google_exceptions.RetryError):
     e = e.cause
-  return isinstance(e, google_exceptions.ServerError)
+  return isinstance(
+      e,
+      (google_exceptions.ServerError, google_exceptions.ResourceExhausted),
+  )
 
 
 def get_compact_callstack(start_function_name: str) -> str:
@@ -70,6 +77,8 @@ def is_retryable(e: Exception) -> bool:
   Returns:
     True if the exception is retryable, False otherwise
   """
+  if isinstance(e, google_exceptions.RetryError):
+    e = e.cause
   code_attr = getattr(e, 'code', None)
   return any([
       isinstance(e, google_exceptions.ResourceExhausted),

--- a/util/errors.py
+++ b/util/errors.py
@@ -28,6 +28,10 @@ class RetryablePostActionError(Exception):
   """Marks a transient infrastructure failure after an action completed."""
 
 
+class RetryablePreActionProbeError(Exception):
+  """Marks a transient completion probe failure before an action starts."""
+
+
 class RetryableTaskRecoveryError(Exception):
   """Marks a transient failure while recovering a prior task delivery."""
 


### PR DESCRIPTION
## Summary

Cloud Tasks may redeliver a worker task. Before this change, a transient
Firestore output write or successor-task creation failure after an action
completed could cause the action to run again, including another paid model
call. This change records task-specific completion so redelivery replays the
output and downstream work without rerunning the action; delivery count alone
never proves completion.

## Behavior

Two durable records use the workflow bucket and Firestore collection already
in the engine:

1. **Task completion output.** After an action completes, the worker creates
   `_task-completions/<task-token>.json` before writing the node output or
   creating successor tasks. The token hashes the Cloud Tasks queue and task
   names with the execution, node, and group, so it remains stable across
   redeliveries of that task. The object is create-only
   (`if_generation_match=0`) and read with one download. A redelivery that finds
   it replays the Firestore output write and successor-task creation without
   calling the action again. Completion objects carry no synthetic expiry
   metadata; retention follows the workflow bucket's lifecycle policy.

   The existing action cache cannot prove task completion: it is shared by
   action and inputs, and `forceExecution` deliberately bypasses it. The new
   object records the output of one specific task instead.

2. **Owner-fenced task state.** The existing Firestore lock document now records
   `running`, `retryable`, `succeeded`, or `failed`, together with the stable
   task token, a unique delivery-owner token, and a 1,860-second lease. A
   same-task redelivery while the owner is active receives a retryable response;
   an expired owner may be replaced in recovery-only mode; and a delayed owner
   cannot change its replacement's state. If the final success-state write
   fails, the handler makes a best-effort recovery-only transition before
   returning a retryable response; a success write that already committed
   cannot be reopened.

A missing completion object permits action execution only when durable state
explicitly records `recoveryOnly: false`. This covers a new task, a quota 429,
and a transient completion download that occurred before any object bytes were
observed. Post-action and ambiguous completion failures remain recovery-only:
later deliveries may replay saved output but may not call the action, and a
missing object or transient download failure returns a retryable response.

Once completion bytes are downloaded, malformed JSON, invalid encoding,
excessive nesting, or a non-object root fails terminally on the first observed
delivery. Unexpected local parser failures remain retryable but recovery-only,
so a later missing object cannot permit the action to run.

If the action cache or completion-object write fails after output was produced,
the task stops rather than risking another paid call. The handler uses the
deployed queues' 30-attempt limit. Quota 429 errors, including
client-library-wrapped forms, remain retryable; model 5xx errors and timeouts are
not retried automatically.

`ROLE=worker` requires the Cloud Tasks queue name, task name, and retry-count
headers before lock access. These headers identify the delivery; Cloud Run
IAM/OIDC remains the authentication boundary. `ROLE=all` keeps the headerless
local-development path.

## Tests

Covers complete, missing, empty, partial, malformed, and local delivery headers;
nonzero retry counts on a task's first observed delivery; forced-action quota
recovery; transient initial completion reads with absent and present output;
create-only write conflicts and single-request reads; terminal invalid encoding,
JSON, nesting, and root shape; recovery-only unexpected parser failures and
create-conflict read failures; missing recovery output; absence of synthetic
expiry metadata; malformed recovery state; active and expired leases; owner
fencing; definite and ambiguous state-write failures; action-cache and
completion-write failures; wrapped quota errors; the 30-attempt boundary; and
ambiguous successor-task creation.

## Risks / Notes

- A model call and its completion-object write cannot be atomic. If output was
  produced but durable completion cannot be proven, the task stops rather than
  risk another billable action.
- If both the success-state write and its best-effort retryable transition fail,
  the document remains `running` until its lease expires. The configured queue
  retry schedule outlives that lease.
- If a fatal action error occurs and Firestore also cannot record `failed`, the
  handler still acknowledges the task to avoid a potentially billable retry;
  the task document may remain `running` until Firestore TTL cleanup.
- For this protocol, a claimed delivery performs one completion-object read. A
  delivery that executes an action also attempts one create-only object write,
  and a claimed delivery normally performs one fenced state-transition
  transaction after the existing claim transaction.
- Create-only writes prevent this worker protocol from replacing an existing
  completion object. A principal with bucket write permission can still modify
  or delete it.
- Completion objects remain until the workflow bucket's lifecycle policy
  removes them; this repository does not install that policy.
- An ambiguous successor-task response may create a duplicate delivery; the
  existing join seal prevents that duplicate from releasing the downstream node
  twice.
- This change does not add a general workflow watchdog or UI repair path.
