### PR TITLE
Use one renderable-scene contract

### DIFF
--- a/ui/src/app/composition/composition.html
+++ b/ui/src/app/composition/composition.html
@@ -119,11 +119,7 @@
 
         <div class="actions-panel">
           <span
-            [matTooltip]="
-              canRender()
-                ? ''
-                : 'Select or upload at least one scene video before rendering.'
-            "
+            [matTooltip]="renderDisabledReason()"
           >
             <button
               mat-flat-button

--- a/ui/src/app/composition/composition.spec.ts
+++ b/ui/src/app/composition/composition.spec.ts
@@ -20,6 +20,7 @@ import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {
   ConfigService,
+  GcsFile,
   GeneratedScene,
   ProjectConfig,
   ProvidedVideoScene,
@@ -118,6 +119,139 @@ describe('CompositionComponent', () => {
     expect(component.filmstripScenes().length).toBe(0);
   });
 
+  it('does not render a URL-only provided video', () => {
+    projectConfigSignal.update(config => ({
+      ...config,
+      storyboard: [
+        {
+          id: 'legacy-video',
+          type: 'video',
+          name: 'Legacy video',
+          video: {url: 'https://legacy.example/video.mp4', path: ''},
+          durationSeconds: 5,
+        },
+      ],
+    }));
+
+    expect(component.filmstripScenes()).toEqual([]);
+    expect(component.canRender()).toBe(false);
+  });
+
+  it('treats a legacy URL-only video with no path field as invalid', () => {
+    projectConfigSignal.update(config => ({
+      ...config,
+      storyboard: [
+        {
+          id: 'legacy-video-without-path',
+          type: 'video',
+          name: 'Legacy video without path',
+          video: {
+            url: 'https://legacy.example/video.mp4',
+          } as unknown as GcsFile,
+          durationSeconds: 5,
+        },
+      ],
+    }));
+
+    expect(component.filmstripScenes()).toEqual([]);
+    expect(component.canRender()).toBe(false);
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['zero', 0],
+  ])(
+    'does not render a provided video with %s duration',
+    (_label, duration) => {
+      projectConfigSignal.update(config => ({
+        ...config,
+        storyboard: [
+          {
+            id: 'invalid-video',
+            type: 'video',
+            name: 'Invalid video',
+            video: {url: '', path: 'videos/invalid.mp4'},
+            durationSeconds: duration,
+          },
+        ],
+      }));
+
+      expect(component.filmstripScenes()).toEqual([]);
+      expect(component.canRender()).toBe(false);
+    },
+  );
+
+  it('does not render a persisted trim shorter than one 24fps frame', () => {
+    projectConfigSignal.update(config => ({
+      ...config,
+      storyboard: [
+        {
+          id: 'too-short',
+          type: 'video',
+          name: 'Too-short clip',
+          video: {url: '', path: 'videos/too-short.mp4'},
+          durationSeconds: 5,
+          trim: {start: 2, end: 2.041},
+        },
+      ],
+    }));
+
+    expect(component.filmstripScenes()).toEqual([]);
+    expect(component.canRender()).toBe(false);
+  });
+
+  it('renders a persisted trim that contains one full 24fps frame', () => {
+    projectConfigSignal.update(config => ({
+      ...config,
+      storyboard: [
+        {
+          id: 'one-frame',
+          type: 'video',
+          name: 'One-frame clip',
+          video: {url: '', path: 'videos/one-frame.mp4'},
+          durationSeconds: 5,
+          trim: {start: 2, end: 2.042},
+        },
+      ],
+    }));
+
+    expect(component.filmstripScenes().map(scene => scene.id)).toEqual([
+      'one-frame',
+    ]);
+    expect(component.canRender()).toBe(true);
+    expect(Math.round(component.playlist()[0].duration * 24)).toBe(1);
+  });
+
+  it('blocks a partial render when an intended clip is invalid', () => {
+    projectConfigSignal.update(config => ({
+      ...config,
+      storyboard: [
+        {
+          id: 'ready',
+          type: 'video',
+          name: 'Ready clip',
+          video: {url: '', path: 'videos/ready.mp4'},
+          durationSeconds: 5,
+        },
+        {
+          id: 'invalid',
+          type: 'video',
+          name: 'Invalid clip',
+          video: {url: '', path: 'videos/invalid.mp4'},
+          durationSeconds: Number.NaN,
+        },
+      ],
+    }));
+
+    expect(component.filmstripScenes().map(scene => scene.id)).toEqual([
+      'ready',
+    ]);
+    expect(component.canRender()).toBe(false);
+    expect(component.renderDisabledReason()).toContain(
+      'storage path or valid duration',
+    );
+  });
+
   it('should show a generated scene in the filmstrip if it has a selected candidate', () => {
     const generatedScene: GeneratedScene = {
       id: '1',
@@ -163,12 +297,13 @@ describe('CompositionComponent', () => {
     expect(component.filmstripScenes().length).toBe(0);
   });
 
-  it('should show a video scene in the filmstrip if it has a videoUrl', () => {
+  it('shows a provided video with a path and positive duration', () => {
     const videoScene: ProvidedVideoScene = {
       id: '2',
       type: 'video',
       name: 'Scene 2',
       video: {url: 'http://video.url/2', path: 'path/to/video/2'},
+      durationSeconds: 5,
     };
 
     projectConfigSignal.set({
@@ -217,6 +352,7 @@ describe('CompositionComponent', () => {
       type: 'video',
       name: 'Scene 2',
       video: {url: '', path: 'path/to/video/2'},
+      durationSeconds: 5,
     };
 
     projectConfigSignal.set({
@@ -289,6 +425,7 @@ describe('CompositionComponent', () => {
         type: 'video',
         name: 'Scene 3',
         video: {url: 'u3', path: 'path3'},
+        durationSeconds: 5,
       },
       {
         id: '4',

--- a/ui/src/app/composition/composition.ts
+++ b/ui/src/app/composition/composition.ts
@@ -39,6 +39,7 @@ import {FormatTimePipe} from '../pipes/format-time-pipe';
 import {
   ConfigService,
   DEFAULT_TRANSITION_OVERLAP,
+  resolveSceneRenderClip,
 } from '../services/config/config';
 import {MediaRef, MediaService} from '../services/media/media';
 import {MediaSrcPipe} from '../services/media/media-src.pipe';
@@ -99,74 +100,69 @@ export class Composition {
     return ratio ? ratio.replace(':', '/') : '16/9';
   });
 
-  filmstripScenes = computed(() => {
-    return this.scenes().filter(scene => {
-      if (
-        this.configService.isGeneratedScene(scene) &&
-        scene.candidates &&
-        scene.selectedCandidateIndex !== undefined
-      ) {
-        // Downstream resolves media by path (signing it on read), so a scene
-        // persisted with a path but a blank url is still renderable: accept
-        // either a path or a url.
-        const video = scene.candidates[scene.selectedCandidateIndex].video;
-        return !!(video?.path || video?.url);
+  private sceneRenderClips = computed(() =>
+    this.scenes().map(scene => ({
+      scene,
+      resolution: resolveSceneRenderClip(scene),
+    })),
+  );
+
+  filmstripScenes = computed(() =>
+    this.sceneRenderClips()
+      .filter(({resolution}) => resolution.state === 'ready')
+      .map(({scene}) => scene),
+  );
+
+  playlist = computed(() => {
+    return this.sceneRenderClips().flatMap(({scene, resolution}) => {
+      if (resolution.state !== 'ready') {
+        return [];
       }
-      if (this.configService.isProvidedVideoScene(scene)) {
-        return !!(scene.video?.path || scene.video?.url);
-      }
-      return false;
+      const {video, start, duration} = resolution.clip;
+      return [
+        {
+          id: scene.id,
+          name: scene.name,
+          video,
+          start,
+          end: start + duration,
+          duration,
+          transitionOverlap: scene.transitionOverlap,
+          type: scene.type,
+        },
+      ];
     });
   });
 
-  playlist = computed(() => {
-    return this.filmstripScenes()
-      .map(scene => {
-        if (this.configService.isGeneratedScene(scene)) {
-          if (!scene.candidates || scene.selectedCandidateIndex === undefined) {
-            return;
-          }
-          const candidate = scene.candidates[scene.selectedCandidateIndex];
-          const start = candidate.trim?.start ?? 0;
-          const end = candidate.trim?.end ?? candidate.durationSeconds;
-          return {
-            id: scene.id,
-            name: scene.name,
-            video: candidate.video,
-            start,
-            end,
-            duration: end - start,
-            transitionOverlap: scene.transitionOverlap,
-            type: 'generated' as const,
-          };
-        } else {
-          // VideoScene
-          const start = scene.trim?.start ?? 0;
-          const end = scene.trim?.end ?? scene.durationSeconds!;
-          return {
-            id: scene.id,
-            name: scene.name,
-            video: scene.video,
-            start,
-            end,
-            duration: end - start,
-            transitionOverlap: scene.transitionOverlap,
-            type: 'video' as const,
-          };
-        }
-      })
-      .filter(item => item !== undefined);
-  });
-
   /**
-   * True when at least one scene contributes a usable video to the render
-   * (a selected candidate with a video, or an uploaded video scene). The
-   * playlist already filters to exactly those scenes, so an empty playlist
-   * means there is nothing to combine — rendering would fail in the backend
-   * with "cannot generate video without at least one video input", so we block
-   * it in the UI instead.
+   * True when at least one scene contributes a usable video and every intended
+   * clip is valid. An empty playlist would fail in the backend, while omitting
+   * an invalid intended clip would silently render only part of the storyboard.
    */
-  canRender = computed(() => this.playlist().length > 0);
+  canRender = computed(
+    () =>
+      this.playlist().length > 0 &&
+      !this.sceneRenderClips().some(
+        ({resolution}) => resolution.state === 'invalid',
+      ),
+  );
+
+  renderDisabledReason = computed(() => {
+    if (
+      this.sceneRenderClips().some(
+        ({resolution}) => resolution.state === 'invalid',
+      )
+    ) {
+      return (
+        'One or more selected scene videos are missing a storage path or valid ' +
+        'duration, or have an invalid trim.'
+      );
+    }
+    if (this.playlist().length === 0) {
+      return 'Select or upload at least one scene video before rendering.';
+    }
+    return '';
+  });
 
   currentPlaylistIndex = signal(0);
   isPlaying = signal(false);

--- a/ui/src/app/services/config/config.ts
+++ b/ui/src/app/services/config/config.ts
@@ -34,6 +34,11 @@ import {debounceTime, distinctUntilChanged, firstValueFrom, skip} from 'rxjs';
  */
 export const DEFAULT_TRANSITION_OVERLAP = 0.5;
 
+/** One full frame at the backend's minimum 24 fps render rate. */
+export const MIN_RENDER_CLIP_DURATION_SECONDS = 0.042;
+
+const DURATION_COMPARISON_EPSILON_SECONDS = 1e-9;
+
 /**
  * Threshold for aspect ratio deviation beyond which a warning is shown.
  */
@@ -316,6 +321,69 @@ export interface ProvidedVideoScene extends Scene {
   video?: GcsFile;
   durationSeconds?: number;
   trim?: {start?: number; end?: number};
+}
+
+export interface SceneRenderClip {
+  video: GcsFile;
+  start: number;
+  duration: number;
+}
+
+export type SceneRenderClipResolution =
+  | {state: 'not-selected'}
+  | {state: 'invalid'}
+  | {state: 'ready'; clip: SceneRenderClip};
+
+/**
+ * Resolves the video material that a scene contributes to a render.
+ *
+ * An unselected generated scene contributes nothing. A provided-video scene,
+ * or a generated scene with a selected candidate, is invalid unless it has a
+ * storage path and at least one frame of effective duration.
+ */
+export function resolveSceneRenderClip(
+  scene: GeneratedScene | ProvidedVideoScene,
+): SceneRenderClipResolution {
+  let video: GcsFile | undefined;
+  let sourceDuration: number | undefined;
+  let trim: {start?: number; end?: number} | undefined;
+
+  if (scene.type === 'generated') {
+    const generatedScene = scene as GeneratedScene;
+    if (generatedScene.selectedCandidateIndex === undefined) {
+      return {state: 'not-selected'};
+    }
+    const candidate =
+      generatedScene.candidates?.[generatedScene.selectedCandidateIndex];
+    if (!candidate) {
+      return {state: 'invalid'};
+    }
+    video = candidate.video;
+    sourceDuration = candidate.durationSeconds;
+    trim = candidate.trim;
+  } else {
+    const providedScene = scene as ProvidedVideoScene;
+    video = providedScene.video;
+    sourceDuration = providedScene.durationSeconds;
+    trim = providedScene.trim;
+  }
+
+  const start = trim?.start ?? 0;
+  const end = trim?.end ?? sourceDuration;
+  const duration = end === undefined ? NaN : end - start;
+  const path = video?.path;
+  if (
+    !video ||
+    typeof path !== 'string' ||
+    !path.trim() ||
+    !Number.isFinite(start) ||
+    !Number.isFinite(duration) ||
+    duration + DURATION_COMPARISON_EPSILON_SECONDS <
+      MIN_RENDER_CLIP_DURATION_SECONDS
+  ) {
+    return {state: 'invalid'};
+  }
+  return {state: 'ready', clip: {video, start, duration}};
 }
 
 export interface ThumbnailMaterial {

--- a/ui/src/app/services/remix-engine/remix-engine-mediated.spec.ts
+++ b/ui/src/app/services/remix-engine/remix-engine-mediated.spec.ts
@@ -85,6 +85,15 @@ describe('RemixEngineService (mediated)', () => {
     return calls[calls.length - 1][0].storyboard[0];
   }
 
+  function setRenderStoryboard(storyboard: any[]) {
+    projectConfigSignal.set({
+      ...projectConfigSignal(),
+      storyboard,
+      audioTracks: [],
+      visualOverlays: [],
+    });
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     // Do NOT replace the global `window` here. jsdom already provides
@@ -1092,18 +1101,122 @@ describe('RemixEngineService (mediated)', () => {
     });
   });
 
+  describe('combineScenes: render contract', () => {
+    it('does not submit a workflow with no renderable video', async () => {
+      setRenderStoryboard([]);
+      const startSpy = vi.spyOn(service, 'startCombineScenesWorkflow');
+
+      await service.combineScenes();
+
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        'Select or upload at least one scene video before rendering.',
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+      expect(configServiceMock.addRenderRun).not.toHaveBeenCalled();
+    });
+
+    it('does not submit a partial render when an intended clip is invalid', async () => {
+      setRenderStoryboard([
+        {
+          id: 'ready',
+          type: 'video',
+          name: 'Ready clip',
+          video: {path: 'videos/ready.mp4', url: ''},
+          durationSeconds: 5,
+        },
+        {
+          id: 'invalid',
+          type: 'generated',
+          name: 'Invalid selected clip',
+          selectedCandidateIndex: 0,
+          candidates: [
+            {
+              video: {path: '', url: 'https://legacy.example/video.mp4'},
+              durationSeconds: 5,
+            },
+          ],
+        },
+      ]);
+      const startSpy = vi.spyOn(service, 'startCombineScenesWorkflow');
+
+      await service.combineScenes();
+
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(matSnackBarMock.open).toHaveBeenCalledWith(
+        expect.stringContaining('storage path or valid duration'),
+        'Dismiss',
+        {panelClass: ['error-snackbar']},
+      );
+      expect(configServiceMock.addRenderRun).not.toHaveBeenCalled();
+      expect(configServiceMock.setPendingRender).not.toHaveBeenCalled();
+      expect(service.combiningScenes()).toBe(false);
+    });
+
+    it('submits the shared clip values and ignores an unselected generated scene', async () => {
+      setRenderStoryboard([
+        {
+          id: 'ready',
+          type: 'generated',
+          name: 'Ready clip',
+          selectedCandidateIndex: 0,
+          candidates: [
+            {
+              video: {path: 'videos/ready.mp4', url: ''},
+              durationSeconds: 10,
+              trim: {start: 2, end: 8},
+            },
+          ],
+        },
+        {
+          id: 'not-selected',
+          type: 'generated',
+          name: 'No candidate selected',
+        },
+      ]);
+      const startSpy = vi
+        .spyOn(service, 'startCombineScenesWorkflow')
+        .mockResolvedValue(of({executionId: 'render-exec-id'}) as any);
+      vi.spyOn(service, 'pollWorkflow').mockResolvedValue({
+        sink: {output: {'0': {video: [{file: 'renders/output.mp4'}]}}},
+      } as any);
+      mediaServiceMock.signUrl.mockResolvedValue(
+        'https://signed.example/renders/output.mp4',
+      );
+
+      await service.combineScenes();
+
+      expect(startSpy).toHaveBeenCalledWith(
+        [
+          {
+            file_type: 'video',
+            file_path: 'videos/ready.mp4',
+            start_time: 0,
+            skip_time: 2,
+            duration: 6,
+          },
+        ],
+        false,
+      );
+    });
+  });
+
   describe('combineScenes: signing-failure resilience', () => {
     it('keeps the pending render and records no error when the output cannot be signed', async () => {
       // A live render finishes, but signing its output URL fails persistently
       // (transient /api/signUrl outage). withRetry exhausts its attempts and the
       // completed render is kept (marker not cleared, no error run) so a reopen
       // re-collects it, mirroring the resumed-render path. (E3)
-      projectConfigSignal.set({
-        id: 'project-1',
-        storyboard: [],
-        audioTracks: [],
-        visualOverlays: [],
-      });
+      setRenderStoryboard([
+        {
+          id: 'video-1',
+          type: 'video',
+          name: 'Video 1',
+          video: {path: 'videos/video-1.mp4', url: ''},
+          durationSeconds: 5,
+        },
+      ]);
       vi.spyOn(service, 'startCombineScenesWorkflow').mockResolvedValue(
         of({executionId: 'render-exec-id'}) as any,
       );

--- a/ui/src/app/services/remix-engine/remix-engine.ts
+++ b/ui/src/app/services/remix-engine/remix-engine.ts
@@ -50,6 +50,7 @@ import {
   ProductImage,
   ProvidedVideoScene,
   RenderRun,
+  resolveSceneRenderClip,
   Resolution,
   VisualOverlay,
 } from '../config/config';
@@ -71,6 +72,13 @@ class ProjectChangedError extends Error {
   constructor() {
     super('Project changed, cancelling workflow polling');
     this.name = 'ProjectChangedError';
+  }
+}
+
+class RenderContractError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RenderContractError';
   }
 }
 
@@ -1407,7 +1415,13 @@ export class RemixEngineService {
       await this.recordRenderOutput(workflowStatus, projectId);
       this.combiningScenes.set(false);
     } catch (error) {
-      if (error instanceof ProjectChangedError) {
+      if (error instanceof RenderContractError) {
+        this.combiningScenes.set(false);
+        this.matSnackBar.open(error.message, 'Dismiss', {
+          panelClass: ['error-snackbar'],
+        });
+        return;
+      } else if (error instanceof ProjectChangedError) {
         // The user left the project mid-render: reset the in-memory button
         // state (otherwise it stays stuck on "Rendering...") but keep the
         // persisted marker so returning to the project resumes the run. Release
@@ -1619,61 +1633,37 @@ export class RemixEngineService {
     }
   }
 
-  private getSceneVideoDuration(
-    scene: GeneratedScene | ProvidedVideoScene,
-    skipTime: number,
-  ) {
-    if (this.configService.isGeneratedScene(scene)) {
-      const candidate = scene.candidates![scene.selectedCandidateIndex!];
-      const end = candidate.trim?.end ?? candidate.durationSeconds;
-      return end - skipTime;
-    }
-    if (this.configService.isProvidedVideoScene(scene)) {
-      const end = scene.trim?.end ?? scene.durationSeconds!;
-      return end - skipTime;
-    }
-    return 0;
-  }
-
   private getCombineScenesArrangements(
     scenes: Array<GeneratedScene | ProvidedVideoScene>,
     audioTracks: AudioTrack[],
     visualOverlays: VisualOverlay[],
   ) {
     const arrangement: CombineScenesArrangement[] = [];
-    const validScenes = scenes.filter(scene => {
-      if (this.configService.isProvidedVideoScene(scene)) {
-        if (scene.durationSeconds) {
-          return scene.video?.path;
-        }
-      } else if (this.configService.isGeneratedScene(scene)) {
-        if (scene.candidates && scene.selectedCandidateIndex !== undefined) {
-          return scene.candidates[scene.selectedCandidateIndex].video?.path;
-        }
-      }
-      return false;
-    });
-    for (const scene of validScenes) {
-      let gcsVideoPath;
-      let skipTime = 0;
-      if (this.configService.isProvidedVideoScene(scene)) {
-        gcsVideoPath = scene.video?.path;
-        skipTime = scene.trim?.start ?? 0;
-      } else if (this.configService.isGeneratedScene(scene)) {
-        const candidate = scene.candidates![scene.selectedCandidateIndex!];
-        gcsVideoPath = candidate.video?.path;
-        skipTime = candidate.trim?.start ?? 0;
-      }
-      const duration = this.getSceneVideoDuration(scene, skipTime);
-      if (!gcsVideoPath) {
-        console.debug(`No video for scene ${scene.id}`);
+    const resolvedScenes = scenes.map(scene => ({
+      scene,
+      resolution: resolveSceneRenderClip(scene),
+    }));
+    if (resolvedScenes.some(({resolution}) => resolution.state === 'invalid')) {
+      throw new RenderContractError(
+        'One or more selected scene videos are missing a storage path or valid ' +
+          'duration, or have an invalid trim.',
+      );
+    }
+    if (!resolvedScenes.some(({resolution}) => resolution.state === 'ready')) {
+      throw new RenderContractError(
+        'Select or upload at least one scene video before rendering.',
+      );
+    }
+    for (const {scene, resolution} of resolvedScenes) {
+      if (resolution.state !== 'ready') {
         continue;
       }
+      const {video, start, duration} = resolution.clip;
       const videoArrangement: CombineScenesArrangement = {
         file_type: 'video',
-        file_path: gcsVideoPath,
+        file_path: video.path,
         start_time: 0,
-        skip_time: skipTime,
+        skip_time: start,
         duration,
       };
       if (scene.transition) {
@@ -1682,12 +1672,6 @@ export class RemixEngineService {
           scene.transitionOverlap ?? DEFAULT_TRANSITION_OVERLAP;
       }
       arrangement.push(videoArrangement);
-
-      if (duration <= 0) {
-        console.error(
-          `ERROR:Unknown scene #${scene.id} video duration: ${duration}, using default value instead.`,
-        );
-      }
     }
 
     for (const track of audioTracks) {

--- a/ui/src/app/storyboard/storyboard.spec.ts
+++ b/ui/src/app/storyboard/storyboard.spec.ts
@@ -26,6 +26,7 @@ import {
   GeneratedScene,
   ProjectConfig,
   ProvidedVideoScene,
+  resolveSceneRenderClip,
 } from '../services/config/config';
 import {RemixEngineService} from '../services/remix-engine/remix-engine';
 import {Storyboard} from './storyboard';
@@ -159,6 +160,19 @@ describe('Storyboard', () => {
     fixture.detectChanges();
   });
 
+  function selectTrimScene(scene: GeneratedScene | ProvidedVideoScene) {
+    projectConfigSignal.update(config => ({
+      ...config,
+      storyboard: [scene],
+    }));
+    component.selectScene(scene.id);
+    component.videoDuration.set(10);
+  }
+
+  function currentProvidedTrim() {
+    return (projectConfigSignal().storyboard[0] as ProvidedVideoScene).trim;
+  }
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
@@ -282,6 +296,106 @@ describe('Storyboard', () => {
     // Test with dragging
     component.draggingTrim.set({start: 3, end: 7});
     expect(component.trimmedDuration()).toBe(4);
+  });
+
+  it('keeps at least one 24fps frame when trim start crosses trim end', () => {
+    const candidate: Candidate = {
+      video: {url: 'http://test.mp4', path: 'test/path'},
+      runNumber: 1,
+      durationSeconds: 10,
+      trim: {start: 2, end: 8},
+      prompt: 'test prompt',
+      model: 'test-model',
+      generateAudio: false,
+      resolution: '1080p',
+    };
+    const scene: GeneratedScene = {
+      id: '1',
+      type: 'generated',
+      name: 'Scene 1',
+      prompt: 'test prompt',
+      candidates: [candidate],
+      selectedCandidateIndex: 0,
+    };
+    selectTrimScene(scene);
+
+    component.updateTrim({start: 9});
+
+    expect(candidate.trim).toEqual({start: 7.958, end: 8});
+    const resolution = resolveSceneRenderClip(scene);
+    expect(resolution.state).toBe('ready');
+    if (resolution.state === 'ready') {
+      expect(Math.round(resolution.clip.duration * 24)).toBe(1);
+    }
+  });
+
+  it('keeps at least one 24fps frame when trim end crosses trim start', () => {
+    const scene: ProvidedVideoScene = {
+      id: '1',
+      type: 'video',
+      name: 'Scene 1',
+      video: {url: 'http://test.mp4', path: 'test/path'},
+      durationSeconds: 10,
+      trim: {start: 2, end: 8},
+    };
+    selectTrimScene(scene);
+
+    component.updateTrim({end: 1});
+
+    expect(currentProvidedTrim()).toEqual({start: 2, end: 2.042});
+    const trim = currentProvidedTrim()!;
+    expect(Math.round((trim.end! - trim.start!) * 24)).toBe(1);
+  });
+
+  it('keeps trim endpoints strictly ordered after rounding', () => {
+    const scene: ProvidedVideoScene = {
+      id: '1',
+      type: 'video',
+      name: 'Scene 1',
+      video: {url: 'http://test.mp4', path: 'test/path'},
+      durationSeconds: 10,
+      trim: {start: 2, end: 8},
+    };
+    selectTrimScene(scene);
+
+    component.updateTrim({end: 2});
+
+    expect(currentProvidedTrim()).toEqual({start: 2, end: 2.042});
+  });
+
+  it('repairs a two-endpoint trim that becomes equal after rounding', () => {
+    const scene: ProvidedVideoScene = {
+      id: '1',
+      type: 'video',
+      name: 'Scene 1',
+      video: {url: 'http://test.mp4', path: 'test/path'},
+      durationSeconds: 10,
+      trim: {start: 1, end: 8},
+    };
+    selectTrimScene(scene);
+
+    component.updateTrim({start: 2, end: 2.0009});
+
+    expect(currentProvidedTrim()).toEqual({start: 2, end: 2.042});
+  });
+
+  it('does not change trim before video metadata loads', () => {
+    const scene: ProvidedVideoScene = {
+      id: '1',
+      type: 'video',
+      name: 'Scene 1',
+      video: {url: 'http://test.mp4', path: 'test/path'},
+      durationSeconds: 10,
+      trim: {start: 2, end: 8},
+    };
+    selectTrimScene(scene);
+    component.videoDuration.set(0);
+    const updateSpy = vi.spyOn(mockConfigService, 'updateProjectConfig');
+
+    component.updateTrim({start: 3});
+
+    expect(currentProvidedTrim()).toEqual({start: 2, end: 8});
+    expect(updateSpy).not.toHaveBeenCalled();
   });
 
   describe('run+letter candidate labels', () => {

--- a/ui/src/app/storyboard/storyboard.ts
+++ b/ui/src/app/storyboard/storyboard.ts
@@ -49,6 +49,7 @@ import {
   Candidate,
   ConfigService,
   GeneratedScene,
+  MIN_RENDER_CLIP_DURATION_SECONDS,
   ProvidedVideoScene,
   toDecimals,
 } from '../services/config/config';
@@ -566,6 +567,9 @@ export class Storyboard {
     const currentTrim = this.trimBySceneType();
 
     const duration = this.videoDuration();
+    if (!Number.isFinite(duration) || duration <= 0) {
+      return;
+    }
     const newTrim = {
       ...currentTrim,
       ...range,
@@ -598,6 +602,43 @@ export class Storyboard {
 
     newTrim.start = toDecimals(newTrim.start, 3);
     newTrim.end = toDecimals(newTrim.end, 3);
+
+    const minimumDurationMilliseconds = Math.round(
+      MIN_RENDER_CLIP_DURATION_SECONDS * 1000,
+    );
+    const sourceDurationMilliseconds = Math.round(
+      toDecimals(duration, 3) * 1000,
+    );
+    let startMilliseconds = Math.round(newTrim.start * 1000);
+    let endMilliseconds = Math.round(newTrim.end * 1000);
+
+    if (endMilliseconds - startMilliseconds < minimumDurationMilliseconds) {
+      if (range.start !== undefined && range.end === undefined) {
+        startMilliseconds = Math.max(
+          0,
+          endMilliseconds - minimumDurationMilliseconds,
+        );
+        if (endMilliseconds - startMilliseconds < minimumDurationMilliseconds) {
+          endMilliseconds = Math.min(
+            sourceDurationMilliseconds,
+            startMilliseconds + minimumDurationMilliseconds,
+          );
+        }
+      } else {
+        endMilliseconds = Math.min(
+          sourceDurationMilliseconds,
+          startMilliseconds + minimumDurationMilliseconds,
+        );
+      }
+      if (endMilliseconds - startMilliseconds < minimumDurationMilliseconds) {
+        startMilliseconds = Math.max(
+          0,
+          endMilliseconds - minimumDurationMilliseconds,
+        );
+      }
+    }
+    newTrim.start = startMilliseconds / 1000;
+    newTrim.end = endMilliseconds / 1000;
 
     if (this.config.isGeneratedScene(scene) && candidate) {
       candidate.trim = newTrim;


### PR DESCRIPTION
## Summary

Use one clip-eligibility contract from storyboard editing through render
payload construction.

## Behavior

- Filmstrip and preview playlist include only clips with a non-empty Cloud
  Storage path and frame-safe effective duration; legacy URL-only media is not
  displayed as renderable.
- Rendering requires at least 0.042 seconds, one full frame at the backend's
  minimum 24fps rate. Shorter persisted trims are rejected.
- Storyboard trim edits wait for video metadata, then retain the same
  0.042-second minimum after three-decimal rounding.
- An invalid intended clip disables Render with a recoverable message and
  stops submission before the combine workflow starts; it is never silently
  omitted from a partial storyboard.
- Arrangement construction uses the same resolved clip values as the
  filmstrip and Render eligibility checks.

## Tests

Covers crossed and sub-frame trims, edits before video metadata loads,
URL-only and missing-duration media, non-finite and zero durations, mixed
valid and invalid storyboards, and exact arrangement values. Crossed-trim
coverage proves the resulting duration produces a positive frame count at
24fps. The focused render slice, full UI suite, compile, lint, and spec
typecheck pass under Node 22.

## Risks / Notes

- Legacy URL-only media must be re-uploaded or repaired before rendering.
- Stacks on #147; review this PR against `port/autosave-ordering` for the
  isolated eight-file change.
