### PR TITLE
Settle media conversion and upload batches

### DIFF
--- a/ui/src/app/services/client-media/client-media.spec.ts
+++ b/ui/src/app/services/client-media/client-media.spec.ts
@@ -18,10 +18,6 @@ import {TestBed} from '@angular/core/testing';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {ClientMediaService} from './client-media';
 
-// Note: convertImage / convertVideoToImage / canvasFromMedia draw to a real
-// canvas 2D context and wait for <img>/<video> load events, which jsdom does not
-// implement. Those are exercised in a real browser (and via the higher-level
-// composition specs); here we cover the pure/FileReader-backed helpers.
 describe('ClientMediaService', () => {
   let service: ClientMediaService;
 
@@ -34,6 +30,80 @@ describe('ClientMediaService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('canvas conversion failures', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('rejects convertImage when canvas encoding returns no blob', async () => {
+      const image = document.createElement('img');
+      Object.defineProperties(image, {
+        naturalWidth: {value: 16},
+        naturalHeight: {value: 9},
+      });
+      const canvas = document.createElement('canvas');
+      vi.spyOn(canvas, 'getContext').mockReturnValue({
+        drawImage: vi.fn(),
+        filter: '',
+      } as unknown as CanvasRenderingContext2D);
+      let encode: BlobCallback | undefined;
+      vi.spyOn(canvas, 'toBlob').mockImplementation(callback => {
+        encode = callback;
+      });
+      const createElement = document.createElement.bind(document);
+      vi.spyOn(document, 'createElement').mockImplementation(((
+        tagName: string,
+        options?: ElementCreationOptions,
+      ) => {
+        if (tagName === 'img') return image;
+        if (tagName === 'canvas') return canvas;
+        return createElement(tagName, options);
+      }) as typeof document.createElement);
+
+      const conversion = service.convertImage('https://example.com/image');
+      image.onload?.(new Event('load'));
+
+      expect(encode).toBeDefined();
+      expect(() => encode?.(null)).not.toThrow();
+      await expect(conversion).rejects.toThrow('Failed to convert image');
+    });
+
+    it('rejects convertVideoToImage when thumbnail encoding returns no blob', async () => {
+      const video = document.createElement('video');
+      Object.defineProperties(video, {
+        videoWidth: {value: 16},
+        videoHeight: {value: 9},
+      });
+      const canvas = document.createElement('canvas');
+      vi.spyOn(canvas, 'getContext').mockReturnValue({
+        drawImage: vi.fn(),
+        filter: '',
+      } as unknown as CanvasRenderingContext2D);
+      let encode: BlobCallback | undefined;
+      vi.spyOn(canvas, 'toBlob').mockImplementation(callback => {
+        encode = callback;
+      });
+      const createElement = document.createElement.bind(document);
+      vi.spyOn(document, 'createElement').mockImplementation(((
+        tagName: string,
+        options?: ElementCreationOptions,
+      ) => {
+        if (tagName === 'video') return video;
+        if (tagName === 'canvas') return canvas;
+        return createElement(tagName, options);
+      }) as typeof document.createElement);
+
+      const conversion = service.convertVideoToImage(
+        'https://example.com/video',
+      );
+      video.onseeked?.(new Event('seeked'));
+
+      expect(encode).toBeDefined();
+      expect(() => encode?.(null)).not.toThrow();
+      await expect(conversion).rejects.toThrow('Failed to generate thumbnail');
+    });
   });
 
   describe('toFile', () => {

--- a/ui/src/app/services/client-media/client-media.ts
+++ b/ui/src/app/services/client-media/client-media.ts
@@ -113,7 +113,8 @@ export class ClientMediaService {
           canvas.toBlob(
             blob => {
               if (!blob) {
-                throw new Error('Failed to generate thumbnail');
+                reject(new Error('Failed to generate thumbnail'));
+                return;
               }
               resolve(blob);
             },
@@ -175,7 +176,8 @@ export class ClientMediaService {
           canvas.toBlob(
             blob => {
               if (!blob) {
-                throw new Error('Failed to convert image');
+                reject(new Error('Failed to convert image'));
+                return;
               }
               resolve(blob);
             },

--- a/ui/src/app/setup/setup.spec.ts
+++ b/ui/src/app/setup/setup.spec.ts
@@ -16,11 +16,14 @@
 
 import {signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {MatSnackBar} from '@angular/material/snack-bar';
 import {provideRouter} from '@angular/router';
 import {RouterTestingHarness} from '@angular/router/testing';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {routes} from '../app.routes';
+import {ClientMediaService} from '../services/client-media/client-media';
 import {ConfigService, ProjectConfig} from '../services/config/config';
+import {ImageImportService} from '../services/image-import/image-import';
 import {RemixEngineService} from '../services/remix-engine/remix-engine';
 import {Setup} from './setup';
 
@@ -52,6 +55,14 @@ describe('Setup image upload', () => {
     videoModels: () => string[];
   };
   let remixMock: {uploadMedia: ReturnType<typeof vi.fn>};
+  let clientMediaMock: {convertImage: ReturnType<typeof vi.fn>};
+  let imageImportMock: {
+    importText: ReturnType<typeof vi.fn>;
+    imageFilesFromDataTransfer: ReturnType<typeof vi.fn>;
+    imageUrlFromDataTransfer: ReturnType<typeof vi.fn>;
+    isEditableTarget: ReturnType<typeof vi.fn>;
+  };
+  let snackBarMock: {open: ReturnType<typeof vi.fn>};
 
   beforeEach(async () => {
     const projectConfig = signal<Partial<ProjectConfig>>({
@@ -79,6 +90,20 @@ describe('Setup image upload', () => {
         .fn()
         .mockResolvedValue({path: 'remix-input/x', url: 'https://x'}),
     };
+    clientMediaMock = {
+      convertImage: vi.fn().mockResolvedValue(
+        new Blob(['converted'], {
+          type: 'image/jpeg',
+        }),
+      ),
+    };
+    imageImportMock = {
+      importText: vi.fn().mockResolvedValue({files: [], failures: []}),
+      imageFilesFromDataTransfer: vi.fn().mockReturnValue([]),
+      imageUrlFromDataTransfer: vi.fn().mockReturnValue(null),
+      isEditableTarget: vi.fn().mockReturnValue(false),
+    };
+    snackBarMock = {open: vi.fn()};
 
     TestBed.configureTestingModule({
       imports: [Setup],
@@ -86,12 +111,15 @@ describe('Setup image upload', () => {
         provideRouter(routes),
         {provide: ConfigService, useValue: configMock},
         {provide: RemixEngineService, useValue: remixMock},
+        {provide: ClientMediaService, useValue: clientMediaMock},
+        {provide: ImageImportService, useValue: imageImportMock},
       ],
     });
     // Swap the template for an empty one: this test exercises the
     // processFiles() class logic only, so the full markup (which reads many
     // ConfigService members not on this focused mock) must not render.
     TestBed.overrideComponent(Setup, {set: {template: ''}});
+    TestBed.overrideProvider(MatSnackBar, {useValue: snackBarMock});
     await TestBed.compileComponents();
 
     const fixture = TestBed.createComponent(Setup);
@@ -104,9 +132,9 @@ describe('Setup image upload', () => {
       type: 'image/jpeg',
     });
 
-    component.processFiles(1, [file] as unknown as FileList);
-    // Let the upload Promise.all + .then microtasks settle.
-    await new Promise(r => setTimeout(r, 0));
+    const result = await component.processFiles(1, [
+      file,
+    ] as unknown as FileList);
 
     expect(remixMock.uploadMedia).toHaveBeenCalledTimes(1);
     // The uploaded image was recorded on the product...
@@ -119,6 +147,196 @@ describe('Setup image upload', () => {
     // saveNow runs after the config update that recorded the new image.
     expect(configMock.saveNow.mock.invocationCallOrder[0]).toBeGreaterThan(
       configMock.updateProjectConfig.mock.invocationCallOrder[0],
+    );
+    expect(result).toEqual({added: 1, failures: []});
+  });
+
+  it('keeps successful uploads in input order when a sibling upload fails', async () => {
+    const files = ['a.jpeg', 'b.jpeg', 'c.jpeg'].map(
+      name => new File([name], name, {type: 'image/jpeg'}),
+    );
+    let resolveFirstUpload!: (value: {path: string; url: string}) => void;
+    let resolveThirdUpload!: (value: {path: string; url: string}) => void;
+    remixMock.uploadMedia.mockImplementation((file: File) => {
+      if (file.name === 'a.jpeg') {
+        return new Promise(resolve => {
+          resolveFirstUpload = resolve;
+        });
+      }
+      if (file.name === 'b.jpeg') {
+        return Promise.reject(new Error('upload failed'));
+      }
+      return new Promise(resolve => {
+        resolveThirdUpload = resolve;
+      });
+    });
+
+    const completion = component.processFiles(1, files);
+    await vi.waitFor(() => {
+      expect(remixMock.uploadMedia).toHaveBeenCalledTimes(3);
+    });
+    resolveThirdUpload({
+      path: 'remix-input/c.jpeg',
+      url: 'https://c.jpeg',
+    });
+    await Promise.resolve();
+    resolveFirstUpload({
+      path: 'remix-input/a.jpeg',
+      url: 'https://a.jpeg',
+    });
+    const result = await completion;
+
+    expect(
+      configMock.projectConfig.value().inputConfig?.products[0].images,
+    ).toEqual([
+      {
+        path: 'remix-input/a.jpeg',
+        url: 'https://a.jpeg',
+        name: 'a.jpeg',
+      },
+      {
+        path: 'remix-input/c.jpeg',
+        url: 'https://c.jpeg',
+        name: 'c.jpeg',
+      },
+    ]);
+    expect(result).toEqual({
+      added: 2,
+      failures: [{source: 'b.jpeg', reason: 'upload failed'}],
+    });
+    expect(component.failuresFor(1)).toEqual([
+      {source: 'b.jpeg', reason: 'upload failed'},
+    ]);
+    expect(configMock.updateProjectConfig).toHaveBeenCalledTimes(1);
+    expect(configMock.saveNow).toHaveBeenCalledTimes(1);
+    expect(snackBarMock.open).toHaveBeenCalledWith(
+      '2 images added. 1 could not be added.',
+      'Close',
+      {duration: 6000},
+    );
+  });
+
+  it('keeps valid siblings when another file exceeds the size limit', async () => {
+    const oversized = new File(['large'], 'too-large.jpeg', {
+      type: 'image/jpeg',
+    });
+    Object.defineProperty(oversized, 'size', {
+      value: component.MAX_FILE_SIZE_BYTES + 1,
+    });
+    const valid = new File(['valid'], 'valid.jpeg', {type: 'image/jpeg'});
+
+    const result = await component.processFiles(1, [oversized, valid]);
+
+    expect(remixMock.uploadMedia).toHaveBeenCalledTimes(1);
+    expect(remixMock.uploadMedia).toHaveBeenCalledWith(valid);
+    expect(result).toEqual({
+      added: 1,
+      failures: [
+        {
+          source: 'too-large.jpeg',
+          reason: `File exceeds the ${component.MAX_FILE_SIZE_MB}MB limit`,
+        },
+      ],
+    });
+    expect(
+      configMock.projectConfig.value().inputConfig?.products[0].images,
+    ).toEqual([{path: 'remix-input/x', url: 'https://x', name: 'valid.jpeg'}]);
+    expect(configMock.saveNow).toHaveBeenCalledTimes(1);
+    expect(snackBarMock.open).toHaveBeenCalledWith(
+      '1 image added. 1 could not be added.',
+      'Close',
+      {duration: 6000},
+    );
+  });
+
+  it('does not update or save when every file fails', async () => {
+    const files = [
+      new File(['text'], 'notes.txt', {type: 'text/plain'}),
+      new File(['image'], 'broken.jpeg', {type: 'image/jpeg'}),
+    ];
+    remixMock.uploadMedia.mockRejectedValue(new Error('storage unavailable'));
+
+    const result = await component.processFiles(1, files);
+
+    expect(result).toEqual({
+      added: 0,
+      failures: [
+        {source: 'notes.txt', reason: 'File is not an image'},
+        {source: 'broken.jpeg', reason: 'storage unavailable'},
+      ],
+    });
+    expect(configMock.updateProjectConfig).not.toHaveBeenCalled();
+    expect(configMock.saveNow).not.toHaveBeenCalled();
+    expect(snackBarMock.open).toHaveBeenCalledWith(
+      '0 images added. 2 could not be added.',
+      'Close',
+      {duration: 6000},
+    );
+  });
+
+  it('settles conversion failures without dropping other uploads', async () => {
+    const files = [
+      new File(['webp'], 'broken.webp', {type: 'image/webp'}),
+      new File(['jpeg'], 'working.jpeg', {type: 'image/jpeg'}),
+    ];
+    clientMediaMock.convertImage.mockRejectedValue(
+      new Error('conversion failed'),
+    );
+
+    const result = await component.processFiles(1, files);
+
+    expect(result).toEqual({
+      added: 1,
+      failures: [{source: 'broken.webp', reason: 'conversion failed'}],
+    });
+    expect(
+      configMock.projectConfig.value().inputConfig?.products[0].images,
+    ).toEqual([
+      {
+        path: 'remix-input/x',
+        url: 'https://x',
+        name: 'working.jpeg',
+      },
+    ]);
+    expect(configMock.saveNow).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps link import busy until uploads settle and reports both failure stages', async () => {
+    const successfulFile = new File(['ok'], 'ok.jpeg', {type: 'image/jpeg'});
+    const failedFile = new File(['bad'], 'bad.jpeg', {type: 'image/jpeg'});
+    imageImportMock.importText.mockResolvedValue({
+      files: [successfulFile, failedFile],
+      failures: [{source: 'bad-link', reason: 'could not be downloaded'}],
+    });
+    let resolveUpload!: (value: {path: string; url: string}) => void;
+    remixMock.uploadMedia.mockImplementation((file: File) => {
+      if (file.name === 'bad.jpeg') {
+        return Promise.reject(new Error('upload failed'));
+      }
+      return new Promise(resolve => {
+        resolveUpload = resolve;
+      });
+    });
+
+    const completion = component.addImagesFromLinks(1, 'two links');
+    await vi.waitFor(() => {
+      expect(remixMock.uploadMedia).toHaveBeenCalledTimes(2);
+    });
+    const importingWhileUploadPending = component.isImporting(1);
+    resolveUpload({path: 'remix-input/ok.jpeg', url: 'https://ok.jpeg'});
+    await completion;
+
+    expect(importingWhileUploadPending).toBe(true);
+    expect(component.isImporting(1)).toBe(false);
+    expect(component.failuresFor(1)).toEqual([
+      {source: 'bad-link', reason: 'could not be downloaded'},
+      {source: 'bad.jpeg', reason: 'upload failed'},
+    ]);
+    expect(snackBarMock.open).toHaveBeenCalledTimes(1);
+    expect(snackBarMock.open).toHaveBeenCalledWith(
+      'Added 1 image. 2 could not be added.',
+      'Close',
+      {duration: 6000},
     );
   });
 });

--- a/ui/src/app/setup/setup.ts
+++ b/ui/src/app/setup/setup.ts
@@ -64,6 +64,11 @@ import {TemplateCard} from '../templates/template-card/template-card';
 import {ConfirmTemplateDialog} from './confirm-template-dialog/confirm-template-dialog';
 import {GenerateStoryboardDialog} from './generate-storyboard-dialog/generate-storyboard-dialog';
 
+interface FileProcessResult {
+  added: number;
+  failures: ImportFailure[];
+}
+
 /**
  * Component for the setup view.
  */
@@ -109,7 +114,7 @@ export class Setup {
 
   /** Per-product: true while that product's links are being fetched. */
   importingLinks = signal<Record<number, boolean>>({});
-  /** Per-product: links / base64 from the last import that could not be added. */
+  /** Per-product: images from the last import that could not be added. */
   importFailures = signal<Record<number, ImportFailure[]>>({});
   /** The product whose area was last interacted with — where a page-level
    * image paste lands. */
@@ -286,7 +291,7 @@ export class Setup {
       event.dataTransfer,
     );
     if (files.length > 0) {
-      this.processFiles(productId, files);
+      void this.processFiles(productId, files);
       return;
     }
     // Dragged from another tab: only the image's URL came across — fetch it,
@@ -300,58 +305,69 @@ export class Setup {
   onFileSelected(event: Event, productId: number) {
     const input = event.target as HTMLInputElement;
     if (input.files) {
-      this.processFiles(productId, input.files);
+      void this.processFiles(productId, input.files);
       input.value = ''; // Reset input to allow selecting the same file again
     }
   }
 
-  processFiles(productId: number, files: FileList | File[]) {
+  async processFiles(
+    productId: number,
+    files: FileList | File[],
+    reportResult = true,
+  ): Promise<FileProcessResult> {
     const fileArray = Array.from(files);
-    const oversizedFile = fileArray.find(
-      file => file.size > this.MAX_FILE_SIZE_BYTES,
+    const results = await Promise.allSettled(
+      fileArray.map(async originalFile => {
+        if (originalFile.size > this.MAX_FILE_SIZE_BYTES) {
+          throw new Error(`File exceeds the ${this.MAX_FILE_SIZE_MB}MB limit`);
+        }
+        if (!originalFile.type.startsWith('image/')) {
+          throw new Error('File is not an image');
+        }
+
+        let uploadFile = originalFile;
+        if (
+          !['image/jpeg', 'image/png', 'image/jpg'].includes(uploadFile.type)
+        ) {
+          const newFileName =
+            uploadFile.name.split('.').slice(0, -1).join('.') + '.jpeg';
+          uploadFile = new File(
+            [
+              await this.clientMediaService.convertImage(uploadFile, {
+                mimeType: 'image/jpeg',
+              }),
+            ],
+            newFileName,
+            {type: 'image/jpeg'},
+          );
+        }
+        const {path, url} =
+          await this.remixEngineService.uploadMedia(uploadFile);
+        return {
+          path,
+          url,
+          name: uploadFile.name,
+        };
+      }),
     );
 
-    if (oversizedFile) {
-      this.snackBar.open(
-        `File "${oversizedFile.name}" (${(oversizedFile.size / 1024 / 1024).toFixed(2)}MB) exceeds the ${this.MAX_FILE_SIZE_MB}MB limit.`,
-        'Close',
-        {
-          duration: 10000,
-        },
-      );
-      return;
-    }
+    const uploadedImages: GcsFile[] = [];
+    const failures: ImportFailure[] = [];
+    results.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        uploadedImages.push(result.value);
+        return;
+      }
+      failures.push({
+        source: fileArray[index].name,
+        reason:
+          result.reason instanceof Error
+            ? result.reason.message
+            : String(result.reason),
+      });
+    });
 
-    void Promise.all(
-      fileArray.map(async file => {
-        if (file.type.startsWith('image/')) {
-          if (!['image/jpeg', 'image/png', 'image/jpg'].includes(file.type)) {
-            const newFileName =
-              file.name.split('.').slice(0, -1).join('.') + '.jpeg';
-            file = new File(
-              [
-                await this.clientMediaService.convertImage(file, {
-                  mimeType: 'image/jpeg',
-                }),
-              ],
-              newFileName,
-              {type: 'image/jpeg'},
-            );
-          }
-          const {path, url} = await this.remixEngineService.uploadMedia(file);
-          return {
-            path,
-            url,
-            name: file.name,
-          };
-        } else {
-          console.error(`File ${file.name} is not an image`);
-          return null;
-        }
-      }),
-    ).then(results => {
-      const uploadedImages: GcsFile[] = [];
-      uploadedImages.push(...results.filter(file => file !== null));
+    if (uploadedImages.length > 0) {
       this.config.updateProjectConfig({
         inputConfig: {
           ...this.config.projectConfig.value().inputConfig,
@@ -369,7 +385,23 @@ export class Setup {
       // document references the uploaded media right away rather than 5s later;
       // the trailing debounce is deduped on the same config. No-op in legacy.
       this.config.saveNow();
-    });
+    }
+
+    if (reportResult) {
+      this.importFailures.update(current => ({
+        ...current,
+        [productId]: failures,
+      }));
+      if (failures.length > 0) {
+        this.snackBar.open(
+          `${uploadedImages.length} image${uploadedImages.length === 1 ? '' : 's'} added. ${failures.length} could not be added.`,
+          'Close',
+          {duration: 6000},
+        );
+      }
+    }
+
+    return {added: uploadedImages.length, failures};
   }
 
   /**
@@ -390,19 +422,21 @@ export class Setup {
     this.importFailures.update(m => ({...m, [productId]: []}));
     try {
       const {files, failures} = await this.imageImport.importText(trimmed);
-      this.importFailures.update(m => ({...m, [productId]: failures}));
-      if (files.length > 0) {
-        this.processFiles(productId, files);
-      }
-      if (files.length > 0 || failures.length > 0) {
+      const uploadResult =
+        files.length > 0
+          ? await this.processFiles(productId, files, false)
+          : {added: 0, failures: []};
+      const allFailures = [...failures, ...uploadResult.failures];
+      this.importFailures.update(m => ({...m, [productId]: allFailures}));
+      if (uploadResult.added > 0 || allFailures.length > 0) {
         const parts: string[] = [];
-        if (files.length > 0) {
+        if (uploadResult.added > 0) {
           parts.push(
-            `Added ${files.length} image${files.length === 1 ? '' : 's'}.`,
+            `Added ${uploadResult.added} image${uploadResult.added === 1 ? '' : 's'}.`,
           );
         }
-        if (failures.length > 0) {
-          parts.push(`${failures.length} could not be added.`);
+        if (allFailures.length > 0) {
+          parts.push(`${allFailures.length} could not be added.`);
         }
         this.snackBar.open(parts.join(' '), 'Close', {duration: 6000});
       }
@@ -445,7 +479,7 @@ export class Setup {
     const target =
       products.find(p => p.id === this.activeProductId()) ?? products[0];
     event.preventDefault();
-    this.processFiles(target.id, images);
+    void this.processFiles(target.id, images);
   }
 
   removeImage(productId: number, imageIndex: number) {


### PR DESCRIPTION
## Summary

Reject null canvas encodes and preserve successful images from partially failed upload batches.

## Behavior

- Canvas conversion promises reject when the browser returns no encoded blob.
- Multi-image uploads wait for every item and attach successful files once in input order.
- Failed direct uploads expose source and reason through the existing failure panel; link imports report one combined result.
- An all-failed batch leaves project state unchanged.
- Link imports remain busy until uploads settle.

## Tests

- Covers both null canvas callbacks, partial conversion and upload failures, oversized and non-image inputs, all-failed batches, and one project save.
- Forces later upload completion before an earlier upload and verifies input ordering.
- Covers link-import settlement and its combined success/failure notice.

## Risks / Notes

Objects uploaded before a later client-side failure cannot be deleted because the current mediated API has no delete operation.
