### PR TITLE
Serve the model catalog to UI dropdowns

### DIFF
--- a/orch.py
+++ b/orch.py
@@ -67,6 +67,7 @@ from google.oauth2 import id_token as google_id_token
 import orchestrator
 from util import database as util_database
 from util import errors as util_errors
+from util import model_allowlist
 from util import submission_validation
 from werkzeug.security import safe_join
 
@@ -676,16 +677,24 @@ def sign_url_handler() -> flask_response:
 
 
 def ui_config_handler() -> flask_response:
-  """Returns the config/global document from the UI database verbatim."""
+  """Returns the config/global document plus the model catalog.
+
+  config/global is served verbatim. modelCatalog comes from the shared
+  allowlist loader (the live config/models doc, or the shipped file on
+  fallback -- modelCatalogSource says which), so the UI's dropdowns read
+  exactly what the submission validator enforces.
+  """
   ui_db = _get_ui_db()
   if ui_db is None:
     return _json_error('FIRESTORE_DB_UI not configured', 500)
   snapshot = ui_db.collection('config').document('global').get()
   if not snapshot.exists:
     return _json_error('Config not seeded', 404)
-  return _json_response(
-      util_database.firestore_to_json_serialisable(snapshot.to_dict())
-  )
+  payload = util_database.firestore_to_json_serialisable(snapshot.to_dict())
+  catalog, source = model_allowlist.load_allowlist_with_source()
+  payload['modelCatalog'] = catalog
+  payload['modelCatalogSource'] = source
+  return _json_response(payload)
 
 
 # --- Project persistence: storyboard split ---------------------------------

--- a/test/test_frontdoor_data.py
+++ b/test/test_frontdoor_data.py
@@ -32,6 +32,7 @@ import uuid
 
 # Reused module-scoped fixture; pytest picks it up from this namespace.
 from test.test_frontdoor import orchestrator_module  # noqa: F401  pylint: disable=unused-import
+from util import model_allowlist
 
 _REPO = pathlib.Path(__file__).resolve().parent.parent
 _BUCKET = 'frontdoor-data-test-bucket'
@@ -942,9 +943,19 @@ def test_templates_crud_and_read_only_guard(monkeypatch, orchestrator_module):
 # ---------------------------------------------------------------------------
 # /api/config
 # ---------------------------------------------------------------------------
-def test_config_returns_seeded_doc(monkeypatch, orchestrator_module):
+def test_config_returns_seeded_doc_plus_model_catalog(
+    monkeypatch, orchestrator_module
+):
   del orchestrator_module
   orch, fake_db, _ = _load_app(monkeypatch)
+  # The catalog loader has its own Firestore client (it is shared with the
+  # validator, not the handler's _ui_db); give it a live doc without network.
+  live_catalog = model_allowlist.load_shipped_allowlist()
+  live_catalog['models']['veo-live-hotfix'] = {
+      'family': 'veo', 'actions': ['generate_video'],
+      'locations': ['global'], 'capabilities': {}}
+  monkeypatch.setattr(
+      model_allowlist, '_fetch_live_catalog', lambda: live_catalog)
   client = orch.app.test_client()
 
   response = client.get('/api/config')
@@ -960,7 +971,45 @@ def test_config_returns_seeded_doc(monkeypatch, orchestrator_module):
   fake_db.collection('config').docs['global'] = seeded
   response = client.get('/api/config')
   assert response.status_code == 200
