### PR TITLE
Make project creation atomic

### DIFF
--- a/orch.py
+++ b/orch.py
@@ -59,6 +59,7 @@ from flask import request as flask_request
 from flask import Response as flask_response
 from flask import send_from_directory
 from flask_cors import CORS
+from google.api_core import exceptions as google_exceptions
 from google.auth import compute_engine
 from google.auth import default as google_auth_default
 from google.auth.transport import requests as google_auth_requests
@@ -902,14 +903,18 @@ def _commit_in_batches(ui_db, ops) -> None:
   for start in range(0, len(ops), _SCENE_BATCH_LIMIT):
     batch = ui_db.batch()
     for op, ref, data in ops[start : start + _SCENE_BATCH_LIMIT]:
-      if op == 'set':
+      if op == 'create':
+        batch.create(ref, data)
+      elif op == 'set':
         batch.set(ref, data)
       else:
         batch.delete(ref)
     batch.commit()
 
 
-def _write_project_doc(ui_db, doc_ref, payload: dict) -> None:
+def _write_project_doc(
+    ui_db, doc_ref, payload: dict, *, create: bool = False
+) -> None:
   """Writes a project, splitting its storyboard into the scenes subcollection.
 
   The root document keeps every field except the scene list (stored empty);
@@ -919,7 +924,8 @@ def _write_project_doc(ui_db, doc_ref, payload: dict) -> None:
   batches: a project that fits in one batch commits atomically; a larger one
   spans multiple batches committed in sequence (not atomic as a whole), so a
   failure partway through can leave the project partially written until the next
-  save.
+  save. When create is true, the root uses Firestore's atomic not-exists
+  precondition; scene writes retain their existing set behavior.
   """
   scenes = payload.get('storyboard')
   if not isinstance(scenes, list):
@@ -928,7 +934,7 @@ def _write_project_doc(ui_db, doc_ref, payload: dict) -> None:
   root['storyboard'] = []
   scenes_ref = doc_ref.collection(_SCENES_SUBCOLLECTION)
   keep_ids = {_scene_doc_id(i) for i in range(len(scenes))}
-  ops = [('set', doc_ref, root)]
+  ops = [('create' if create else 'set', doc_ref, root)]
   for index, scene in enumerate(scenes):
     ops.append(('set', scenes_ref.document(_scene_doc_id(index)), scene))
   for snapshot in scenes_ref.stream():
@@ -1020,15 +1026,12 @@ def projects_handler() -> flask_response:
     return _json_error('Invalid project id', 400)
   payload['id'] = project_id
   doc_ref = collection.document(project_id)
-  # Create-only: POST must not overwrite an existing project (which would also
-  # re-stamp createdBy to the poster, reassigning the owner shown in "My
-  # projects"). Updates go through PATCH, which preserves createdBy. A repeated
-  # POST of the same id returns 409 instead of silently clobbering.
-  if doc_ref.get().exists:
-    return _json_error('Project already exists', 409)
   payload['createdBy'] = _request_email()
   _convert_project_dates(payload)
-  _write_project_doc(ui_db, doc_ref, payload)
+  try:
+    _write_project_doc(ui_db, doc_ref, payload, create=True)
+  except google_exceptions.AlreadyExists:
+    return _json_error('Project already exists', 409)
   return _json_response({'id': project_id})
 
 

--- a/test/test_frontdoor_data.py
+++ b/test/test_frontdoor_data.py
@@ -28,7 +28,10 @@ import datetime
 import importlib
 import pathlib
 import sys
+import threading
 import uuid
+
+from google.api_core import exceptions as google_exceptions
 
 # Reused module-scoped fixture; pytest picks it up from this namespace.
 from test.test_frontdoor import orchestrator_module  # noqa: F401  pylint: disable=unused-import
@@ -201,24 +204,34 @@ class FakeCollection(FakeQuery):
 
 
 class FakeBatch:
-  """WriteBatch fake: buffers set()/delete() ops, applies them on commit()."""
+  """Buffers create/set/delete writes and commits them atomically."""
 
-  def __init__(self):
+  def __init__(self, db):
+    self._db = db
     self._ops = []
 
   def set(self, ref, data):
     self._ops.append(('set', ref, data))
 
