### PR TITLE
Serialize project saves and enforce render eligibility

### DIFF
--- a/actions/combine_video.py
+++ b/actions/combine_video.py
@@ -113,7 +113,10 @@ def execute(
       if 'video' == arr['file_type']:
         transition = arr.get('transition')
         transition_overlap = arr.get('transition_overlap')
-        if transition and not transition_overlap:
+        # Only an absent overlap defaults. An explicit 0 means a hard cut and
+        # is falsy, so a truthiness check would silently turn it into a
+        # half-second crossfade.
+        if transition and transition_overlap is None:
           transition_overlap = 0.5
 
         ffmpeg.add_video(

--- a/actions/test/test_combine_video.py
+++ b/actions/test/test_combine_video.py
@@ -358,6 +358,33 @@ class TestCombineVideo(unittest.TestCase):
         transition_overlap=0.5,
     )
 
+  def test_execute_preserves_explicit_zero_transition_overlap(self):
+    """An explicit 0 overlap means a hard cut and must not become 0.5."""
+    arrangement = [{
+        'file_type': 'video',
+        'file_path': 'video1.mp4',
+        'transition': 'circlecrop',
+        'transition_overlap': 0,
+    }]
+    self.mock_gcs.load_text.return_value = json.dumps(arrangement)
+
+    combine_video.execute(
+        self.mock_gcs,
+        self.mock_workflow_params,
+        [{Key.FILE.value: 'arrangement.json'}],
+        '1280:720',
+        6,
+        20,
+    )
+
+    self.mock_ffmpeg.add_video.assert_called_with(
+        path=mock.ANY,
+        skip_time=0,
+        duration=-1,
+        transition='circlecrop',
+        transition_overlap=0,
+    )
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/ui/src/app/composition/composition.html
+++ b/ui/src/app/composition/composition.html
@@ -119,11 +119,7 @@
 
         <div class="actions-panel">
           <span
-            [matTooltip]="
-              canRender()
-                ? ''
-                : 'Select or upload at least one scene video before rendering.'
-            "
+            [matTooltip]="renderDisabledReason()"
           >
             <button
               mat-flat-button

--- a/ui/src/app/composition/composition.spec.ts
+++ b/ui/src/app/composition/composition.spec.ts
@@ -499,6 +499,33 @@ describe('CompositionComponent', () => {
     expect(button.textContent).toContain('Rendering...');
   });
 
+  it('reports the render-in-progress reason ahead of other disabled reasons', () => {
+    const remixEngineService = TestBed.inject(RemixEngineService);
+    // An invalid scene would normally set its own disabled reason; a render
+    // already in progress must be reported instead.
+    projectConfigSignal.set({
+      ...projectConfigSignal(),
+      storyboard: [
+        {
+          id: 'invalid',
+          type: 'video',
+          name: 'Invalid clip',
+          video: {url: '', path: 'videos/invalid.mp4'},
+          durationSeconds: Number.NaN,
+        },
+      ],
+    });
+    remixEngineService.combiningScenes.set(true);
+    fixture.detectChanges();
+
+    expect(component.renderDisabledReason()).toBe(
+      'Video rendering is in progress.',
+    );
+    const button = fixture.nativeElement.querySelector('button.mat-primary');
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toContain('Rendering...');
+  });
+
   it('should enable the render button when combiningScenes is false', () => {
     const remixEngineService = TestBed.inject(RemixEngineService);
     // The render button also requires at least one renderable scene (a

--- a/ui/src/app/composition/composition.spec.ts
+++ b/ui/src/app/composition/composition.spec.ts
@@ -499,6 +499,68 @@ describe('CompositionComponent', () => {
     expect(button.textContent).toContain('Rendering...');
   });
 
+  it('disables Render when a transition is longer than the clips it joins', () => {
+    // Each clip is individually valid, but the 0.5s crossfade on the second
+    // scene is longer than the 42ms first clip, which ffmpeg would consume
+    // entirely.
+    projectConfigSignal.set({
+      ...projectConfigSignal(),
+      storyboard: [
+        {
+          id: 'short',
+          type: 'video',
+          name: 'Short clip',
+          video: {url: '', path: 'videos/short.mp4'},
+          durationSeconds: 5,
+          trim: {start: 0, end: 0.042},
+        },
+        {
+          id: 'next',
+          type: 'video',
+          name: 'Next clip',
+          video: {url: '', path: 'videos/next.mp4'},
+          durationSeconds: 5,
+          transition: 'fade',
+          transitionOverlap: 0.5,
+        },
+      ],
+    });
+    fixture.detectChanges();
+
+    expect(component.canRender()).toBe(false);
+    expect(component.renderDisabledReason()).toContain(
+      'longer than the clips it joins',
+    );
+  });
+
+  it('keeps Render enabled for a transition that fits its clips', () => {
+    projectConfigSignal.set({
+      ...projectConfigSignal(),
+      storyboard: [
+        {
+          id: 'a',
+          type: 'video',
+          name: 'Clip A',
+          video: {url: '', path: 'videos/a.mp4'},
+          durationSeconds: 5,
+        },
+        {
+          id: 'b',
+          type: 'video',
+          name: 'Clip B',
+          video: {url: '', path: 'videos/b.mp4'},
+          durationSeconds: 5,
+          transition: 'fade',
+          transitionOverlap: 0.5,
+        },
+      ],
+    });
+    fixture.detectChanges();
+
+    expect(component.canRender()).toBe(true);
+    expect(component.renderDisabledReason()).toBe('');
+  });
+
   it('reports the render-in-progress reason ahead of other disabled reasons', () => {
     const remixEngineService = TestBed.inject(RemixEngineService);
     // An invalid scene would normally set its own disabled reason; a render

--- a/ui/src/app/composition/composition.spec.ts
+++ b/ui/src/app/composition/composition.spec.ts
@@ -20,6 +20,7 @@ import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {
   ConfigService,
+  GcsFile,
   GeneratedScene,
   ProjectConfig,
   ProvidedVideoScene,
@@ -118,6 +119,139 @@ describe('CompositionComponent', () => {
     expect(component.filmstripScenes().length).toBe(0);
   });
 
+  it('does not render a URL-only provided video', () => {
+    projectConfigSignal.update(config => ({
+      ...config,
+      storyboard: [
+        {
+          id: 'legacy-video',
+          type: 'video',
+          name: 'Legacy video',
+          video: {url: 'https://legacy.example/video.mp4', path: ''},
+          durationSeconds: 5,
+        },
+      ],
+    }));
+
+    expect(component.filmstripScenes()).toEqual([]);
+    expect(component.canRender()).toBe(false);
+  });
+
+  it('treats a legacy URL-only video with no path field as invalid', () => {
+    projectConfigSignal.update(config => ({
+      ...config,
+      storyboard: [
+        {
+          id: 'legacy-video-without-path',
+          type: 'video',
+          name: 'Legacy video without path',
+          video: {
+            url: 'https://legacy.example/video.mp4',
+          } as unknown as GcsFile,
+          durationSeconds: 5,
+        },
+      ],
+    }));
+
+    expect(component.filmstripScenes()).toEqual([]);
+    expect(component.canRender()).toBe(false);
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['zero', 0],
+  ])(
+    'does not render a provided video with %s duration',
+    (_label, duration) => {
+      projectConfigSignal.update(config => ({
+        ...config,
+        storyboard: [
+          {
+            id: 'invalid-video',
+            type: 'video',
+            name: 'Invalid video',
+            video: {url: '', path: 'videos/invalid.mp4'},
+            durationSeconds: duration,
+          },
+        ],
+      }));
+
+      expect(component.filmstripScenes()).toEqual([]);
+      expect(component.canRender()).toBe(false);
+    },
+  );
+
+  it('does not render a persisted trim shorter than one 24fps frame', () => {
+    projectConfigSignal.update(config => ({
+      ...config,
+      storyboard: [
+        {
+          id: 'too-short',
+          type: 'video',
+          name: 'Too-short clip',
+          video: {url: '', path: 'videos/too-short.mp4'},
+          durationSeconds: 5,
+          trim: {start: 2, end: 2.041},
+        },
+      ],
+    }));
+
+    expect(component.filmstripScenes()).toEqual([]);
+    expect(component.canRender()).toBe(false);
+  });
+
+  it('renders a persisted trim that contains one full 24fps frame', () => {
+    projectConfigSignal.update(config => ({
+      ...config,
+      storyboard: [
+        {
+          id: 'one-frame',
+          type: 'video',
+          name: 'One-frame clip',
+          video: {url: '', path: 'videos/one-frame.mp4'},
+          durationSeconds: 5,
+          trim: {start: 2, end: 2.042},
+        },
+      ],
+    }));
+
+    expect(component.filmstripScenes().map(scene => scene.id)).toEqual([
+      'one-frame',
+    ]);
+    expect(component.canRender()).toBe(true);
+    expect(Math.round(component.playlist()[0].duration * 24)).toBe(1);
+  });
+
+  it('blocks a partial render when an intended clip is invalid', () => {
+    projectConfigSignal.update(config => ({
+      ...config,
+      storyboard: [
+        {
+          id: 'ready',
+          type: 'video',
+          name: 'Ready clip',
+          video: {url: '', path: 'videos/ready.mp4'},
+          durationSeconds: 5,
+        },
+        {
+          id: 'invalid',
+          type: 'video',
+          name: 'Invalid clip',
+          video: {url: '', path: 'videos/invalid.mp4'},
+          durationSeconds: Number.NaN,
+        },
+      ],
+    }));
+
+    expect(component.filmstripScenes().map(scene => scene.id)).toEqual([
+      'ready',
+    ]);
+    expect(component.canRender()).toBe(false);
+    expect(component.renderDisabledReason()).toContain(
+      'storage path or valid duration',
+    );
+  });
+
   it('should show a generated scene in the filmstrip if it has a selected candidate', () => {
     const generatedScene: GeneratedScene = {
       id: '1',
@@ -163,12 +297,13 @@ describe('CompositionComponent', () => {
     expect(component.filmstripScenes().length).toBe(0);
   });
 
-  it('should show a video scene in the filmstrip if it has a videoUrl', () => {
+  it('shows a provided video with a path and positive duration', () => {
     const videoScene: ProvidedVideoScene = {
       id: '2',
       type: 'video',
       name: 'Scene 2',
       video: {url: 'http://video.url/2', path: 'path/to/video/2'},
+      durationSeconds: 5,
     };
 
     projectConfigSignal.set({
@@ -217,6 +352,7 @@ describe('CompositionComponent', () => {
       type: 'video',
       name: 'Scene 2',
       video: {url: '', path: 'path/to/video/2'},
+      durationSeconds: 5,
     };
 
     projectConfigSignal.set({
@@ -289,6 +425,7 @@ describe('CompositionComponent', () => {
         type: 'video',
         name: 'Scene 3',
         video: {url: 'u3', path: 'path3'},
+        durationSeconds: 5,
       },
       {
         id: '4',

--- a/ui/src/app/composition/composition.ts
+++ b/ui/src/app/composition/composition.ts
@@ -148,6 +148,9 @@ export class Composition {
   );
 
   renderDisabledReason = computed(() => {
+    if (this.combiningScenes()) {
+      return 'Video rendering is in progress.';
+    }
     if (
       this.sceneRenderClips().some(
         ({resolution}) => resolution.state === 'invalid',

--- a/ui/src/app/composition/composition.ts
+++ b/ui/src/app/composition/composition.ts
@@ -39,6 +39,7 @@ import {FormatTimePipe} from '../pipes/format-time-pipe';
 import {
   ConfigService,
   DEFAULT_TRANSITION_OVERLAP,
+  findTransitionContractViolation,
   resolveSceneRenderClip,
 } from '../services/config/config';
 import {MediaRef, MediaService} from '../services/media/media';
@@ -139,12 +140,17 @@ export class Composition {
    * clip is valid. An empty playlist would fail in the backend, while omitting
    * an invalid intended clip would silently render only part of the storyboard.
    */
+  private transitionViolation = computed(() =>
+    findTransitionContractViolation(this.scenes()),
+  );
+
   canRender = computed(
     () =>
       this.playlist().length > 0 &&
       !this.sceneRenderClips().some(
         ({resolution}) => resolution.state === 'invalid',
-      ),
+      ) &&
+      this.transitionViolation() === null,
   );
 
   renderDisabledReason = computed(() => {
@@ -163,6 +169,10 @@ export class Composition {
     }
     if (this.playlist().length === 0) {
       return 'Select or upload at least one scene video before rendering.';
+    }
+    const transitionViolation = this.transitionViolation();
+    if (transitionViolation) {
+      return transitionViolation;
     }
     return '';
   });

--- a/ui/src/app/composition/composition.ts
+++ b/ui/src/app/composition/composition.ts
@@ -39,6 +39,7 @@ import {FormatTimePipe} from '../pipes/format-time-pipe';
 import {
   ConfigService,
   DEFAULT_TRANSITION_OVERLAP,
+  resolveSceneRenderClip,
 } from '../services/config/config';
 import {MediaRef, MediaService} from '../services/media/media';
 import {MediaSrcPipe} from '../services/media/media-src.pipe';
@@ -99,74 +100,69 @@ export class Composition {
     return ratio ? ratio.replace(':', '/') : '16/9';
   });
 
-  filmstripScenes = computed(() => {
-    return this.scenes().filter(scene => {
-      if (
-        this.configService.isGeneratedScene(scene) &&
-        scene.candidates &&
-        scene.selectedCandidateIndex !== undefined
-      ) {
-        // Downstream resolves media by path (signing it on read), so a scene
-        // persisted with a path but a blank url is still renderable: accept
-        // either a path or a url.
-        const video = scene.candidates[scene.selectedCandidateIndex].video;
-        return !!(video?.path || video?.url);
+  private sceneRenderClips = computed(() =>
+    this.scenes().map(scene => ({
+      scene,
+      resolution: resolveSceneRenderClip(scene),
+    })),
+  );
+
+  filmstripScenes = computed(() =>
+    this.sceneRenderClips()
+      .filter(({resolution}) => resolution.state === 'ready')
+      .map(({scene}) => scene),
+  );
+
+  playlist = computed(() => {
+    return this.sceneRenderClips().flatMap(({scene, resolution}) => {
+      if (resolution.state !== 'ready') {
+        return [];
       }
-      if (this.configService.isProvidedVideoScene(scene)) {
-        return !!(scene.video?.path || scene.video?.url);
-      }
-      return false;
+      const {video, start, duration} = resolution.clip;
+      return [
+        {
+          id: scene.id,
+          name: scene.name,
+          video,
+          start,
+          end: start + duration,
+          duration,
+          transitionOverlap: scene.transitionOverlap,
+          type: scene.type,
+        },
+      ];
     });
   });
 
-  playlist = computed(() => {
-    return this.filmstripScenes()
-      .map(scene => {
-        if (this.configService.isGeneratedScene(scene)) {
-          if (!scene.candidates || scene.selectedCandidateIndex === undefined) {
-            return;
-          }
-          const candidate = scene.candidates[scene.selectedCandidateIndex];
-          const start = candidate.trim?.start ?? 0;
-          const end = candidate.trim?.end ?? candidate.durationSeconds;
-          return {
-            id: scene.id,
-            name: scene.name,
-            video: candidate.video,
-            start,
-            end,
-            duration: end - start,
-            transitionOverlap: scene.transitionOverlap,
-            type: 'generated' as const,
-          };
-        } else {
-          // VideoScene
-          const start = scene.trim?.start ?? 0;
-          const end = scene.trim?.end ?? scene.durationSeconds!;
-          return {
-            id: scene.id,
-            name: scene.name,
-            video: scene.video,
-            start,
-            end,
-            duration: end - start,
-            transitionOverlap: scene.transitionOverlap,
-            type: 'video' as const,
-          };
-        }
-      })
-      .filter(item => item !== undefined);
-  });
-
   /**
-   * True when at least one scene contributes a usable video to the render
-   * (a selected candidate with a video, or an uploaded video scene). The
-   * playlist already filters to exactly those scenes, so an empty playlist
-   * means there is nothing to combine — rendering would fail in the backend
-   * with "cannot generate video without at least one video input", so we block
-   * it in the UI instead.
+   * True when at least one scene contributes a usable video and every intended
+   * clip is valid. An empty playlist would fail in the backend, while omitting
+   * an invalid intended clip would silently render only part of the storyboard.
    */
-  canRender = computed(() => this.playlist().length > 0);
+  canRender = computed(
+    () =>
+      this.playlist().length > 0 &&
+      !this.sceneRenderClips().some(
+        ({resolution}) => resolution.state === 'invalid',
+      ),
+  );
+
+  renderDisabledReason = computed(() => {
+    if (
+      this.sceneRenderClips().some(
+        ({resolution}) => resolution.state === 'invalid',
+      )
+    ) {
+      return (
+        'One or more selected scene videos are missing a storage path or valid ' +
+        'duration, or have an invalid trim.'
+      );
+    }
+    if (this.playlist().length === 0) {
+      return 'Select or upload at least one scene video before rendering.';
+    }
+    return '';
+  });
 
   currentPlaylistIndex = signal(0);
   isPlaying = signal(false);

--- a/ui/src/app/services/config/config-mediated.spec.ts
+++ b/ui/src/app/services/config/config-mediated.spec.ts
@@ -793,6 +793,107 @@ describe('ConfigService (mediated data plane)', () => {
     });
   });
 
+  describe('stale autosave callbacks after deletion', () => {
+    it('a late SUCCESS after deletion starts no queued save', async () => {
+      markPersisted('proj-1');
+      const firstResponse = new Subject<unknown>();
+      httpClientMock.patch.mockReturnValue(firstResponse);
+
+      service.updateProjectConfig({id: 'proj-1', name: 'A'});
+      service.saveNow();
+      // Queues a pending save against the SAME (soon-to-be-orphaned) state
+      // object, since a save is already in flight.
+      service.updateProjectConfig({name: 'B'});
+      service.saveNow();
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+
+      await service.deleteProject('proj-1');
+
+      // The in-flight request's response arrives after the project is gone.
+      firstResponse.next({});
+
+      // Unguarded, the success handler would start the queued pending save,
+      // resurrecting the project with a second PATCH.
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+      expect((service as any).projectSaveStates.has('proj-1')).toBe(false);
+    });
+
+    it('a late FAILURE after deletion shows no snackbar and retries nothing', async () => {
+      markPersisted('proj-1');
+      const firstResponse = new Subject<unknown>();
+      httpClientMock.patch.mockReturnValue(firstResponse);
+
+      service.updateProjectConfig({id: 'proj-1', name: 'A'});
+      service.saveNow();
+
+      await service.deleteProject('proj-1');
+
+      firstResponse.error(new Error('late failure'));
+
+      expect(matSnackBarMock.open).not.toHaveBeenCalled();
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+      expect((service as any).projectSaveStates.has('proj-1')).toBe(false);
+    });
+
+    it('Retry from a snackbar shown before deletion does not recreate the project', async () => {
+      markPersisted('proj-1');
+      const failedResponse = new Subject<unknown>();
+      const retryAction = new Subject<void>();
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      httpClientMock.patch.mockReturnValueOnce(failedResponse);
+      matSnackBarMock.open.mockReturnValue({onAction: () => retryAction});
+
+      service.updateProjectConfig({id: 'proj-1', name: 'A'});
+      service.saveNow();
+      failedResponse.error(new Error('save failed'));
+      expect(matSnackBarMock.open).toHaveBeenCalledTimes(1);
+
+      await service.deleteProject('proj-1');
+      retryAction.next();
+
+      // Unguarded, Retry calls persistNow() for the deleted id, which (since
+      // persistedProjectIds was also cleared by delete) issues a fresh POST.
+      expect(httpClientMock.post).not.toHaveBeenCalled();
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+      expect((service as any).projectSaveStates.has('proj-1')).toBe(false);
+      errorSpy.mockRestore();
+    });
+
+    it('a stale callback cannot corrupt a same-id project recreated after delete', async () => {
+      markPersisted('proj-1');
+      const oldResponse = new Subject<unknown>();
+      httpClientMock.patch.mockReturnValueOnce(oldResponse);
+
+      // The old project: a save starts (capturing the OLD save-state object),
+      // then a second edit queues a pending save against that same object.
+      service.updateProjectConfig({id: 'proj-1', name: 'old-A'});
+      service.saveNow();
+      service.updateProjectConfig({name: 'old-B'});
+      service.saveNow();
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+
+      await service.deleteProject('proj-1');
+
+      // A new project reuses the same id, getting its OWN save-state object.
+      service.setNewProject('proj-1');
+      service.updateProjectConfig({name: 'new'});
+      service.saveNow();
+      expect(httpClientMock.post).toHaveBeenCalledTimes(1);
+
+      // The old in-flight request finally resolves. Unguarded, its success
+      // handler would start the OLD queued 'old-B' pending save against the
+      // NOW-persisted id, PATCHing the new project with stale deleted data.
+      oldResponse.next({});
+
+      // Still just the one PATCH for 'old-A' from before deletion: nothing
+      // new was triggered by the stale response.
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+      expect(
+        (service as any).projectSaveStates.get('proj-1').lastSavedSource.name,
+      ).toBe('new');
+    });
+  });
+
   describe('debounced autosave interplay', () => {
     it('should save a dirty config via the debounce when not flushed', async () => {
       markPersisted('proj-1');

--- a/ui/src/app/services/config/config-mediated.spec.ts
+++ b/ui/src/app/services/config/config-mediated.spec.ts
@@ -20,7 +20,7 @@ import {DOCUMENT} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {Router} from '@angular/router';
-import {of, throwError} from 'rxjs';
+import {of, Subject, throwError} from 'rxjs';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {ConfigService} from './config';
 
@@ -377,6 +377,366 @@ describe('ConfigService (mediated data plane)', () => {
     });
   });
 
+  describe('ordered autosave persistence', () => {
+    it('preserves newer local data when returning during an in-flight save', async () => {
+      const firstSave = new Subject<unknown>();
+      const secondSave = new Subject<unknown>();
+      const staleReload = new Subject<any>();
+      httpClientMock.patch
+        .mockReturnValueOnce(firstSave)
+        .mockReturnValueOnce(secondSave);
+      httpClientMock.get.mockImplementation((url: string) => {
+        if (url === '/api/config') {
+          return of({});
+        }
+        if (url === '/api/projects/proj-2') {
+          return of({
+            ...service.projectConfig.value(),
+            id: 'proj-2',
+            name: 'project B',
+          });
+        }
+        return staleReload;
+      });
+      markPersisted('proj-1');
+      service.updateProjectConfig({
+        id: 'proj-1',
+        name: 'new A',
+        inputConfig: {
+          ...service.projectConfig.value().inputConfig,
+          composition: 'new local composition',
+        },
+      });
+      service.saveNow();
+
+      service.loadProjectConfig('proj-2');
+      await vi.waitFor(() => {
+        expect(service.projectConfig.value().id).toBe('proj-2');
+      });
+      service.loadProjectConfig('proj-1');
+      await vi.waitFor(() => {
+        expect(httpClientMock.get).toHaveBeenCalledWith('/api/projects/proj-1');
+      });
+      staleReload.next({
+        ...service.projectConfig.value(),
+        id: 'proj-1',
+        name: 'old A',
+        inputConfig: {
+          ...service.projectConfig.value().inputConfig,
+          composition: 'old server composition',
+        },
+      });
+      staleReload.complete();
+      await vi.waitFor(() => {
+        expect(service.projectConfig.value().id).toBe('proj-1');
+      });
+
+      firstSave.next({});
+      firstSave.complete();
+      service.updateProjectConfig({name: 'edited after reload'});
+      service.saveNow();
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(2);
+      expect(httpClientMock.patch.mock.calls[1][1]).toEqual(
+        expect.objectContaining({
+          name: 'edited after reload',
+          inputConfig: expect.objectContaining({
+            composition: 'new local composition',
+          }),
+        }),
+      );
+      secondSave.next({});
+    });
+
+    it('preserves a failed new project when its reload returns 404', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      httpClientMock.post.mockReturnValue(
+        throwError(() => new Error('save failed')),
+      );
+      httpClientMock.get.mockImplementation((url: string) =>
+        url === '/api/config'
+          ? of({})
+          : throwError(() => new HttpErrorResponse({status: 404})),
+      );
+      service.setNewProject('new-proj');
+      service.updateProjectConfig({name: 'unsaved local project'});
+      service.saveNow();
+      service.setNewProject('other-proj');
+
+      service.loadProjectConfig('new-proj');
+
+      await vi.waitFor(() => {
+        expect(service.projectConfig.value()).toEqual(
+          expect.objectContaining({
+            id: 'new-proj',
+            name: 'unsaved local project',
+          }),
+        );
+      });
+      errorSpy.mockRestore();
+    });
+
+    it('waits for the current save before sending a newer snapshot', () => {
+      markPersisted('proj-1');
+      const firstResponse = new Subject<unknown>();
+      const secondResponse = new Subject<unknown>();
+      httpClientMock.patch
+        .mockReturnValueOnce(firstResponse)
+        .mockReturnValueOnce(secondResponse);
+
+      service.updateProjectConfig({id: 'proj-1', name: 'A'});
+      service.saveNow();
+      service.updateProjectConfig({name: 'B'});
+      service.saveNow();
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+      expect(httpClientMock.patch.mock.calls[0][1]).toEqual(
+        expect.objectContaining({name: 'A'}),
+      );
+
+      firstResponse.next({});
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(2);
+      expect(httpClientMock.patch.mock.calls[1][1]).toEqual(
+        expect.objectContaining({name: 'B'}),
+      );
+      secondResponse.next({});
+    });
+
+    it('coalesces intermediate snapshots while a save is in flight', () => {
+      markPersisted('proj-1');
+      const firstResponse = new Subject<unknown>();
+      const finalResponse = new Subject<unknown>();
+      httpClientMock.patch
+        .mockReturnValueOnce(firstResponse)
+        .mockReturnValueOnce(finalResponse);
+
+      service.updateProjectConfig({id: 'proj-1', name: 'A'});
+      service.saveNow();
+      service.updateProjectConfig({name: 'B'});
+      service.saveNow();
+      service.updateProjectConfig({name: 'C'});
+      service.saveNow();
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+      firstResponse.next({});
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(2);
+      expect(
+        httpClientMock.patch.mock.calls.map(([, body]: any[]) => body.name),
+      ).toEqual(['A', 'C']);
+      finalResponse.next({});
+    });
+
+    it('captures queued nested data without defeating source dedupe', () => {
+      markPersisted('proj-1');
+      const firstResponse = new Subject<unknown>();
+      const queuedResponse = new Subject<unknown>();
+      httpClientMock.patch
+        .mockReturnValueOnce(firstResponse)
+        .mockReturnValueOnce(queuedResponse);
+
+      service.updateProjectConfig({id: 'proj-1', name: 'A'});
+      service.saveNow();
+      service.updateProjectConfig({
+        name: 'B',
+        inputConfig: {
+          ...service.projectConfig.value().inputConfig,
+          products: [{id: 1, name: 'queued product', images: []}],
+        },
+      });
+      service.saveNow();
+
+      const queuedSource = service.projectConfig.value();
+      queuedSource.inputConfig.products[0].name = 'mutated after queueing';
+      service.saveNow();
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+      firstResponse.next({});
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(2);
+      expect(httpClientMock.patch.mock.calls[1][1]).toEqual(
+        expect.objectContaining({
+          inputConfig: expect.objectContaining({
+            products: [expect.objectContaining({name: 'queued product'})],
+          }),
+        }),
+      );
+      queuedResponse.next({});
+    });
+
+    it('keeps ordering and confirmation state independent per project', () => {
+      markPersisted('proj-1');
+      const firstProjectResponse = new Subject<unknown>();
+      const queuedFirstProjectResponse = new Subject<unknown>();
+      const secondProjectResponse = new Subject<unknown>();
+      httpClientMock.patch.mockImplementation(
+        (url: string, body: {name: string}) => {
+          if (url.endsWith('/proj-2')) {
+            return secondProjectResponse;
+          }
+          return body.name === 'project A1'
+            ? firstProjectResponse
+            : queuedFirstProjectResponse;
+        },
+      );
+
+      service.updateProjectConfig({id: 'proj-1', name: 'project A1'});
+      service.saveNow();
+      service.updateProjectConfig({name: 'project A2'});
+      service.saveNow();
+
+      service.setNewProject('proj-2');
+      markPersisted('proj-2');
+      service.updateProjectConfig({name: 'project B'});
+      service.saveNow();
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(2);
+
+      secondProjectResponse.next({});
+      firstProjectResponse.next({});
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(3);
+      expect(httpClientMock.patch.mock.calls[2][1]).toEqual(
+        expect.objectContaining({name: 'project A2'}),
+      );
+      queuedFirstProjectResponse.next({});
+      service.saveNow();
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(3);
+    });
+
+    it('recovers a queued create conflict with one PATCH of the latest snapshot', () => {
+      const createResponse = new Subject<unknown>();
+      const updateResponse = new Subject<unknown>();
+      httpClientMock.post.mockReturnValue(createResponse);
+      httpClientMock.patch.mockReturnValue(updateResponse);
+
+      service.setNewProject('dupe-proj');
+      service.updateProjectConfig({name: 'A'});
+      service.saveNow();
+      service.updateProjectConfig({name: 'B'});
+      service.saveNow();
+
+      expect(httpClientMock.post).toHaveBeenCalledTimes(1);
+      expect(httpClientMock.patch).not.toHaveBeenCalled();
+
+      createResponse.error(new HttpErrorResponse({status: 409}));
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+      expect(httpClientMock.patch.mock.calls[0][1]).toEqual(
+        expect.objectContaining({id: 'dupe-proj', name: 'B'}),
+      );
+      updateResponse.next({});
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+    });
+
+    it('continues with the latest queued snapshot after a failed save', () => {
+      markPersisted('proj-1');
+      const firstResponse = new Subject<unknown>();
+      const queuedResponse = new Subject<unknown>();
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      httpClientMock.patch
+        .mockReturnValueOnce(firstResponse)
+        .mockReturnValueOnce(queuedResponse);
+
+      service.updateProjectConfig({id: 'proj-1', name: 'A'});
+      service.saveNow();
+      service.updateProjectConfig({name: 'B'});
+      service.saveNow();
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+      firstResponse.error(new Error('save failed'));
+
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Unsaved changes — failed to save the project.',
+        'Retry',
+        {panelClass: ['error-snackbar']},
+      );
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(2);
+      expect(httpClientMock.patch.mock.calls[1][1]).toEqual(
+        expect.objectContaining({name: 'B'}),
+      );
+      queuedResponse.next({});
+      errorSpy.mockRestore();
+    });
+
+    it('recovers an off-project create conflict with the captured project', () => {
+      const createResponse = new Subject<unknown>();
+      const updateResponse = new Subject<unknown>();
+      httpClientMock.post.mockReturnValue(createResponse);
+      httpClientMock.patch.mockReturnValue(updateResponse);
+
+      service.setNewProject('dupe-proj');
+      service.updateProjectConfig({name: 'project A'});
+      service.saveNow();
+      service.setNewProject('other-proj');
+
+      createResponse.error(new HttpErrorResponse({status: 409}));
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+      expect(httpClientMock.patch).toHaveBeenCalledWith(
+        '/api/projects/dupe-proj',
+        expect.objectContaining({id: 'dupe-proj', name: 'project A'}),
+      );
+      updateResponse.next({});
+    });
+
+    it('does not retry an older failure after a newer snapshot succeeds off-project', () => {
+      markPersisted('proj-1');
+      const failedResponse = new Subject<unknown>();
+      const queuedResponse = new Subject<unknown>();
+      const retryAction = new Subject<void>();
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      httpClientMock.patch
+        .mockReturnValueOnce(failedResponse)
+        .mockReturnValueOnce(queuedResponse)
+        .mockReturnValue(of({}));
+      matSnackBarMock.open.mockReturnValue({onAction: () => retryAction});
+
+      service.updateProjectConfig({id: 'proj-1', name: 'A'});
+      service.saveNow();
+      service.updateProjectConfig({name: 'B'});
+      service.saveNow();
+      failedResponse.error(new Error('save failed'));
+
+      service.setNewProject('proj-2');
+      queuedResponse.next({});
+      retryAction.next();
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(2);
+      errorSpy.mockRestore();
+    });
+
+    it('retries the latest unsaved snapshot from the snackbar action', () => {
+      markPersisted('proj-1');
+      const failedResponse = new Subject<unknown>();
+      const retryResponse = new Subject<unknown>();
+      const retryAction = new Subject<void>();
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      httpClientMock.patch
+        .mockReturnValueOnce(failedResponse)
+        .mockReturnValueOnce(retryResponse);
+      matSnackBarMock.open.mockReturnValue({onAction: () => retryAction});
+
+      service.updateProjectConfig({id: 'proj-1', name: 'A'});
+      service.saveNow();
+      failedResponse.error(new Error('save failed'));
+
+      service.updateProjectConfig({name: 'B'});
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+
+      retryAction.next();
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(2);
+      expect(httpClientMock.patch.mock.calls[1][1]).toEqual(
+        expect.objectContaining({name: 'B'}),
+      );
+      retryResponse.next({});
+      errorSpy.mockRestore();
+    });
+  });
+
   describe('flush on leaving a project', () => {
     it('resetProjectConfig should flush the dirty project before clearing', () => {
       markPersisted('proj-1');
@@ -418,6 +778,18 @@ describe('ConfigService (mediated data plane)', () => {
     it('reset with a clean project should not save', () => {
       service.resetProjectConfig();
       expect(saveRequestCount()).toBe(0);
+    });
+  });
+
+  describe('deleteProject', () => {
+    it('forgets per-project save state after deletion', async () => {
+      markPersisted('proj-1');
+      service.updateProjectConfig({id: 'proj-1', name: 'saved'});
+      service.saveNow();
+
+      await service.deleteProject('proj-1');
+
+      expect((service as any).projectSaveStates.has('proj-1')).toBe(false);
     });
   });
 

--- a/ui/src/app/services/config/config-mediated.spec.ts
+++ b/ui/src/app/services/config/config-mediated.spec.ts
@@ -794,6 +794,33 @@ describe('ConfigService (mediated data plane)', () => {
   });
 
   describe('stale autosave callbacks after deletion', () => {
+    it('does not start a queued save after deletion begins', async () => {
+      markPersisted('proj-1');
+      const firstResponse = new Subject<unknown>();
+      const deleteResponse = new Subject<unknown>();
+      httpClientMock.patch.mockReturnValue(firstResponse);
+      httpClientMock.delete.mockReturnValue(deleteResponse);
+
+      service.updateProjectConfig({id: 'proj-1', name: 'A'});
+      service.saveNow();
+      service.updateProjectConfig({name: 'B'});
+      service.saveNow();
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+
+      // Deletion STARTS but its response has not arrived yet.
+      const deletion = service.deleteProject('proj-1');
+
+      // The in-flight save now succeeds. Fencing only after DELETE resolves
+      // would let this dispatch the queued 'B' save mid-deletion.
+      firstResponse.next({});
+
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+
+      deleteResponse.next({});
+      await deletion;
+      expect((service as any).projectSaveStates.has('proj-1')).toBe(false);
+    });
+
     it('a late SUCCESS after deletion starts no queued save', async () => {
       markPersisted('proj-1');
       const firstResponse = new Subject<unknown>();

--- a/ui/src/app/services/config/config.ts
+++ b/ui/src/app/services/config/config.ts
@@ -215,6 +215,18 @@ export interface ProjectConfig {
   pendingRender?: PendingRender;
 }
 
+interface ProjectSave {
+  source: ProjectConfig;
+  payload: ProjectConfig;
+}
+
+interface ProjectSaveState {
+  latestSource: ProjectConfig | null;
+  lastSavedSource: ProjectConfig | null;
+  inFlight: ProjectSave | null;
+  pending: ProjectSave | null;
+}
+
 interface Scene {
   id: string;
   name: string;
@@ -451,6 +463,9 @@ export class ConfigService {
       if (params.projectId === null) {
         return {...this.DEFAULT_PROJECT_CONFIG()};
       }
+      const localProjectAtLoad = this.projectWithUnsettledSave(
+        params.projectId,
+      );
       try {
         const data = await firstValueFrom(
           this.httpClient.get<ProjectConfig>(
@@ -458,9 +473,21 @@ export class ConfigService {
           ),
         );
         this.persistedProjectIds.add(params.projectId);
+        if (localProjectAtLoad) {
+          return (
+            this.projectSaveStates.get(params.projectId)?.latestSource ??
+            localProjectAtLoad
+          );
+        }
         return this.normalizeLoadedProject(data);
       } catch (error) {
         if (error instanceof HttpErrorResponse && error.status === 404) {
+          if (localProjectAtLoad) {
+            return (
+              this.projectSaveStates.get(params.projectId)?.latestSource ??
+              localProjectAtLoad
+            );
+          }
           void this.router.navigate(['/']);
           console.error(`Project ${params.projectId} does not exist.`);
           return {...this.DEFAULT_PROJECT_CONFIG()};
@@ -515,20 +542,11 @@ export class ConfigService {
     localStorage.getItem('primaryColor') ?? 'theme-azure',
   );
   /**
-   * The exact config object last handed to a save request; lets the
-   * debounced autosave skip a config that `flushPendingSave()` already
-   * persisted, keeping request counts identical to the pre-flush behavior.
+   * Save ordering and identity-based dedupe state, isolated per project.
+   * Requests carry a cloned payload while source references remain available
+   * to dedupe immediate saves against trailing autosave emissions.
    */
-  // The last config whose save the SERVER confirmed. Used to dedupe the
-  // trailing autosave emission against an explicit flush/saveNow of the same
-  // object. Only advanced on a successful response (see saveProjectMediated),
-  // never optimistically, so a failed save is not mistaken for a saved one.
-  private lastSavedConfig: ProjectConfig | null = null;
-  // The config whose POST/PATCH is currently in flight. Dedupes concurrent
-  // saves of the same object without claiming it is saved; cleared on success
-  // (it becomes lastSavedConfig) and on failure (so a later flush/saveNow or
-  // the next autosave emission re-attempts the unsaved work).
-  private inFlightConfig: ProjectConfig | null = null;
+  private readonly projectSaveStates = new Map<string, ProjectSaveState>();
 
   constructor() {
     toObservable(this.projectConfig.value)
@@ -537,7 +555,7 @@ export class ConfigService {
         if (!config.id) {
           return;
         }
-        if (config === this.lastSavedConfig || config === this.inFlightConfig) {
+        if (this.isTrackedConfig(config)) {
           // Already persisted (or a save of this exact object is in flight);
           // avoid a duplicate save.
           return;
@@ -595,10 +613,79 @@ export class ConfigService {
     this.initFaviconListener();
   }
 
-  /** Saves one config object, marking it in-flight for dedupe. */
+  private saveState(projectId: string): ProjectSaveState {
+    let state = this.projectSaveStates.get(projectId);
+    if (!state) {
+      state = {
+        latestSource: null,
+        lastSavedSource: null,
+        inFlight: null,
+        pending: null,
+      };
+      this.projectSaveStates.set(projectId, state);
+    }
+    return state;
+  }
+
+  /**
+   * A GET started before a local save settles can return older project bytes.
+   * Keep this load on the newest local object until that save settles.
+   */
+  private projectWithUnsettledSave(projectId: string): ProjectConfig | null {
+    const state = this.projectSaveStates.get(projectId);
+    if (
+      !state?.latestSource ||
+      (!state.inFlight &&
+        !state.pending &&
+        state.latestSource === state.lastSavedSource)
+    ) {
+      return null;
+    }
+    return state.latestSource;
+  }
+
+  private isTrackedConfig(config: ProjectConfig): boolean {
+    const state = this.projectSaveStates.get(config.id);
+    return (
+      state !== undefined &&
+      (config === state.lastSavedSource ||
+        config === state.inFlight?.source ||
+        config === state.pending?.source)
+    );
+  }
+
+  private captureSave(source: ProjectConfig): ProjectSave {
+    return {source, payload: structuredClone(source)};
+  }
+
+  /** Starts a save or replaces the newest snapshot queued for its project. */
   private persistNow(config: ProjectConfig) {
-    this.inFlightConfig = config;
-    this.saveProjectMediated(config);
+    const state = this.saveState(config.id);
+    if (this.isTrackedConfig(config)) {
+      return;
+    }
+    state.latestSource = config;
+    const save = this.captureSave(config);
+    if (state.inFlight) {
+      state.pending = save;
+      return;
+    }
+    this.startSave(save, state);
+  }
+
+  private startSave(save: ProjectSave, state: ProjectSaveState) {
+    state.inFlight = save;
+    this.saveProjectMediated(save, state);
+  }
+
+  private startPendingSave(state: ProjectSaveState): boolean {
+    const pending = state.pending;
+    state.pending = null;
+    if (!pending) {
+      return false;
+    }
+    this.startSave(pending, state);
+    return true;
   }
 
   /**
@@ -610,12 +697,7 @@ export class ConfigService {
    */
   flushPendingSave() {
     const config = this.projectConfig.value();
-    if (
-      !this.shouldSave ||
-      !config.id ||
-      config === this.lastSavedConfig ||
-      config === this.inFlightConfig
-    ) {
+    if (!this.shouldSave || !config.id || this.isTrackedConfig(config)) {
       return;
     }
     config.lastEdited = new Date();
@@ -630,16 +712,12 @@ export class ConfigService {
    * Unlike flushPendingSave(), this does not require shouldSave to be set: a
    * brand-new project (setNewProject leaves shouldSave === false) must still
    * be created server-side on demand. It reuses persistNow()'s mechanics and
-   * records lastSavedConfig, so the trailing debounced emission for the SAME
-   * config object is deduped at the autosave guard — no double POST/PATCH.
+   * records the confirmed source reference, so the trailing debounced emission
+   * for the SAME config object is deduped — no double POST/PATCH.
    */
   saveNow() {
     const config = this.projectConfig.value();
-    if (
-      !config.id ||
-      config === this.lastSavedConfig ||
-      config === this.inFlightConfig
-    ) {
+    if (!config.id || this.isTrackedConfig(config)) {
       return;
     }
     config.lastEdited = new Date();
@@ -653,44 +731,50 @@ export class ConfigService {
    * Unlike the legacy silent path, failures surface a persistent snackbar
    * with a Retry affordance.
    */
-  private saveProjectMediated(config: ProjectConfig) {
-    const isPersisted = this.persistedProjectIds.has(config.id);
+  private saveProjectMediated(save: ProjectSave, state: ProjectSaveState) {
+    const projectId = save.source.id;
+    const isPersisted = this.persistedProjectIds.has(projectId);
     const request = isPersisted
-      ? this.httpClient.patch(`/api/projects/${config.id}`, config)
-      : this.httpClient.post<{id: string}>('/api/projects', config);
+      ? this.httpClient.patch(`/api/projects/${projectId}`, save.payload)
+      : this.httpClient.post<{id: string}>('/api/projects', save.payload);
     request.subscribe({
       next: () => {
-        this.persistedProjectIds.add(config.id);
+        this.persistedProjectIds.add(projectId);
         // Confirmed saved: now it is safe to dedupe future saves of this exact
         // object, and it is no longer in flight.
-        this.lastSavedConfig = config;
-        if (this.inFlightConfig === config) {
-          this.inFlightConfig = null;
+        state.lastSavedSource = save.source;
+        if (state.inFlight === save) {
+          state.inFlight = null;
         }
+        this.startPendingSave(state);
       },
       error: error => {
         // The save did NOT happen: clear the in-flight marker (without ever
-        // setting lastSavedConfig) so a later flush/saveNow or the next
+        // setting lastSavedSource) so a later flush/saveNow or the next
         // autosave emission re-attempts this work instead of skipping it.
-        if (this.inFlightConfig === config) {
-          this.inFlightConfig = null;
+        if (state.inFlight === save) {
+          state.inFlight = null;
         }
         // POST is create-only server-side, so a 409 means the project already
         // exists (e.g. an earlier POST landed but its response was lost, leaving
         // this client thinking the project is still new). Recover by marking it
-        // persisted and re-saving once via PATCH instead of looping on POST. Go
-        // through persistNow with the LATEST state (the user may have edited
-        // since the failed POST) so the retry sends current data and is tracked
-        // in inFlightConfig; the persisted-id guard makes this a single switch
-        // to PATCH, not a loop.
+        // persisted and retrying the newest queued snapshot via PATCH. The
+        // persisted-id guard makes this a single switch, not a loop.
         if (
           error instanceof HttpErrorResponse &&
           error.status === 409 &&
-          !this.persistedProjectIds.has(config.id)
+          !this.persistedProjectIds.has(projectId)
         ) {
-          this.persistedProjectIds.add(config.id);
-          const latest = this.projectConfig.value();
-          this.persistNow(latest.id === config.id ? latest : config);
+          this.persistedProjectIds.add(projectId);
+          if (!this.startPendingSave(state)) {
+            const latest = this.projectConfig.value();
+            const retrySource =
+              latest.id === projectId
+                ? latest
+                : (state.latestSource ?? save.source);
+            state.latestSource = retrySource;
+            this.startSave(this.captureSave(retrySource), state);
+          }
           return;
         }
         console.error('Error saving project config:', error);
@@ -700,13 +784,16 @@ export class ConfigService {
           {panelClass: ['error-snackbar']},
         );
         snackBarRef.onAction().subscribe(() => {
-          // Retry with the latest state if the user is still on this project,
-          // otherwise with the state captured at failure time. Go through
-          // persistNow so the retry is tracked in inFlightConfig and a
-          // concurrent save is still deduped.
+          // Retry the current state when still on this project, otherwise the
+          // newest source this project's queue has observed.
           const latest = this.projectConfig.value();
-          this.persistNow(latest.id === config.id ? latest : config);
+          this.persistNow(
+            latest.id === projectId
+              ? latest
+              : (state.latestSource ?? save.source),
+          );
         });
+        this.startPendingSave(state);
       },
     });
   }
@@ -852,5 +939,6 @@ export class ConfigService {
   async deleteProject(projectId: string) {
     await firstValueFrom(this.httpClient.delete(`/api/projects/${projectId}`));
     this.persistedProjectIds.delete(projectId);
+    this.projectSaveStates.delete(projectId);
   }
 }

--- a/ui/src/app/services/config/config.ts
+++ b/ui/src/app/services/config/config.ts
@@ -437,8 +437,8 @@ export function findTransitionContractViolation(
     }
     const previousDuration = renderable[index - 1].duration;
     if (
-      overlap >= duration + DURATION_COMPARISON_EPSILON_SECONDS ||
-      overlap >= previousDuration + DURATION_COMPARISON_EPSILON_SECONDS
+      overlap + DURATION_COMPARISON_EPSILON_SECONDS >= duration ||
+      overlap + DURATION_COMPARISON_EPSILON_SECONDS >= previousDuration
     ) {
       return (
         `The transition on "${scene.name}" is longer than the clips it joins. ` +

--- a/ui/src/app/services/config/config.ts
+++ b/ui/src/app/services/config/config.ts
@@ -34,6 +34,11 @@ import {debounceTime, distinctUntilChanged, firstValueFrom, skip} from 'rxjs';
  */
 export const DEFAULT_TRANSITION_OVERLAP = 0.5;
 
+/** One full frame at the backend's minimum 24 fps render rate. */
+export const MIN_RENDER_CLIP_DURATION_SECONDS = 0.042;
+
+const DURATION_COMPARISON_EPSILON_SECONDS = 1e-9;
+
 /**
  * Threshold for aspect ratio deviation beyond which a warning is shown.
  */
@@ -316,6 +321,69 @@ export interface ProvidedVideoScene extends Scene {
   video?: GcsFile;
   durationSeconds?: number;
   trim?: {start?: number; end?: number};
+}
+
+export interface SceneRenderClip {
+  video: GcsFile;
+  start: number;
+  duration: number;
+}
+
+export type SceneRenderClipResolution =
+  | {state: 'not-selected'}
+  | {state: 'invalid'}
+  | {state: 'ready'; clip: SceneRenderClip};
+
+/**
+ * Resolves the video material that a scene contributes to a render.
+ *
+ * An unselected generated scene contributes nothing. A provided-video scene,
+ * or a generated scene with a selected candidate, is invalid unless it has a
+ * storage path and at least one frame of effective duration.
+ */
+export function resolveSceneRenderClip(
+  scene: GeneratedScene | ProvidedVideoScene,
+): SceneRenderClipResolution {
+  let video: GcsFile | undefined;
+  let sourceDuration: number | undefined;
+  let trim: {start?: number; end?: number} | undefined;
+
+  if (scene.type === 'generated') {
+    const generatedScene = scene as GeneratedScene;
+    if (generatedScene.selectedCandidateIndex === undefined) {
+      return {state: 'not-selected'};
+    }
+    const candidate =
+      generatedScene.candidates?.[generatedScene.selectedCandidateIndex];
+    if (!candidate) {
+      return {state: 'invalid'};
+    }
+    video = candidate.video;
+    sourceDuration = candidate.durationSeconds;
+    trim = candidate.trim;
+  } else {
+    const providedScene = scene as ProvidedVideoScene;
+    video = providedScene.video;
+    sourceDuration = providedScene.durationSeconds;
+    trim = providedScene.trim;
+  }
+
+  const start = trim?.start ?? 0;
+  const end = trim?.end ?? sourceDuration;
+  const duration = end === undefined ? NaN : end - start;
+  const path = video?.path;
+  if (
+    !video ||
+    typeof path !== 'string' ||
+    !path.trim() ||
+    !Number.isFinite(start) ||
+    !Number.isFinite(duration) ||
+    duration + DURATION_COMPARISON_EPSILON_SECONDS <
+      MIN_RENDER_CLIP_DURATION_SECONDS
+  ) {
+    return {state: 'invalid'};
+  }
+  return {state: 'ready', clip: {video, start, duration}};
 }
 
 export interface ThumbnailMaterial {

--- a/ui/src/app/services/config/config.ts
+++ b/ui/src/app/services/config/config.ts
@@ -372,18 +372,81 @@ export function resolveSceneRenderClip(
   const end = trim?.end ?? sourceDuration;
   const duration = end === undefined ? NaN : end - start;
   const path = video?.path;
+  // A clip must not only be long enough, it must lie inside the source. A
+  // trim starting at or past the source end still satisfies the minimum
+  // duration, but there is no video left to read and ffmpeg emits an
+  // audio-only output instead of failing.
+  const withinSource =
+    Number.isFinite(sourceDuration) &&
+    (sourceDuration as number) > 0 &&
+    start >= 0 &&
+    start < (sourceDuration as number) &&
+    end !== undefined &&
+    end <= (sourceDuration as number) + DURATION_COMPARISON_EPSILON_SECONDS;
   if (
     !video ||
     typeof path !== 'string' ||
     !path.trim() ||
     !Number.isFinite(start) ||
     !Number.isFinite(duration) ||
+    !withinSource ||
     duration + DURATION_COMPARISON_EPSILON_SECONDS <
       MIN_RENDER_CLIP_DURATION_SECONDS
   ) {
     return {state: 'invalid'};
   }
   return {state: 'ready', clip: {video, start, duration}};
+}
+
+/**
+ * The message shown when a scene's transition cannot be applied, or null when
+ * every transition in the storyboard is applicable.
+ *
+ * Per-clip validity is not enough: a transition consumes time from BOTH the
+ * clip it is on and the one before it (ffmpeg offsets the crossfade by
+ * `overlap` into the accumulated timeline). An overlap at least as long as
+ * either neighbour swallows that clip entirely, so a storyboard of
+ * individually valid clips can still render as a single wash of colour.
+ *
+ * Shared by render eligibility and arrangement construction so the button and
+ * the submitted workflow cannot disagree.
+ */
+export function findTransitionContractViolation(
+  scenes: Array<GeneratedScene | ProvidedVideoScene>,
+): string | null {
+  const renderable: Array<{
+    scene: GeneratedScene | ProvidedVideoScene;
+    duration: number;
+  }> = [];
+  for (const scene of scenes) {
+    const resolution = resolveSceneRenderClip(scene);
+    if (resolution.state === 'ready') {
+      renderable.push({scene, duration: resolution.clip.duration});
+    }
+  }
+  // The first clip has nothing to transition from, so ffmpeg ignores its
+  // transition; start at the second.
+  for (let index = 1; index < renderable.length; index++) {
+    const {scene, duration} = renderable[index];
+    if (!scene.transition) {
+      continue;
+    }
+    const overlap = scene.transitionOverlap ?? DEFAULT_TRANSITION_OVERLAP;
+    if (!Number.isFinite(overlap) || overlap <= 0) {
+      continue; // an explicit zero (or absent) overlap is a hard cut
+    }
+    const previousDuration = renderable[index - 1].duration;
+    if (
+      overlap >= duration + DURATION_COMPARISON_EPSILON_SECONDS ||
+      overlap >= previousDuration + DURATION_COMPARISON_EPSILON_SECONDS
+    ) {
+      return (
+        `The transition on "${scene.name}" is longer than the clips it joins. ` +
+        'Shorten the transition or lengthen the scenes.'
+      );
+    }
+  }
+  return null;
 }
 
 export interface ThumbnailMaterial {
@@ -1033,8 +1096,17 @@ export class ConfigService {
   }
 
   async deleteProject(projectId: string) {
-    await firstValueFrom(this.httpClient.delete(`/api/projects/${projectId}`));
+    // Fence the project BEFORE the request, not after it resolves: while a
+    // DELETE is in flight the save state would otherwise still be current, so
+    // an in-flight save completing mid-deletion would dispatch its queued
+    // successor against the project being deleted. Dropping the state first
+    // makes every outstanding callback fail its isCurrentSaveState check.
+    //
+    // This orders the client's own writes. A PATCH already dispatched to the
+    // server can still be processed after the DELETE arrives; that ordering
+    // is the server's to guarantee.
     this.persistedProjectIds.delete(projectId);
     this.projectSaveStates.delete(projectId);
+    await firstValueFrom(this.httpClient.delete(`/api/projects/${projectId}`));
   }
 }

--- a/ui/src/app/services/config/config.ts
+++ b/ui/src/app/services/config/config.ts
@@ -696,6 +696,22 @@ export class ConfigService {
   }
 
   /**
+   * Whether `state` is still the tracked save state for `projectId`.
+   *
+   * A deleted project can be recreated with the same id, which allocates a
+   * new ProjectSaveState object under that id. An HTTP callback captured a
+   * specific state object when its request started; if the map no longer
+   * points at that same object, the callback belongs to a project that no
+   * longer exists (or has been replaced) and must not act.
+   */
+  private isCurrentSaveState(
+    projectId: string,
+    state: ProjectSaveState,
+  ): boolean {
+    return this.projectSaveStates.get(projectId) === state;
+  }
+
+  /**
    * A GET started before a local save settles can return older project bytes.
    * Keep this load on the newest local object until that save settles.
    */
@@ -807,6 +823,12 @@ export class ConfigService {
       : this.httpClient.post<{id: string}>('/api/projects', save.payload);
     request.subscribe({
       next: () => {
+        // The project may have been deleted (and possibly recreated under the
+        // same id, with its own new state object) while this request was in
+        // flight. A stale response must not touch project state at all.
+        if (!this.isCurrentSaveState(projectId, state)) {
+          return;
+        }
         this.persistedProjectIds.add(projectId);
         // Confirmed saved: now it is safe to dedupe future saves of this exact
         // object, and it is no longer in flight.
@@ -817,6 +839,9 @@ export class ConfigService {
         this.startPendingSave(state);
       },
       error: error => {
+        if (!this.isCurrentSaveState(projectId, state)) {
+          return;
+        }
         // The save did NOT happen: clear the in-flight marker (without ever
         // setting lastSavedSource) so a later flush/saveNow or the next
         // autosave emission re-attempts this work instead of skipping it.
@@ -852,6 +877,9 @@ export class ConfigService {
           {panelClass: ['error-snackbar']},
         );
         snackBarRef.onAction().subscribe(() => {
+          if (!this.isCurrentSaveState(projectId, state)) {
+            return;
+          }
           // Retry the current state when still on this project, otherwise the
           // newest source this project's queue has observed.
           const latest = this.projectConfig.value();

--- a/ui/src/app/services/remix-engine/remix-engine-mediated.spec.ts
+++ b/ui/src/app/services/remix-engine/remix-engine-mediated.spec.ts
@@ -1117,6 +1117,80 @@ describe('RemixEngineService (mediated)', () => {
       expect(configServiceMock.addRenderRun).not.toHaveBeenCalled();
     });
 
+    it('does not submit a workflow when a transition outlasts its clips', async () => {
+      setRenderStoryboard([
+        {
+          id: 'short',
+          type: 'video',
+          name: 'Short clip',
+          video: {path: 'videos/short.mp4', url: ''},
+          durationSeconds: 5,
+          trim: {start: 0, end: 0.042},
+        },
+        {
+          id: 'next',
+          type: 'video',
+          name: 'Next clip',
+          video: {path: 'videos/next.mp4', url: ''},
+          durationSeconds: 5,
+          transition: 'fade',
+          transitionOverlap: 0.5,
+        },
+      ]);
+      const startSpy = vi.spyOn(service, 'startCombineScenesWorkflow');
+
+      await service.combineScenes();
+
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(configServiceMock.addRenderRun).not.toHaveBeenCalled();
+      expect(configServiceMock.setPendingRender).not.toHaveBeenCalled();
+      expect(service.combiningScenes()).toBe(false);
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        expect.stringContaining('longer than the clips it joins'),
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+    });
+
+    it('submits a transition that fits, using the persisted overlap', async () => {
+      setRenderStoryboard([
+        {
+          id: 'a',
+          type: 'video',
+          name: 'Clip A',
+          video: {path: 'videos/a.mp4', url: ''},
+          durationSeconds: 5,
+        },
+        {
+          id: 'b',
+          type: 'video',
+          name: 'Clip B',
+          video: {path: 'videos/b.mp4', url: ''},
+          durationSeconds: 5,
+          transition: 'fade',
+          transitionOverlap: 0,
+        },
+      ]);
+      const startSpy = vi
+        .spyOn(service, 'startCombineScenesWorkflow')
+        .mockResolvedValue(of({executionId: 'render-exec-id'}) as any);
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue({
+        sink: {output: {'0': {video: [{file: 'renders/output.mp4'}]}}},
+      } as any);
+      mediaServiceMock.signUrl.mockResolvedValue(
+        'https://signed.example/o.mp4',
+      );
+
+      await service.combineScenes();
+
+      expect(startSpy).toHaveBeenCalled();
+      // An explicit zero overlap is a hard cut and must reach the backend as
+      // 0, not be dropped or defaulted.
+      expect(startSpy.mock.calls[0][0][1]).toEqual(
+        expect.objectContaining({transition: 'fade', transition_overlap: 0}),
+      );
+    });
+
     it('does not submit a workflow when every scene is unselected (non-empty storyboard)', async () => {
       // Distinct from the empty-storyboard case above: the storyboard is
       // non-empty, but the only scene is a generated one with no candidate

--- a/ui/src/app/services/remix-engine/remix-engine-mediated.spec.ts
+++ b/ui/src/app/services/remix-engine/remix-engine-mediated.spec.ts
@@ -1117,6 +1117,38 @@ describe('RemixEngineService (mediated)', () => {
       expect(configServiceMock.addRenderRun).not.toHaveBeenCalled();
     });
 
+    it('does not submit a workflow when every scene is unselected (non-empty storyboard)', async () => {
+      // Distinct from the empty-storyboard case above: the storyboard is
+      // non-empty, but the only scene is a generated one with no candidate
+      // chosen yet, so it resolves to 'not-selected', never 'ready'.
+      setRenderStoryboard([
+        {
+          id: 'unselected',
+          type: 'generated',
+          name: 'No candidate selected',
+          candidates: [
+            {
+              video: {path: 'videos/candidate.mp4', url: ''},
+              durationSeconds: 5,
+            },
+          ],
+        },
+      ]);
+      const startSpy = vi.spyOn(service, 'startCombineScenesWorkflow');
+
+      await service.combineScenes();
+
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(configServiceMock.addRenderRun).not.toHaveBeenCalled();
+      expect(configServiceMock.setPendingRender).not.toHaveBeenCalled();
+      expect(service.combiningScenes()).toBe(false);
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Select or upload at least one scene video before rendering.',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+    });
+
     it('does not submit a partial render when an intended clip is invalid', async () => {
       setRenderStoryboard([
         {

--- a/ui/src/app/services/remix-engine/remix-engine-mediated.spec.ts
+++ b/ui/src/app/services/remix-engine/remix-engine-mediated.spec.ts
@@ -85,6 +85,15 @@ describe('RemixEngineService (mediated)', () => {
     return calls[calls.length - 1][0].storyboard[0];
   }
 
+  function setRenderStoryboard(storyboard: any[]) {
+    projectConfigSignal.set({
+      ...projectConfigSignal(),
+      storyboard,
+      audioTracks: [],
+      visualOverlays: [],
+    });
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     // Do NOT replace the global `window` here. jsdom already provides
@@ -1092,18 +1101,122 @@ describe('RemixEngineService (mediated)', () => {
     });
   });
 
+  describe('combineScenes: render contract', () => {
+    it('does not submit a workflow with no renderable video', async () => {
+      setRenderStoryboard([]);
+      const startSpy = vi.spyOn(service, 'startCombineScenesWorkflow');
+
+      await service.combineScenes();
+
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Select or upload at least one scene video before rendering.',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+      expect(configServiceMock.addRenderRun).not.toHaveBeenCalled();
+    });
+
+    it('does not submit a partial render when an intended clip is invalid', async () => {
+      setRenderStoryboard([
+        {
+          id: 'ready',
+          type: 'video',
+          name: 'Ready clip',
+          video: {path: 'videos/ready.mp4', url: ''},
+          durationSeconds: 5,
+        },
+        {
+          id: 'invalid',
+          type: 'generated',
+          name: 'Invalid selected clip',
+          selectedCandidateIndex: 0,
+          candidates: [
+            {
+              video: {path: '', url: 'https://legacy.example/video.mp4'},
+              durationSeconds: 5,
+            },
+          ],
+        },
+      ]);
+      const startSpy = vi.spyOn(service, 'startCombineScenesWorkflow');
+
+      await service.combineScenes();
+
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        expect.stringContaining('storage path or valid duration'),
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+      expect(configServiceMock.addRenderRun).not.toHaveBeenCalled();
+      expect(configServiceMock.setPendingRender).not.toHaveBeenCalled();
+      expect(service.combiningScenes()).toBe(false);
+    });
+
+    it('submits the shared clip values and ignores an unselected generated scene', async () => {
+      setRenderStoryboard([
+        {
+          id: 'ready',
+          type: 'generated',
+          name: 'Ready clip',
+          selectedCandidateIndex: 0,
+          candidates: [
+            {
+              video: {path: 'videos/ready.mp4', url: ''},
+              durationSeconds: 10,
+              trim: {start: 2, end: 8},
+            },
+          ],
+        },
+        {
+          id: 'not-selected',
+          type: 'generated',
+          name: 'No candidate selected',
+        },
+      ]);
+      const startSpy = vi
+        .spyOn(service, 'startCombineScenesWorkflow')
+        .mockResolvedValue(of({executionId: 'render-exec-id'}) as any);
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue({
+        sink: {output: {'0': {video: [{file: 'renders/output.mp4'}]}}},
+      } as any);
+      mediaServiceMock.signUrl.mockResolvedValue(
+        'https://signed.example/renders/output.mp4',
+      );
+
+      await service.combineScenes();
+
+      expect(startSpy).toHaveBeenCalledWith(
+        [
+          {
+            file_type: 'video',
+            file_path: 'videos/ready.mp4',
+            start_time: 0,
+            skip_time: 2,
+            duration: 6,
+          },
+        ],
+        false,
+      );
+    });
+  });
+
   describe('combineScenes: signing-failure resilience', () => {
     it('keeps the pending render and records no error when the output cannot be signed', async () => {
       // A live render finishes, but signing its output URL fails persistently
       // (transient /api/signUrl outage). withRetry exhausts its attempts and the
       // completed render is kept (marker not cleared, no error run) so a reopen
       // re-collects it, mirroring the resumed-render path. (E3)
-      projectConfigSignal.set({
-        id: 'project-1',
-        storyboard: [],
-        audioTracks: [],
-        visualOverlays: [],
-      });
+      setRenderStoryboard([
+        {
+          id: 'video-1',
+          type: 'video',
+          name: 'Video 1',
+          video: {path: 'videos/video-1.mp4', url: ''},
+          durationSeconds: 5,
+        },
+      ]);
       vi.spyOn(service, 'startCombineScenesWorkflow').mockResolvedValue(
         of({executionId: 'render-exec-id'}) as any,
       );

--- a/ui/src/app/services/remix-engine/remix-engine-mediated.spec.ts
+++ b/ui/src/app/services/remix-engine/remix-engine-mediated.spec.ts
@@ -1152,6 +1152,70 @@ describe('RemixEngineService (mediated)', () => {
       );
     });
 
+    it('does not submit a transition exactly as long as its own clip', async () => {
+      setRenderStoryboard([
+        {
+          id: 'long',
+          type: 'video',
+          name: 'Long clip',
+          video: {path: 'videos/long.mp4', url: ''},
+          durationSeconds: 5,
+        },
+        {
+          id: 'exact',
+          type: 'video',
+          name: 'Exact clip',
+          video: {path: 'videos/exact.mp4', url: ''},
+          durationSeconds: 5,
+          trim: {start: 0, end: 0.5},
+          transition: 'fade',
+          transitionOverlap: 0.5,
+        },
+      ]);
+      const startSpy = vi.spyOn(service, 'startCombineScenesWorkflow');
+
+      await service.combineScenes();
+
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        expect.stringContaining('longer than the clips it joins'),
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+    });
+
+    it('does not submit a transition exactly as long as the previous clip', async () => {
+      setRenderStoryboard([
+        {
+          id: 'exact-prev',
+          type: 'video',
+          name: 'Exact previous',
+          video: {path: 'videos/prev.mp4', url: ''},
+          durationSeconds: 5,
+          trim: {start: 0, end: 0.5},
+        },
+        {
+          id: 'long-next',
+          type: 'video',
+          name: 'Long next',
+          video: {path: 'videos/next.mp4', url: ''},
+          durationSeconds: 5,
+          transition: 'fade',
+          transitionOverlap: 0.5,
+        },
+      ]);
+      const startSpy = vi.spyOn(service, 'startCombineScenesWorkflow');
+
+      await service.combineScenes();
+
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        expect.stringContaining('longer than the clips it joins'),
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+    });
+
     it('submits a transition that fits, using the persisted overlap', async () => {
       setRenderStoryboard([
         {

--- a/ui/src/app/services/remix-engine/remix-engine.ts
+++ b/ui/src/app/services/remix-engine/remix-engine.ts
@@ -50,6 +50,7 @@ import {
   ProductImage,
   ProvidedVideoScene,
   RenderRun,
+  resolveSceneRenderClip,
   Resolution,
   VisualOverlay,
 } from '../config/config';
@@ -71,6 +72,13 @@ class ProjectChangedError extends Error {
   constructor() {
     super('Project changed, cancelling workflow polling');
     this.name = 'ProjectChangedError';
+  }
+}
+
+class RenderContractError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RenderContractError';
   }
 }
 
@@ -1407,7 +1415,13 @@ export class RemixEngineService {
       await this.recordRenderOutput(workflowStatus, projectId);
       this.combiningScenes.set(false);
     } catch (error) {
-      if (error instanceof ProjectChangedError) {
+      if (error instanceof RenderContractError) {
+        this.combiningScenes.set(false);
+        this.matSnackBar.open(error.message, 'Dismiss', {
+          panelClass: ['error-snackbar'],
+        });
+        return;
+      } else if (error instanceof ProjectChangedError) {
         // The user left the project mid-render: reset the in-memory button
         // state (otherwise it stays stuck on "Rendering...") but keep the
         // persisted marker so returning to the project resumes the run. Release
@@ -1619,61 +1633,37 @@ export class RemixEngineService {
     }
   }
 
-  private getSceneVideoDuration(
-    scene: GeneratedScene | ProvidedVideoScene,
-    skipTime: number,
-  ) {
-    if (this.configService.isGeneratedScene(scene)) {
-      const candidate = scene.candidates![scene.selectedCandidateIndex!];
-      const end = candidate.trim?.end ?? candidate.durationSeconds;
-      return end - skipTime;
-    }
-    if (this.configService.isProvidedVideoScene(scene)) {
-      const end = scene.trim?.end ?? scene.durationSeconds!;
-      return end - skipTime;
-    }
-    return 0;
-  }
-
   private getCombineScenesArrangements(
     scenes: Array<GeneratedScene | ProvidedVideoScene>,
     audioTracks: AudioTrack[],
     visualOverlays: VisualOverlay[],
   ) {
     const arrangement: CombineScenesArrangement[] = [];
-    const validScenes = scenes.filter(scene => {
-      if (this.configService.isProvidedVideoScene(scene)) {
-        if (scene.durationSeconds) {
-          return scene.video?.path;
-        }
-      } else if (this.configService.isGeneratedScene(scene)) {
-        if (scene.candidates && scene.selectedCandidateIndex !== undefined) {
-          return scene.candidates[scene.selectedCandidateIndex].video?.path;
-        }
-      }
-      return false;
-    });
-    for (const scene of validScenes) {
-      let gcsVideoPath;
-      let skipTime = 0;
-      if (this.configService.isProvidedVideoScene(scene)) {
-        gcsVideoPath = scene.video?.path;
-        skipTime = scene.trim?.start ?? 0;
-      } else if (this.configService.isGeneratedScene(scene)) {
-        const candidate = scene.candidates![scene.selectedCandidateIndex!];
-        gcsVideoPath = candidate.video?.path;
-        skipTime = candidate.trim?.start ?? 0;
-      }
-      const duration = this.getSceneVideoDuration(scene, skipTime);
-      if (!gcsVideoPath) {
-        console.debug(`No video for scene ${scene.id}`);
+    const resolvedScenes = scenes.map(scene => ({
+      scene,
+      resolution: resolveSceneRenderClip(scene),
+    }));
+    if (resolvedScenes.some(({resolution}) => resolution.state === 'invalid')) {
+      throw new RenderContractError(
+        'One or more selected scene videos are missing a storage path or valid ' +
+          'duration, or have an invalid trim.',
+      );
+    }
+    if (!resolvedScenes.some(({resolution}) => resolution.state === 'ready')) {
+      throw new RenderContractError(
+        'Select or upload at least one scene video before rendering.',
+      );
+    }
+    for (const {scene, resolution} of resolvedScenes) {
+      if (resolution.state !== 'ready') {
         continue;
       }
+      const {video, start, duration} = resolution.clip;
       const videoArrangement: CombineScenesArrangement = {
         file_type: 'video',
-        file_path: gcsVideoPath,
+        file_path: video.path,
         start_time: 0,
-        skip_time: skipTime,
+        skip_time: start,
         duration,
       };
       if (scene.transition) {
@@ -1682,12 +1672,6 @@ export class RemixEngineService {
           scene.transitionOverlap ?? DEFAULT_TRANSITION_OVERLAP;
       }
       arrangement.push(videoArrangement);
-
-      if (duration <= 0) {
-        console.error(
-          `ERROR:Unknown scene #${scene.id} video duration: ${duration}, using default value instead.`,
-        );
-      }
     }
 
     for (const track of audioTracks) {

--- a/ui/src/app/services/remix-engine/remix-engine.ts
+++ b/ui/src/app/services/remix-engine/remix-engine.ts
@@ -50,6 +50,7 @@ import {
   ProductImage,
   ProvidedVideoScene,
   RenderRun,
+  findTransitionContractViolation,
   resolveSceneRenderClip,
   Resolution,
   VisualOverlay,
@@ -1653,6 +1654,10 @@ export class RemixEngineService {
       throw new RenderContractError(
         'Select or upload at least one scene video before rendering.',
       );
+    }
+    const transitionViolation = findTransitionContractViolation(scenes);
+    if (transitionViolation) {
+      throw new RenderContractError(transitionViolation);
     }
     for (const {scene, resolution} of resolvedScenes) {
       if (resolution.state !== 'ready') {

--- a/ui/src/app/storyboard/storyboard.spec.ts
+++ b/ui/src/app/storyboard/storyboard.spec.ts
@@ -379,6 +379,25 @@ describe('Storyboard', () => {
     expect(currentProvidedTrim()).toEqual({start: 2, end: 2.042});
   });
 
+  it('preserves millisecond trim precision through the round trip', () => {
+    // 1.001 * 1000 is 1000.9999999999999 in IEEE-754, so a naive
+    // Math.floor(seconds * 1000)/1000 pre-rounding step truncates 1.001s to
+    // 1.000s before the millisecond math ever runs.
+    const scene: ProvidedVideoScene = {
+      id: '1',
+      type: 'video',
+      name: 'Scene 1',
+      video: {url: 'http://test.mp4', path: 'test/path'},
+      durationSeconds: 10,
+      trim: {start: 0, end: 10},
+    };
+    selectTrimScene(scene);
+
+    component.updateTrim({start: 1.001, end: 5.001});
+
+    expect(currentProvidedTrim()).toEqual({start: 1.001, end: 5.001});
+  });
+
   it('does not change trim before video metadata loads', () => {
     const scene: ProvidedVideoScene = {
       id: '1',

--- a/ui/src/app/storyboard/storyboard.spec.ts
+++ b/ui/src/app/storyboard/storyboard.spec.ts
@@ -379,6 +379,55 @@ describe('Storyboard', () => {
     expect(currentProvidedTrim()).toEqual({start: 2, end: 2.042});
   });
 
+  describe('resolveSceneRenderClip source bounds', () => {
+    function providedScene(
+      durationSeconds: number | undefined,
+      trim: {start?: number; end?: number},
+    ): ProvidedVideoScene {
+      return {
+        id: 'b',
+        type: 'video',
+        name: 'Bounds',
+        video: {url: 'http://test.mp4', path: 'videos/test.mp4'},
+        durationSeconds,
+        trim,
+      } as ProvidedVideoScene;
+    }
+
+    it('rejects a trim starting at the source end', () => {
+      // Long enough to pass the minimum-duration check, but there is no
+      // source video left to read: ffmpeg yields an audio-only output.
+      expect(
+        resolveSceneRenderClip(providedScene(5, {start: 5, end: 5.042})).state,
+      ).toBe('invalid');
+    });
+
+    it('rejects a trim ending beyond the source duration', () => {
+      expect(
+        resolveSceneRenderClip(providedScene(5, {start: 4, end: 6})).state,
+      ).toBe('invalid');
+    });
+
+    it('rejects an explicit trim with no source duration', () => {
+      expect(
+        resolveSceneRenderClip(providedScene(undefined, {start: 0, end: 2}))
+          .state,
+      ).toBe('invalid');
+    });
+
+    it('rejects a negative trim start', () => {
+      expect(
+        resolveSceneRenderClip(providedScene(5, {start: -1, end: 2})).state,
+      ).toBe('invalid');
+    });
+
+    it('still accepts a trim that ends exactly at the source duration', () => {
+      expect(
+        resolveSceneRenderClip(providedScene(5, {start: 1, end: 5})).state,
+      ).toBe('ready');
+    });
+  });
+
   it('preserves millisecond trim precision through the round trip', () => {
     // 1.001 * 1000 is 1000.9999999999999 in IEEE-754, so a naive
     // Math.floor(seconds * 1000)/1000 pre-rounding step truncates 1.001s to

--- a/ui/src/app/storyboard/storyboard.spec.ts
+++ b/ui/src/app/storyboard/storyboard.spec.ts
@@ -26,6 +26,7 @@ import {
   GeneratedScene,
   ProjectConfig,
   ProvidedVideoScene,
+  resolveSceneRenderClip,
 } from '../services/config/config';
 import {RemixEngineService} from '../services/remix-engine/remix-engine';
 import {Storyboard} from './storyboard';
@@ -159,6 +160,19 @@ describe('Storyboard', () => {
     fixture.detectChanges();
   });
 
+  function selectTrimScene(scene: GeneratedScene | ProvidedVideoScene) {
+    projectConfigSignal.update(config => ({
+      ...config,
+      storyboard: [scene],
+    }));
+    component.selectScene(scene.id);
+    component.videoDuration.set(10);
+  }
+
+  function currentProvidedTrim() {
+    return (projectConfigSignal().storyboard[0] as ProvidedVideoScene).trim;
+  }
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
@@ -282,6 +296,106 @@ describe('Storyboard', () => {
     // Test with dragging
     component.draggingTrim.set({start: 3, end: 7});
     expect(component.trimmedDuration()).toBe(4);
+  });
+
+  it('keeps at least one 24fps frame when trim start crosses trim end', () => {
+    const candidate: Candidate = {
+      video: {url: 'http://test.mp4', path: 'test/path'},
+      runNumber: 1,
+      durationSeconds: 10,
+      trim: {start: 2, end: 8},
+      prompt: 'test prompt',
+      model: 'test-model',
+      generateAudio: false,
+      resolution: '1080p',
+    };
+    const scene: GeneratedScene = {
+      id: '1',
+      type: 'generated',
+      name: 'Scene 1',
+      prompt: 'test prompt',
+      candidates: [candidate],
+      selectedCandidateIndex: 0,
+    };
+    selectTrimScene(scene);
+
+    component.updateTrim({start: 9});
+
+    expect(candidate.trim).toEqual({start: 7.958, end: 8});
+    const resolution = resolveSceneRenderClip(scene);
+    expect(resolution.state).toBe('ready');
+    if (resolution.state === 'ready') {
+      expect(Math.round(resolution.clip.duration * 24)).toBe(1);
+    }
+  });
+
+  it('keeps at least one 24fps frame when trim end crosses trim start', () => {
+    const scene: ProvidedVideoScene = {
+      id: '1',
+      type: 'video',
+      name: 'Scene 1',
+      video: {url: 'http://test.mp4', path: 'test/path'},
+      durationSeconds: 10,
+      trim: {start: 2, end: 8},
+    };
+    selectTrimScene(scene);
+
+    component.updateTrim({end: 1});
+
+    expect(currentProvidedTrim()).toEqual({start: 2, end: 2.042});
+    const trim = currentProvidedTrim()!;
+    expect(Math.round((trim.end! - trim.start!) * 24)).toBe(1);
+  });
+
+  it('keeps trim endpoints strictly ordered after rounding', () => {
+    const scene: ProvidedVideoScene = {
+      id: '1',
+      type: 'video',
+      name: 'Scene 1',
+      video: {url: 'http://test.mp4', path: 'test/path'},
+      durationSeconds: 10,
+      trim: {start: 2, end: 8},
+    };
+    selectTrimScene(scene);
+
+    component.updateTrim({end: 2});
+
+    expect(currentProvidedTrim()).toEqual({start: 2, end: 2.042});
+  });
+
+  it('repairs a two-endpoint trim that becomes equal after rounding', () => {
+    const scene: ProvidedVideoScene = {
+      id: '1',
+      type: 'video',
+      name: 'Scene 1',
+      video: {url: 'http://test.mp4', path: 'test/path'},
+      durationSeconds: 10,
+      trim: {start: 1, end: 8},
+    };
+    selectTrimScene(scene);
+
+    component.updateTrim({start: 2, end: 2.0009});
+
+    expect(currentProvidedTrim()).toEqual({start: 2, end: 2.042});
+  });
+
+  it('does not change trim before video metadata loads', () => {
+    const scene: ProvidedVideoScene = {
+      id: '1',
+      type: 'video',
+      name: 'Scene 1',
+      video: {url: 'http://test.mp4', path: 'test/path'},
+      durationSeconds: 10,
+      trim: {start: 2, end: 8},
+    };
+    selectTrimScene(scene);
+    component.videoDuration.set(0);
+    const updateSpy = vi.spyOn(mockConfigService, 'updateProjectConfig');
+
+    component.updateTrim({start: 3});
+
+    expect(currentProvidedTrim()).toEqual({start: 2, end: 8});
+    expect(updateSpy).not.toHaveBeenCalled();
   });
 
   describe('run+letter candidate labels', () => {

--- a/ui/src/app/storyboard/storyboard.ts
+++ b/ui/src/app/storyboard/storyboard.ts
@@ -600,15 +600,15 @@ export class Storyboard {
       newTrim.end = duration;
     }
 
-    newTrim.start = toDecimals(newTrim.start, 3);
-    newTrim.end = toDecimals(newTrim.end, 3);
-
+    // Convert the raw clamped seconds straight to integer milliseconds:
+    // toDecimals() truncates via Math.floor, and 1.001 * 1000 evaluates to
+    // 1000.9999999999999 in IEEE-754, so pre-rounding to 3 decimals in
+    // seconds silently drops a millisecond that Math.round would keep. All
+    // the repair math below runs in integer milliseconds for the same reason.
     const minimumDurationMilliseconds = Math.round(
       MIN_RENDER_CLIP_DURATION_SECONDS * 1000,
     );
-    const sourceDurationMilliseconds = Math.round(
-      toDecimals(duration, 3) * 1000,
-    );
+    const sourceDurationMilliseconds = Math.round(duration * 1000);
     let startMilliseconds = Math.round(newTrim.start * 1000);
     let endMilliseconds = Math.round(newTrim.end * 1000);
 

--- a/ui/src/app/storyboard/storyboard.ts
+++ b/ui/src/app/storyboard/storyboard.ts
@@ -49,6 +49,7 @@ import {
   Candidate,
   ConfigService,
   GeneratedScene,
+  MIN_RENDER_CLIP_DURATION_SECONDS,
   ProvidedVideoScene,
   toDecimals,
 } from '../services/config/config';
@@ -566,6 +567,9 @@ export class Storyboard {
     const currentTrim = this.trimBySceneType();
 
     const duration = this.videoDuration();
+    if (!Number.isFinite(duration) || duration <= 0) {
+      return;
+    }
     const newTrim = {
       ...currentTrim,
       ...range,
@@ -598,6 +602,43 @@ export class Storyboard {
 
     newTrim.start = toDecimals(newTrim.start, 3);
     newTrim.end = toDecimals(newTrim.end, 3);
+
+    const minimumDurationMilliseconds = Math.round(
+      MIN_RENDER_CLIP_DURATION_SECONDS * 1000,
+    );
+    const sourceDurationMilliseconds = Math.round(
+      toDecimals(duration, 3) * 1000,
+    );
+    let startMilliseconds = Math.round(newTrim.start * 1000);
+    let endMilliseconds = Math.round(newTrim.end * 1000);
+
+    if (endMilliseconds - startMilliseconds < minimumDurationMilliseconds) {
+      if (range.start !== undefined && range.end === undefined) {
+        startMilliseconds = Math.max(
+          0,
+          endMilliseconds - minimumDurationMilliseconds,
+        );
+        if (endMilliseconds - startMilliseconds < minimumDurationMilliseconds) {
+          endMilliseconds = Math.min(
+            sourceDurationMilliseconds,
+            startMilliseconds + minimumDurationMilliseconds,
+          );
+        }
+      } else {
+        endMilliseconds = Math.min(
+          sourceDurationMilliseconds,
+          startMilliseconds + minimumDurationMilliseconds,
+        );
+      }
+      if (endMilliseconds - startMilliseconds < minimumDurationMilliseconds) {
+        startMilliseconds = Math.max(
+          0,
+          endMilliseconds - minimumDurationMilliseconds,
+        );
+      }
+    }
+    newTrim.start = startMilliseconds / 1000;
+    newTrim.end = endMilliseconds / 1000;
 
     if (this.config.isGeneratedScene(scene) && candidate) {
       candidate.trim = newTrim;


### PR DESCRIPTION
## Summary

Serialize whole-project saves per project and use one frame-safe render
contract from storyboard editing through arrangement submission.

## Behavior

- Only one save request per project can be in flight. Newer edits wait behind
  it, and intermediate queued snapshots are replaced by the latest state.
- Queued payloads are copied after their edit timestamp is set, so later nested
  mutations cannot change already queued bytes.
- A reload begun during an unsettled save preserves the newest local snapshot,
  including stale GET and 404 responses. Save state remains isolated by project
  and is removed after project deletion.
- Retry sends the newest observed project snapshot and does nothing when that
  snapshot has already saved.
- Save state is dropped when a delete begins rather than when it returns, so a
  save completing mid-deletion cannot dispatch its queued successor. A request
  already sent may still reach the server after the delete; that ordering is
  the server's.
- Filmstrip, preview, and render submission use only clips with a non-empty
  Cloud Storage path, at least 0.042 seconds of effective duration, and a trim
  that lies inside the source video.
- Trim edits wait for video metadata and keep millisecond resolution: endpoints
  convert to integer milliseconds before any minimum-duration or ordering
  repair.
- An invalid intended clip disables Render with a recoverable message rather
  than silently producing a partial storyboard. A render already in progress
  reports that instead.
- A transition longer than either clip it joins disables Render and is refused
  at arrangement construction, since the crossfade would consume a neighbouring
  clip entirely.
- An explicit zero transition overlap means a hard cut end to end; only an
  absent overlap takes the default.
- Arrangement construction uses the same resolved clip values and the same
  transition check as eligibility and preview.

## Tests

- Covers delayed saves, three-edit coalescing, payload isolation, navigation
  during a save, stale and missing reload responses, create-conflict recovery,
  retry, cleanup, and catalog correction.
- Covers crossed and sub-frame trims, millisecond precision, trims starting at
  or running past the source end, edits before metadata loads, URL-only and
  missing-duration media, invalid mixed storyboards, oversized transitions in
  both the UI and arrangement construction, explicit zero overlap through to
  the backend, and exact arrangement values.
- The exact combined head passes the full UI build, lint, unit-test, spec
  type-check, and repository checks.

## Risks / Notes

- Concurrent browser tabs and multiple users remain last-writer-wins; save
  serialization is scoped to one app session. Ordering a save against a delete
  is likewise client-side only: a request already in flight when the delete is
  issued can still be applied server-side afterwards.
- Legacy URL-only media must be re-uploaded or repaired before rendering.