-  assert response.get_json() == seeded  # verbatim
+  payload = response.get_json()
+  assert payload['modelCatalogSource'] == 'firestore'
+  assert 'veo-live-hotfix' in payload['modelCatalog']['models']
+  for key, value in seeded.items():
+    assert payload[key] == value  # the global doc itself stays verbatim
+
+
+def test_config_serves_shipped_catalog_when_the_live_doc_is_unusable(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch, fake_db, _ = _load_app(monkeypatch)
+  def unreachable():
+    raise RuntimeError('firestore down')
+  monkeypatch.setattr(model_allowlist, '_fetch_live_catalog', unreachable)
+  fake_db.collection('config').docs['global'] = {'gcpProject': 'p'}
+  client = orch.app.test_client()
+
+  payload = client.get('/api/config').get_json()
+  assert payload['modelCatalogSource'] == 'shipped'
+  assert payload['modelCatalog'] == model_allowlist.load_shipped_allowlist()
+
+
+def test_config_survives_a_console_edit_with_a_firestore_typed_value(
+    monkeypatch, orchestrator_module
+):
+  # A timestamp planted anywhere in the live doc must degrade to the shipped
+  # catalog -- never a serialization 500 for every /api/config caller.
+  del orchestrator_module
+  orch, fake_db, _ = _load_app(monkeypatch)
+  live = model_allowlist.load_shipped_allowlist()
+  live['updated_at'] = datetime.datetime(2026, 7, 1)
+  monkeypatch.setattr(model_allowlist, '_fetch_live_catalog', lambda: live)
+  fake_db.collection('config').docs['global'] = {'gcpProject': 'p'}
+  client = orch.app.test_client()
+
+  response = client.get('/api/config')
+  assert response.status_code == 200
+  assert response.get_json()['modelCatalogSource'] == 'shipped'
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_model_allowlist.py
+++ b/test/test_model_allowlist.py
@@ -44,8 +44,6 @@ from util.model_allowlist import (
 _REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _ACTIONS_JSON = os.path.join(_REPO, 'ui', 'definitions', 'actions.json')
 _CONFIG_TEMPLATE = os.path.join(_REPO, 'config.template.txt')
-_CONFIG_TS = os.path.join(
-    _REPO, 'ui', 'src', 'app', 'services', 'config', 'config.ts')
 
 # Param names that mark a model-parameterized action in actions.json.
 _MODEL_PARAM_NAMES = {'gemini_model', 'image_model', 'model'}
@@ -179,8 +177,9 @@ _MODEL_ID_RE = re.compile(r'^[a-z][a-z0-9.]*-[a-z0-9.\-]+$')
 
 def _shipped_models():
   """Model IDs the product actually offers: config.template.txt 'Recommended
-  models' lines and the config.ts video-model dropdown. If one of these is not
-  allowlisted, it is rejected for every user the moment enforcement is on."""
+  models' lines. (The UI dropdown reads the catalog from /api/config, so it
+  can no longer drift.) If one of these is not allowlisted, it is rejected
+  for every user the moment enforcement is on."""
   ids = set()
   with open(_CONFIG_TEMPLATE, encoding='utf-8') as f:
     for line in f:
@@ -191,10 +190,6 @@ def _shipped_models():
         token = re.sub(r'\(.*?\)', '', token).strip()  # drop "(Nano Banana Pro)"
         if _MODEL_ID_RE.match(token):
           ids.add(token)
-  with open(_CONFIG_TS, encoding='utf-8') as f:
-    block = re.search(r'VIDEO_GENERATION_MODELS\s*=\s*\[(.*?)]', f.read(), re.DOTALL)
-  assert block, 'VIDEO_GENERATION_MODELS array not found in config.ts (renamed?)'
-  ids.update(re.findall(r"'([^']+)'", block.group(1)))
   return ids
 
 

--- a/ui/src/app/services/config/config-catalog.spec.ts
+++ b/ui/src/app/services/config/config-catalog.spec.ts
@@ -1,0 +1,345 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {HttpClient} from '@angular/common/http';
+import {DOCUMENT} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {Router} from '@angular/router';
+import {of} from 'rxjs';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {ConfigService, ModelCatalog} from './config';
+
+const CATALOG: ModelCatalog = {
+  defaults: {veo: 'veo-default', image: 'image-a'},
+  actions: {
+    generate_video: {location_param: 'gcp_location', default_key: 'veoModel'},
+    generate_image: {
+      location_param: 'image_location',
+      default_key: 'imageModel',
+    },
+  },
+  models: {
+    'veo-default': {
+      family: 'veo',
+      actions: ['generate_video'],
+      locations: ['global', 'us-central1'],
+    },
+    'veo-fast': {
+      family: 'veo',
+      actions: ['generate_video'],
+      locations: ['global'],
+    },
+    'veo-central-only': {
+      family: 'veo',
+      actions: ['generate_video'],
+      locations: ['us-central1'],
+    },
+    'image-a': {
+      family: 'image',
+      actions: ['generate_image'],
+      locations: ['global'],
+    },
+  },
+};
+
+/** A served /api/config payload with the live catalog. */
+function liveGlobalConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    veoLocation: 'global',
+    veoModel: 'veo-default',
+    modelCatalog: CATALOG,
+    modelCatalogSource: 'firestore',
+    ...overrides,
+  };
+}
+
+describe('ConfigService model catalog', () => {
+  let service: ConfigService;
+  let httpClientMock: any;
+  let matSnackBarMock: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    httpClientMock = {
+      get: vi.fn().mockReturnValue(of({})),
+      post: vi.fn().mockReturnValue(of({id: 'created'})),
+      patch: vi.fn().mockReturnValue(of({})),
+      delete: vi.fn().mockReturnValue(of({})),
+    };
+    matSnackBarMock = {
+      open: vi.fn().mockReturnValue({onAction: () => of()}),
+    };
+    const documentMock = {
+      documentElement: {classList: {add: vi.fn(), remove: vi.fn()}},
+      defaultView: {
+        matchMedia: vi
+          .fn()
+          .mockReturnValue({matches: false, addEventListener: vi.fn()}),
+      },
+      querySelector: vi.fn(),
+    };
+    (globalThis as any).localStorage = {getItem: vi.fn(), setItem: vi.fn()};
+
+    TestBed.configureTestingModule({
+      providers: [
+        ConfigService,
+        {provide: HttpClient, useValue: httpClientMock},
+        {provide: MatSnackBar, useValue: matSnackBarMock},
+        {provide: Router, useValue: {navigate: vi.fn()}},
+        {provide: DOCUMENT, useValue: documentMock},
+      ],
+    });
+    service = TestBed.inject(ConfigService);
+  });
+
+  /** Lets the resource loaders resolve once and flushes pending effects. */
+  async function settle() {
+    TestBed.tick();
+    await Promise.resolve();
+    await Promise.resolve();
+    TestBed.tick();
+  }
+
+  it('lists only generate_video models available at the Veo location', async () => {
+    await settle();
+    (service as any).globalConfig.set(liveGlobalConfig());
+
+    // 'veo-central-only' is a video model but not at veoLocation 'global';
+    // 'image-a' is at 'global' but not a video model.
+    expect(service.videoModels()).toEqual(['veo-default', 'veo-fast']);
+  });
+
+  it('follows the configured Veo location', async () => {
+    await settle();
+    (service as any).globalConfig.set(
+      liveGlobalConfig({veoLocation: 'us-central1'}),
+    );
+
+    expect(service.videoModels()).toEqual(['veo-central-only', 'veo-default']);
+  });
+
+  it('is empty while the catalog or location is missing', async () => {
+    await settle();
+    (service as any).globalConfig.set(undefined);
+    expect(service.videoModels()).toEqual([]);
+
+    (service as any).globalConfig.set(
+      liveGlobalConfig({veoLocation: undefined}),
+    );
+    expect(service.videoModels()).toEqual([]);
+  });
+
+  it('switches an out-of-catalog project model to the veo default and says so', async () => {
+    await settle();
+    (service as any).globalConfig.set(liveGlobalConfig());
+    service.projectConfig.value.set({
+      ...service.projectConfig.value(),
+      id: 'proj-1',
+      model: 'veo-removed-by-operator',
+    });
+
+    TestBed.tick(); // flush the catalog effect
+
+    expect(service.projectConfig.value().model).toBe('veo-default');
+    expect(matSnackBarMock.open).toHaveBeenCalledWith(
+      expect.stringContaining('veo-removed-by-operator'),
+      'OK',
+    );
+  });
+
+  it('corrects an untouched seeded default quietly, without dirtying the project', async () => {
+    // A fresh project starts with model = config/global.veoModel, which the
+    // user never picked. If the catalog no longer offers it, fix it without
+    // a snackbar and without triggering the autosave that would POST an
+    // orphan project.
+    await settle();
+    (service as any).globalConfig.set(
+      liveGlobalConfig({veoModel: 'veo-retired-default'}),
+    );
+    service.projectConfig.value.set({
+      ...service.projectConfig.value(),
+      id: 'proj-new',
+      model: 'veo-retired-default',
+    });
+    (service as any).shouldSave = false;
+
+    TestBed.tick();
+
+    expect(service.projectConfig.value().model).toBe('veo-default');
+    expect(matSnackBarMock.open).not.toHaveBeenCalled();
+    expect((service as any).shouldSave).toBe(false);
+  });
+
+  it('posts a compatible model when creating from a removed deploy default', async () => {
+    await settle();
+    (service as any).globalConfig.set(
+      liveGlobalConfig({veoModel: 'veo-retired-default'}),
+    );
+
+    service.setNewProject('proj-new');
+    service.saveNow();
+
+    expect(httpClientMock.post).toHaveBeenCalledWith(
+      '/api/projects',
+      expect.objectContaining({id: 'proj-new', model: 'veo-default'}),
+    );
+    expect(matSnackBarMock.open).not.toHaveBeenCalled();
+  });
+
+  it('keeps a compatible deploy default when creating a project', async () => {
+    await settle();
+    (service as any).globalConfig.set(liveGlobalConfig({veoModel: 'veo-fast'}));
+
+    service.setNewProject('proj-new');
+    service.saveNow();
+
+    expect(httpClientMock.post).toHaveBeenCalledWith(
+      '/api/projects',
+      expect.objectContaining({id: 'proj-new', model: 'veo-fast'}),
+    );
+    expect(matSnackBarMock.open).not.toHaveBeenCalled();
+  });
+
+  it('gives a saved project on the deploy default the visible, persisted rewrite', async () => {
+    // Same model value as the untouched default, but the project is known
+    // server-side: the correction must persist and be announced, or a reload
+    // would bring the removed model back.
+    await settle();
+    (service as any).globalConfig.set(
+      liveGlobalConfig({veoModel: 'veo-retired-default'}),
+    );
+    (service as any).persistedProjectIds.add('proj-1');
+    service.projectConfig.value.set({
+      ...service.projectConfig.value(),
+      id: 'proj-1',
+      model: 'veo-retired-default',
+    });
+    (service as any).shouldSave = false;
+
+    TestBed.tick();
+
+    expect(service.projectConfig.value().model).toBe('veo-default');
+    expect(matSnackBarMock.open).toHaveBeenCalledWith(
+      expect.stringContaining('veo-retired-default'),
+      'OK',
+    );
+    service.flushPendingSave();
+    expect(httpClientMock.patch).toHaveBeenCalledWith(
+      '/api/projects/proj-1',
+      expect.objectContaining({id: 'proj-1', model: 'veo-default'}),
+    );
+  });
+
+  it('persists the fallback for a saved project with no model', async () => {
+    await settle();
+    (service as any).globalConfig.set(liveGlobalConfig());
+    (service as any).persistedProjectIds.add('proj-1');
+    service.projectConfig.value.set({
+      ...service.projectConfig.value(),
+      id: 'proj-1',
+      model: '',
+    });
+    (service as any).shouldSave = false;
+
+    TestBed.tick();
+
+    expect(service.projectConfig.value().model).toBe('veo-default');
+    expect(matSnackBarMock.open).toHaveBeenCalledWith(
+      expect.stringContaining('saved video model'),
+      'OK',
+    );
+    service.flushPendingSave();
+    expect(httpClientMock.patch).toHaveBeenCalledWith(
+      '/api/projects/proj-1',
+      expect.objectContaining({id: 'proj-1', model: 'veo-default'}),
+    );
+  });
+
+  it('leaves a model that is in the catalog untouched', async () => {
+    await settle();
+    (service as any).globalConfig.set(liveGlobalConfig());
+    service.projectConfig.value.set({
+      ...service.projectConfig.value(),
+      id: 'proj-1',
+      model: 'veo-fast',
+    });
+
+    TestBed.tick();
+
+    expect(service.projectConfig.value().model).toBe('veo-fast');
+    expect(matSnackBarMock.open).not.toHaveBeenCalled();
+  });
+
+  it('never rewrites when the catalog is the shipped fallback', async () => {
+    // The shipped file may lack an operator-added model; rewriting from it
+    // autosaves and would permanently alter projects during a degradation.
+    await settle();
+    (service as any).globalConfig.set(
+      liveGlobalConfig({modelCatalogSource: 'shipped'}),
+    );
+    service.projectConfig.value.set({
+      ...service.projectConfig.value(),
+      id: 'proj-1',
+      model: 'veo-added-live-only',
+    });
+
+    TestBed.tick();
+
+    expect(service.projectConfig.value().model).toBe('veo-added-live-only');
+    expect(matSnackBarMock.open).not.toHaveBeenCalled();
+  });
+
+  it('never rewrites while the catalog is missing', async () => {
+    await settle();
+    (service as any).globalConfig.set(undefined);
+    service.projectConfig.value.set({
+      ...service.projectConfig.value(),
+      id: 'proj-1',
+      model: 'veo-removed-by-operator',
+    });
+
+    TestBed.tick();
+
+    expect(service.projectConfig.value().model).toBe('veo-removed-by-operator');
+    expect(matSnackBarMock.open).not.toHaveBeenCalled();
+  });
+
+  it('falls back within location-compatible models when the veo default is unusable', async () => {
+    await settle();
+    (service as any).globalConfig.set(
+      liveGlobalConfig({
+        veoLocation: 'us-central1',
+        // At us-central1 the compatible set is veo-central-only and
+        // veo-default; point the default at an incompatible model.
+        modelCatalog: {
+          ...CATALOG,
+          defaults: {veo: 'veo-fast'},
+        },
+      }),
+    );
+    service.projectConfig.value.set({
+      ...service.projectConfig.value(),
+      id: 'proj-1',
+      model: 'veo-removed-by-operator',
+    });
+
+    TestBed.tick();
+
+    expect(service.projectConfig.value().model).toBe('veo-central-only');
+  });
+});

--- a/ui/src/app/services/config/config.ts
+++ b/ui/src/app/services/config/config.ts
@@ -58,13 +58,21 @@ export interface GcsFile {
 }
 
 /**
- * List of available video generation models.
+ * One model's entry in the catalog served by /api/config (the same catalog
+ * the backend validator enforces, so the dropdowns cannot drift from it).
  */
-export const VIDEO_GENERATION_MODELS = [
-  'veo-3.1-generate-001',
-  'veo-3.1-fast-generate-001',
-  'veo-3.1-lite-generate-001',
-];
+export interface ModelCatalogEntry {
+  family: string;
+  actions: string[];
+  locations: string[];
+  capabilities?: Record<string, unknown>;
+}
+
+export interface ModelCatalog {
+  defaults: Record<string, string>;
+  actions: Record<string, {location_param: string | null; default_key: string}>;
+  models: Record<string, ModelCatalogEntry>;
+}
 
 interface GlobalConfig {
   // GCP
@@ -95,6 +103,11 @@ interface GlobalConfig {
   // FFmpeg
   encodingSpeed: number;
   qualityLevel: number;
+
+  // Model catalog (merged into the response by the backend; 'firestore' when
+  // the live config/models doc was served, 'shipped' on fallback).
+  modelCatalog?: ModelCatalog;
+  modelCatalogSource?: 'firestore' | 'shipped';
 }
 
 /**
@@ -368,7 +381,46 @@ export class ConfigService {
    */
   private persistedProjectIds = new Set<string>();
 
-  readonly VIDEO_GENERATION_MODELS = VIDEO_GENERATION_MODELS;
+  /**
+   * Video models compatible with the configured Veo location.
+   * Matches the backend model/location validator. Sorted: Firestore returns
+   * map keys sorted, the shipped fallback keeps file order.
+   */
+  readonly videoModels = computed(() => {
+    const config = this.globalConfig.value();
+    const catalog = config?.modelCatalog;
+    const location = config?.veoLocation;
+    if (!catalog || !location) {
+      return [];
+    }
+    return Object.entries(catalog.models)
+      .filter(
+        ([, model]) =>
+          model.actions.includes('generate_video') &&
+          model.locations.includes(location),
+      )
+      .map(([id]) => id)
+      .sort();
+  });
+
+  /**
+   * Only choose replacements from the live catalog.
+   * The shipped fallback can be stale and must not change project models.
+   */
+  private liveCatalogVideoFallback(): string | undefined {
+    const config = this.globalConfig.value();
+    const catalog = config?.modelCatalog;
+    const models = this.videoModels();
+    if (
+      config?.modelCatalogSource !== 'firestore' ||
+      !catalog ||
+      models.length === 0
+    ) {
+      return undefined;
+    }
+    const veoDefault = catalog.defaults['veo'];
+    return veoDefault && models.includes(veoDefault) ? veoDefault : models[0];
+  }
 
   globalConfig = resource({
     loader: () => this.loadGlobalConfig(),
@@ -506,6 +558,39 @@ export class ConfigService {
         ...ConfigService.THEME_COLORS,
       );
       this.document.documentElement.classList.add(this.primaryColor());
+    });
+    // Replace unavailable project models in this service; not every project
+    // route creates the setup component.
+    effect(() => {
+      const project = this.projectConfig.value();
+      const config = this.globalConfig.value();
+      const models = this.videoModels();
+      const fallback = this.liveCatalogVideoFallback();
+      if (!project.id || !fallback) {
+        return;
+      }
+      if (project.model && models.includes(project.model)) {
+        return;
+      }
+      const previous = project.model;
+      const isPersistedProject = this.persistedProjectIds.has(project.id);
+      const isUnsavedDeployDefault =
+        previous === config?.veoModel && !isPersistedProject;
+      const shouldPersistCorrection =
+        isPersistedProject || (!!previous && !isUnsavedDeployDefault);
+      if (shouldPersistCorrection) {
+        this.updateProjectConfig({model: fallback});
+        const unavailableModel = previous
+          ? `Video model ${previous}`
+          : 'The saved video model';
+        this.matSnackBar.open(
+          `${unavailableModel} is no longer available; switched to ${fallback}.`,
+          'OK',
+        );
+      } else {
+        // A catalog correction alone must not create a new project.
+        this.projectConfig.value.update(c => ({...c, model: fallback}));
+      }
     });
     this.initFaviconListener();
   }
@@ -696,12 +781,19 @@ export class ConfigService {
     // Not persisted yet: the first autosave POSTs /api/projects, where the
     // server stamps createdBy from the verified identity. Left undefined here.
     this.persistedProjectIds.delete(uuid);
-    this.projectConfig.set({
+    const project = {
       ...this.DEFAULT_PROJECT_CONFIG(),
       id: uuid,
       name: 'Untitled Project',
       createdBy: undefined,
-    });
+    };
+    if (!this.videoModels().includes(project.model)) {
+      const fallback = this.liveCatalogVideoFallback();
+      if (fallback) {
+        project.model = fallback;
+      }
+    }
+    this.projectConfig.set(project);
     this.shouldSave = false;
   }
 

--- a/ui/src/app/setup/setup.html
+++ b/ui/src/app/setup/setup.html
@@ -73,7 +73,7 @@
               [ngModel]="config.projectConfig.value().model"
               (ngModelChange)="config.updateProjectConfig({model: $event})"
             >
-              @for (model of config.VIDEO_GENERATION_MODELS; track model) {
+              @for (model of config.videoModels(); track model) {
                 <mat-option [value]="model">{{ model }}</mat-option>
               }
             </mat-select>

--- a/ui/src/app/setup/setup.spec.ts
+++ b/ui/src/app/setup/setup.spec.ts
@@ -49,7 +49,7 @@ describe('Setup image upload', () => {
     projectConfig: {value: ReturnType<typeof signal<Partial<ProjectConfig>>>};
     updateProjectConfig: ReturnType<typeof vi.fn>;
     saveNow: ReturnType<typeof vi.fn>;
-    VIDEO_GENERATION_MODELS: string[];
+    videoModels: () => string[];
   };
   let remixMock: {uploadMedia: ReturnType<typeof vi.fn>};
 
@@ -71,9 +71,8 @@ describe('Setup image upload', () => {
         projectConfig.update(c => ({...c, ...partial})),
       ),
       saveNow: vi.fn(),
-      // The component's model effect reads this; empty keeps the effect's
-      // guard (length > 0) false so it does not fire an extra config update.
-      VIDEO_GENERATION_MODELS: [],
+      // The template's model dropdown reads this.
+      videoModels: () => [],
     };
     remixMock = {
       uploadMedia: vi

--- a/ui/src/app/setup/setup.ts
+++ b/ui/src/app/setup/setup.ts
@@ -181,17 +181,6 @@ export class Setup {
         });
       }
     });
-
-    effect(() => {
-      const project = this.config.projectConfig.value();
-      const availableModels = this.config.VIDEO_GENERATION_MODELS;
-
-      if (project.id && availableModels.length > 0) {
-        if (!project.model || !availableModels.includes(project.model)) {
-          this.config.updateProjectConfig({model: availableModels[0]});
-        }
-      }
-    });
   }
 
   aspectRatioUpdated(aspectRatio: AspectRatio) {

--- a/ui/src/app/storyboard/storyboard.html
+++ b/ui/src/app/storyboard/storyboard.html
@@ -800,7 +800,7 @@
                       [ngModel]="config.projectConfig.value().model"
                       (ngModelChange)="config.updateProjectConfig({model: $event})"
                     >
-                      @for (model of config.VIDEO_GENERATION_MODELS; track model) {
+                      @for (model of config.videoModels(); track model) {
                         <mat-option [value]="model">{{ model }}</mat-option>
                       }
                     </mat-select>

--- a/ui/src/app/storyboard/storyboard.spec.ts
+++ b/ui/src/app/storyboard/storyboard.spec.ts
@@ -65,6 +65,7 @@ describe('Storyboard', () => {
     updateProjectConfig: (partial: Partial<ProjectConfig>) => {
       projectConfigSignal.update(config => ({...config, ...partial}));
     },
+    videoModels: () => [],
     sceneIdCounter: sceneIdCounterSignal,
     primaryColor: signal('theme-green'),
     isGeneratedScene: (
@@ -103,6 +104,7 @@ describe('Storyboard', () => {
       updateProjectConfig: (partial: Partial<ProjectConfig>) => {
         projectConfigSignal.update(config => ({...config, ...partial}));
       },
+      videoModels: () => [],
       sceneIdCounter: sceneIdCounterSignal,
       primaryColor: signal('theme-green'),
       isGeneratedScene: (


### PR DESCRIPTION
## Summary

Serve the model catalog through the existing `/api/config` response and use it for video-model choices on the setup and storyboard pages. This removes the hardcoded UI list so displayed choices follow the same catalog the backend validates.

## Behavior

- `/api/config` adds `modelCatalog` and `modelCatalogSource` while preserving the existing global configuration fields.
- Video-model dropdowns list models that support `generate_video` at the configured Veo location. Model IDs are sorted for stable ordering across live and shipped catalog sources.
- When the live catalog no longer contains a saved project model, the configuration service switches it to the compatible Veo default and shows a notice on any project page. If that default is unavailable at the configured location, it uses the first compatible model.
- A new project whose deploy default is no longer available uses the compatible catalog model before its first save. Saved-project corrections remain visible and are persisted.
- Missing catalogs and the shipped fallback never rewrite existing projects. An unusable live catalog keeps `/api/config` available with the shipped catalog.
- The hardcoded UI model constant and its duplicate drift check are removed.

## Tests

- Backend coverage verifies live-catalog responses, shipped fallback behavior, preservation of global configuration fields, and a console-edited catalog containing Firestore timestamp values.
- UI coverage verifies action and location filtering, stable ordering, missing-config behavior, saved and unsaved model corrections, the immediate new-project payload, incompatible defaults, visible notices, and no rewrite from the shipped fallback.
- Setup and storyboard component fixtures use the catalog-derived model list, while the remaining shipped-model check continues to verify the deployment template against the allowlist.

## Risks / Notes

- Dropdowns are empty while `/api/config` is loading or unavailable.
- Catalog changes reach an open browser tab on reload; this keeps the existing freshness behavior of global configuration.
- Removing a model from the live catalog can update saved projects that used it. The UI announces that update and does not perform it from the shipped fallback.