+  def create(self, ref, data):
+    self._ops.append(('create', ref, data))
+
   def delete(self, ref):
     self._ops.append(('delete', ref, None))
 
   def commit(self):
-    for op, ref, data in self._ops:
-      if op == 'set':
-        ref.set(data)
-      else:
-        ref.delete()
-    self._ops.clear()
+    if self._db.commit_barrier is not None:
+      self._db.commit_barrier.wait(timeout=5)
+    with self._db.lock:
+      for op, ref, _ in self._ops:
+        if op == 'create' and ref.id in ref._collection.docs:
+          raise google_exceptions.AlreadyExists('document already exists')
+      for op, ref, data in self._ops:
+        if op in ('create', 'set'):
+          ref.set(data)
+        else:
+          ref.delete()
+      self._ops.clear()
 
 
 class FakeUiDb:
@@ -226,12 +239,14 @@ class FakeUiDb:
 
   def __init__(self):
     self._collections = {}
+    self.lock = threading.Lock()
+    self.commit_barrier = None
 
   def collection(self, name):
     return self._collections.setdefault(name, FakeCollection())
 
   def batch(self):
-    return FakeBatch()
+    return FakeBatch(self)
 
 
 # ---------------------------------------------------------------------------
@@ -784,6 +799,77 @@ def _scenes_docs(fake_db, project_id):
   return (
       fake_db.collection('projects').document(project_id).collection('scenes').docs
   )
+
+
+def test_concurrent_project_posts_are_atomically_create_only(
+    monkeypatch, orchestrator_module
+):
+  del orchestrator_module
+  orch, fake_db, _ = _load_app(
+      monkeypatch, AUTH_MODE='iap', IAP_AUDIENCE=_IAP_AUDIENCE
+  )
+  _stub_identity(
+      monkeypatch,
+      orch,
+      {'t-u1': {'email': 'u1@x'}, 't-u2': {'email': 'u2@x'}},
+  )
+  fake_db.commit_barrier = threading.Barrier(2)
+  project_id = str(uuid.uuid4())
+  submissions = {
+      'first': {
+          'assertion': 't-u1',
+          'owner': 'u1@x',
+          'payload': {
+              'id': project_id,
+              'name': 'First',
+              'storyboard': [
+                  {'description': 'first-0'},
+                  {'description': 'first-1'},
+              ],
+          },
+      },
+      'second': {
+          'assertion': 't-u2',
+          'owner': 'u2@x',
+          'payload': {
+              'id': project_id,
+              'name': 'Second',
+              'storyboard': [{'description': 'second-0'}],
+          },
+      },
+  }
+  statuses = {}
+
+  def post_project(label):
+    submission = submissions[label]
+    with orch.app.test_client() as client:
+      response = client.post(
+          '/api/projects',
+          json=submission['payload'],
+          headers=_iap(submission['assertion']),
+      )
+    statuses[label] = response.status_code
+
+  threads = [
+      threading.Thread(target=post_project, args=(label,))
+      for label in submissions
+  ]
+  for thread in threads:
+    thread.start()
+  for thread in threads:
+    thread.join(timeout=10)
+  assert not any(thread.is_alive() for thread in threads)
+
+  assert sorted(statuses.values()) == [200, 409]
+  winner = next(label for label, status in statuses.items() if status == 200)
+  expected = submissions[winner]
+  stored = fake_db.collection('projects').docs[project_id]
+  assert stored['name'] == expected['payload']['name']
+  assert stored['createdBy'] == expected['owner']
+  stored_scenes = [
+      scene for _, scene in sorted(_scenes_docs(fake_db, project_id).items())
+  ]
+  assert stored_scenes == expected['payload']['storyboard']
 
 
 def test_project_storyboard_split_into_scenes_subcollection(


### PR DESCRIPTION
## Summary

Enforce the project POST create-only contract with Firestore's atomic
not-exists precondition.

## Behavior

- Concurrent creates for the same project ID produce one success and one 409.
- The losing request cannot replace project data or `createdBy`.
- PATCH keeps its existing update behavior.

## Tests

Covers two overlapping same-ID creates, verifies the winning root and scene
documents stay consistent, and exercises the existing project CRUD paths.

## Risks / Notes

Large project writes that span multiple Firestore batches retain their existing
partial-write risk if a later batch fails. Stacks on #148.
