### PR TITLE
Make Gemini 3.8 Flash the default text model and drop the Gemini 3 sampling knobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ gcloud auth application-default login   # 2. Application Default Credentials (AD
     :--------------------- | :--------------------------------------------------------- | :-------------------------
     `PROJECT`              | Your Google Cloud Platform Project ID.                     | Required
     `REGION`               | Deployment region for various GCP resources.               | e.g., `us-central1`
-    `GEMINI_MODEL`         | Text generation model for prompts and analysis.            | `gemini-3.5-flash`
+    `GEMINI_MODEL`         | Text generation model for prompts and analysis.            | `gemini-3.7-flash`
     `GEMINI_REGION`        | Region for model invocation.                               | Check locations availability. Recommended `global`.
     `VEO_MODEL`            | Video generation model.                                    | `veo-3.1-generate-001`
     `VEO_REGION`           | Region for Veo model invocation.                           | Check availability. Recommended `global`.

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ gcloud auth application-default login   # 2. Application Default Credentials (AD
     :--------------------- | :--------------------------------------------------------- | :-------------------------
     `PROJECT`              | Your Google Cloud Platform Project ID.                     | Required
     `REGION`               | Deployment region for various GCP resources.               | e.g., `us-central1`
-    `GEMINI_MODEL`         | Text generation model for prompts and analysis.            | `gemini-3.7-flash`
+    `GEMINI_MODEL`         | Text generation model for prompts and analysis.            | `gemini-3.8-flash`
     `GEMINI_REGION`        | Region for model invocation.                               | Check locations availability. Recommended `global`.
     `VEO_MODEL`            | Video generation model.                                    | `veo-3.1-generate-001`
     `VEO_REGION`           | Region for Veo model invocation.                           | Check availability. Recommended `global`.

--- a/actions/generate_storyboard.py
+++ b/actions/generate_storyboard.py
@@ -351,8 +351,6 @@ def execute(
       system_instruction=generate_system_prompt(
           len(products), len(images)
       ),
-      temperature=0.7,
-      top_p=0.2,
       response_schema=response_schema,
       response_mime_type=ContentType.JSON.value,
       safety_settings=[

--- a/actions/test/test_generate_storyboard.py
+++ b/actions/test/test_generate_storyboard.py
@@ -107,6 +107,37 @@ class TestGenerateStoryboard(unittest.TestCase):
       )
     self.assertIn("No storyboard found in the response.", str(cm.exception))
 
+  @patch("actions.generate_storyboard.genai.Client")
+  def test_execute_config_has_no_sampling_knobs(self, mock_genai_client_class):
+    mock_client = MagicMock()
+    mock_genai_client_class.return_value = mock_client
+
+    mock_response = MagicMock()
+    mock_client.models.generate_content.return_value = mock_response
+
+    mock_candidate = MagicMock()
+    mock_part = MagicMock()
+    mock_part.text = (
+      '{"storyboard": [{"image_id": "i1", "product_id": "p1",'
+      ' "scene_name": "Scene 1", "video_prompt": "Prompt 1'
+      ' list"}]}'
+    )
+    mock_candidate.content.parts = [mock_part]
+    mock_response.candidates = [mock_candidate]
+
+    generate_storyboard.execute(
+      self.mock_gcs,
+      self.mock_params,
+      self.mock_images,
+      self.mock_user_prompt,
+      self.gemini_model,
+      self.gemini_model_location,
+    )
+
+    _, kwargs = mock_client.models.generate_content.call_args
+    self.assertIsNone(kwargs["config"].temperature)
+    self.assertIsNone(kwargs["config"].top_p)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/actions_lib/gemini.py
+++ b/actions_lib/gemini.py
@@ -86,7 +86,7 @@ def prompt(
     file_uris: list[str] = None,
     need_to_remove_md_notation=True,
     location="us-central1",
-    model="gemini-3.5-flash",
+    model="gemini-3.7-flash",
     temperature: float = 0.2,
     top_p: float = 0.2,
     tracking_type: TrackingType | None = None,
@@ -103,7 +103,7 @@ def prompt(
       need_to_remove_md_notation: If True and response_schema is not provided,
         removes markdown code block notations (like ```json) from the output.
       location: The Vertex AI location to use (default: "us-central1").
-      model: The Gemini model to use (default: "gemini-3.5-flash").
+      model: The Gemini model to use (default: "gemini-3.7-flash").
       temperature: Sampling temperature to control creativity.
       top_p: Nucleus sampling probability.
 

--- a/actions_lib/gemini.py
+++ b/actions_lib/gemini.py
@@ -85,10 +85,8 @@ def prompt(
     ] = None,
     file_uris: list[str] = None,
     need_to_remove_md_notation=True,
-    location="us-central1",
-    model="gemini-3.7-flash",
-    temperature: float = 0.2,
-    top_p: float = 0.2,
+    location="global",
+    model="gemini-3.8-flash",
     tracking_type: TrackingType | None = None,
 ):
     """Prompts Gemini for a response.
@@ -102,10 +100,8 @@ def prompt(
         prompt.
       need_to_remove_md_notation: If True and response_schema is not provided,
         removes markdown code block notations (like ```json) from the output.
-      location: The Vertex AI location to use (default: "us-central1").
-      model: The Gemini model to use (default: "gemini-3.7-flash").
-      temperature: Sampling temperature to control creativity.
-      top_p: Nucleus sampling probability.
+      location: The Vertex AI location to use (default: "global").
+      model: The Gemini model to use (default: "gemini-3.8-flash").
 
     Returns:
       A dictionary containing the parsed JSON response if response_schema is
@@ -155,8 +151,6 @@ def prompt(
     ]
 
     generate_content_config = types.GenerateContentConfig(
-        temperature=temperature,
-        top_p=top_p,
         max_output_tokens=8192,
         response_modalities=[types.Modality.TEXT.value]
         if not response_schema

--- a/actions_lib/gemini.py
+++ b/actions_lib/gemini.py
@@ -85,8 +85,8 @@ def prompt(
     ] = None,
     file_uris: list[str] = None,
     need_to_remove_md_notation=True,
-    location="global",
-    model="gemini-3.8-flash",
+    location: str = "global",
+    model: str = "gemini-3.8-flash",
     tracking_type: TrackingType | None = None,
 ):
     """Prompts Gemini for a response.

--- a/actions_lib/test/test_gemini.py
+++ b/actions_lib/test/test_gemini.py
@@ -68,9 +68,12 @@ class TestGemini(unittest.TestCase):
         mock_client_class.assert_called_once_with(
             vertexai=True,
             project="test-proj",
-            location="us-central1",
+            location="global",
             http_options=mock.ANY,
         )
+
+        args, kwargs = mock_client.models.generate_content.call_args
+        self.assertEqual(kwargs["model"], "gemini-3.8-flash")
 
 
     @mock.patch("google.genai.Client")
@@ -153,6 +156,35 @@ class TestGemini(unittest.TestCase):
         self.assertEqual(
             kwargs["config"].thinking_config.thinking_budget, expected_budget
         )
+
+    @parameterized.expand([
+        ("gemini-3.8-flash",),
+        ("gemini-3.7-flash",),
+        ("gemini-3.1-pro-preview",),
+    ])
+    @mock.patch("google.genai.Client")
+    def test_prompt_gemini3_has_no_sampling_knobs(
+        self, model_name, mock_client_class
+    ):
+        """Gemini 3 models get no temperature or top_p in the config."""
+        mock_client = mock_client_class.return_value
+        mock_response = mock.Mock()
+        mock_candidate = mock.Mock()
+        mock_part = mock.Mock()
+        mock_part.text = "success"
+        mock_candidate.content.parts = [mock_part]
+        mock_response.candidates = [mock_candidate]
+        mock_client.models.generate_content.return_value = mock_response
+
+        gemini.prompt(
+            gcp_project="test-proj",
+            text_prompt="hi",
+            model=model_name,
+        )
+
+        _, kwargs = mock_client.models.generate_content.call_args
+        self.assertIsNone(kwargs["config"].temperature)
+        self.assertIsNone(kwargs["config"].top_p)
 
     @parameterized.expand([
         ("gemini-3.5-flash",),

--- a/actions_lib/test/test_gemini.py
+++ b/actions_lib/test/test_gemini.py
@@ -72,7 +72,7 @@ class TestGemini(unittest.TestCase):
             http_options=mock.ANY,
         )
 
-        args, kwargs = mock_client.models.generate_content.call_args
+        _, kwargs = mock_client.models.generate_content.call_args
         self.assertEqual(kwargs["model"], "gemini-3.8-flash")
 
 
@@ -100,7 +100,7 @@ class TestGemini(unittest.TestCase):
         self.assertEqual(output, {"result": "success"})
 
         mock_client.models.generate_content.assert_called_once()
-        args, kwargs = mock_client.models.generate_content.call_args
+        _, kwargs = mock_client.models.generate_content.call_args
 
         # Verify prompt text is passed correctly in the complex structure
         self.assertEqual(kwargs["contents"][0].parts[0].text, "get json")
@@ -152,7 +152,7 @@ class TestGemini(unittest.TestCase):
             model=model_name,
         )
 
-        args, kwargs = mock_client.models.generate_content.call_args
+        _, kwargs = mock_client.models.generate_content.call_args
         self.assertEqual(
             kwargs["config"].thinking_config.thinking_budget, expected_budget
         )

--- a/config.template.txt
+++ b/config.template.txt
@@ -15,8 +15,8 @@ export REGION=us-central1
 # Text model.
 # All available models can be found at:
 # https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/models#gemini-models
-# Recommended models: gemini-3.7-flash, gemini-3.1-pro-preview
-export GEMINI_MODEL=gemini-3.7-flash
+# Recommended models: gemini-3.8-flash, gemini-3.7-flash, gemini-3.1-pro-preview
+export GEMINI_MODEL=gemini-3.8-flash
 export GEMINI_REGION=global # choose from: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#google-models
 
 # Video generation model.

--- a/config.template.txt
+++ b/config.template.txt
@@ -15,8 +15,8 @@ export REGION=us-central1
 # Text model.
 # All available models can be found at:
 # https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/models#gemini-models
-# Recommended models: gemini-3.5-flash
-export GEMINI_MODEL=gemini-3.5-flash
+# Recommended models: gemini-3.7-flash, gemini-3.1-pro-preview
+export GEMINI_MODEL=gemini-3.7-flash
 export GEMINI_REGION=global # choose from: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#google-models
 
 # Video generation model.

--- a/test/test_model_allowlist.py
+++ b/test/test_model_allowlist.py
@@ -136,6 +136,14 @@ def test_is_pair_allowed_location_gated():
   assert not is_pair_allowed('generate_video', 'gemini-3-pro-image', 'global')
 
 
+def test_flash_models_allow_us_and_eu():
+  for mid in ('gemini-3.8-flash', 'gemini-3.7-flash'):
+    for loc in ('global', 'us', 'eu'):
+      assert is_pair_allowed('translate', mid, loc)
+    assert not is_pair_allowed('translate', mid, 'us-central1')
+  assert not is_pair_allowed('translate', 'gemini-3.1-pro-preview', 'us')
+
+
 # --- coverage: every literal (model, location) pair in workflow_examples ------
 
 def _example_pairs():

--- a/test/test_submission_validation.py
+++ b/test/test_submission_validation.py
@@ -82,6 +82,25 @@ def test_gemini_action_disallowed_location():
               ) == 'MODEL_LOCATION_PAIR_INVALID'
 
 
+@pytest.mark.parametrize(
+    ('action', 'location'),
+    (
+        ('translate', 'us'),
+        ('translate', 'eu'),
+        ('write_products_script', 'us'),
+        ('write_products_script', 'eu'),
+        ('generate_storyboard', 'us'),
+        ('generate_storyboard', 'eu'),
+    ),
+)
+def test_flash_text_actions_accept_us_and_eu(action, location):
+  # gemini-3.8-flash was widened to serve us and eu alongside global; every
+  # text action must accept the pair.
+  assert _code(_sub(action,
+                    {'gemini_model': 'gemini-3.8-flash',
+                     'gemini_model_location': location})) is None
+
+
 def test_image_action_disallowed_location():
   # Same for the image_model_location gate.
   assert _code(_sub('generate_image',

--- a/test/test_submission_validation.py
+++ b/test/test_submission_validation.py
@@ -83,21 +83,21 @@ def test_gemini_action_disallowed_location():
 
 
 @pytest.mark.parametrize(
-    ('action', 'location'),
+    ('model', 'action', 'location'),
     (
-        ('translate', 'us'),
-        ('translate', 'eu'),
-        ('write_products_script', 'us'),
-        ('write_products_script', 'eu'),
-        ('generate_storyboard', 'us'),
-        ('generate_storyboard', 'eu'),
+        (model, action, location)
+        for model in ('gemini-3.8-flash', 'gemini-3.7-flash')
+        for action in (
+            'translate', 'write_products_script', 'generate_storyboard'
+        )
+        for location in ('us', 'eu')
     ),
 )
-def test_flash_text_actions_accept_us_and_eu(action, location):
-  # gemini-3.8-flash was widened to serve us and eu alongside global; every
-  # text action must accept the pair.
+def test_flash_text_actions_accept_us_and_eu(model, action, location):
+  # Both Flash models serve us and eu alongside global; every text action must
+  # accept each model/location pair.
   assert _code(_sub(action,
-                    {'gemini_model': 'gemini-3.8-flash',
+                    {'gemini_model': model,
                      'gemini_model_location': location})) is None
 
 

--- a/test/test_validate_config_models.py
+++ b/test/test_validate_config_models.py
@@ -83,6 +83,16 @@ def test_model_set_without_region_flagged():
   assert any('region is required' in e for e in errors)
 
 
+def test_flash_model_allows_us_and_eu_region():
+  # gemini-3.8-flash was widened beyond global; the deploy-time check must
+  # accept the shipped allowlist's us and eu regions for it.
+  models = load_shipped_allowlist()['models']
+  for region in ('us', 'eu'):
+    assert validate_config_models.collect_errors(
+        {'GEMINI_MODEL': 'gemini-3.8-flash', 'GEMINI_REGION': region},
+        models) == []
+
+
 def test_config_template_defaults_pass_real_allowlist():
   # The actual config.template.txt defaults must validate against the shipped
   # allowlist -- parsed from the file, not hard-coded, so a drifted default

--- a/test/test_validate_config_models.py
+++ b/test/test_validate_config_models.py
@@ -17,6 +17,8 @@
 import os
 import re
 
+import pytest
+
 from scripts import validate_config_models
 from util.model_allowlist import load_shipped_allowlist
 
@@ -83,14 +85,14 @@ def test_model_set_without_region_flagged():
   assert any('region is required' in e for e in errors)
 
 
-def test_flash_model_allows_us_and_eu_region():
-  # gemini-3.8-flash was widened beyond global; the deploy-time check must
-  # accept the shipped allowlist's us and eu regions for it.
+@pytest.mark.parametrize('model', ('gemini-3.8-flash', 'gemini-3.7-flash'))
+@pytest.mark.parametrize('region', ('us', 'eu'))
+def test_flash_model_allows_us_and_eu_region(model, region):
+  # Both Flash models serve us and eu; the deploy-time check must accept the
+  # shipped allowlist's regions for each model.
   models = load_shipped_allowlist()['models']
-  for region in ('us', 'eu'):
-    assert validate_config_models.collect_errors(
-        {'GEMINI_MODEL': 'gemini-3.8-flash', 'GEMINI_REGION': region},
-        models) == []
+  assert validate_config_models.collect_errors(
+      {'GEMINI_MODEL': model, 'GEMINI_REGION': region}, models) == []
 
 
 def test_config_template_defaults_pass_real_allowlist():

--- a/ui/definitions/models.json
+++ b/ui/definitions/models.json
@@ -1,6 +1,6 @@
 {
   "defaults": {
-    "gemini": "gemini-3.7-flash",
+    "gemini": "gemini-3.8-flash",
     "image": "gemini-3-pro-image",
     "veo": "veo-3.1-generate-001"
   },
@@ -13,6 +13,12 @@
     "generate_video":        { "location_param": "gcp_location",          "default_key": "veoModel" }
   },
   "models": {
+    "gemini-3.8-flash": {
+      "family": "gemini",
+      "actions": ["translate", "write_products_script", "generate_storyboard"],
+      "locations": ["global"],
+      "capabilities": {}
+    },
     "gemini-3.7-flash": {
       "family": "gemini",
       "actions": ["translate", "write_products_script", "generate_storyboard"],

--- a/ui/definitions/models.json
+++ b/ui/definitions/models.json
@@ -1,6 +1,6 @@
 {
   "defaults": {
-    "gemini": "gemini-3.5-flash",
+    "gemini": "gemini-3.7-flash",
     "image": "gemini-3-pro-image",
     "veo": "veo-3.1-generate-001"
   },
@@ -13,6 +13,12 @@
     "generate_video":        { "location_param": "gcp_location",          "default_key": "veoModel" }
   },
   "models": {
+    "gemini-3.7-flash": {
+      "family": "gemini",
+      "actions": ["translate", "write_products_script", "generate_storyboard"],
+      "locations": ["global"],
+      "capabilities": {}
+    },
     "gemini-3.5-flash": {
       "family": "gemini",
       "actions": ["translate", "write_products_script", "generate_storyboard"],

--- a/ui/definitions/models.json
+++ b/ui/definitions/models.json
@@ -16,13 +16,13 @@
     "gemini-3.8-flash": {
       "family": "gemini",
       "actions": ["translate", "write_products_script", "generate_storyboard"],
-      "locations": ["global"],
+      "locations": ["global", "us", "eu"],
       "capabilities": {}
     },
     "gemini-3.7-flash": {
       "family": "gemini",
       "actions": ["translate", "write_products_script", "generate_storyboard"],
-      "locations": ["global"],
+      "locations": ["global", "us", "eu"],
       "capabilities": {}
     },
     "gemini-3.5-flash": {

--- a/workflow_examples/demo.json
+++ b/workflow_examples/demo.json
@@ -14,7 +14,7 @@
       "parameters": {
         "source_language": "en",
         "target_language": ["de", "es", "la", "it", "nl", "pt", "hu", "se"],
-        "gemini_model": "gemini-3.7-flash",
+        "gemini_model": "gemini-3.8-flash",
         "gemini_model_location": "global"
       },
       "input": {
@@ -29,7 +29,7 @@
       "parameters": {
         "source_language": "en",
         "target_language": ["cs", "es", "la", "it", "nl", "pt", "hu", "se"],
-        "gemini_model": "gemini-3.7-flash",
+        "gemini_model": "gemini-3.8-flash",
         "gemini_model_location": "global"
       },
       "input": {

--- a/workflow_examples/demo.json
+++ b/workflow_examples/demo.json
@@ -14,7 +14,7 @@
       "parameters": {
         "source_language": "en",
         "target_language": ["de", "es", "la", "it", "nl", "pt", "hu", "se"],
-        "gemini_model": "gemini-3.5-flash",
+        "gemini_model": "gemini-3.7-flash",
         "gemini_model_location": "global"
       },
       "input": {
@@ -29,7 +29,7 @@
       "parameters": {
         "source_language": "en",
         "target_language": ["cs", "es", "la", "it", "nl", "pt", "hu", "se"],
-        "gemini_model": "gemini-3.5-flash",
+        "gemini_model": "gemini-3.7-flash",
         "gemini_model_location": "global"
       },
       "input": {

--- a/workflow_examples/generate_storyboard.json
+++ b/workflow_examples/generate_storyboard.json
@@ -24,7 +24,7 @@
         }
       },
       "parameters": {
-        "gemini_model": "gemini-3.7-flash",
+        "gemini_model": "gemini-3.8-flash",
         "gemini_model_location": "global"
       },
       "dimensionsConsumed": [

--- a/workflow_examples/generate_storyboard.json
+++ b/workflow_examples/generate_storyboard.json
@@ -24,7 +24,7 @@
         }
       },
       "parameters": {
-        "gemini_model": "gemini-3.5-flash",
+        "gemini_model": "gemini-3.7-flash",
         "gemini_model_location": "global"
       },
       "dimensionsConsumed": [


### PR DESCRIPTION
## Summary

Gemini 3.8 Flash is GA and becomes the default text model for the storyboard, translation and product-script actions. Gemini 3.7 Flash and Gemini 3.1 Pro stay selectable in the catalog.

- `actions_lib/gemini.py`: `prompt()` no longer sends `temperature` or `top_p`. Google's Gemini 3 guides state the backend ignores these sampling parameters, so the storyboard's 0.7/0.2 overrides were dead weight; the model defaults are used. The location default is `global`, since no Gemini 3 model exists at `us-central1`.
- Catalog: `gemini-3.8-flash` (default), `gemini-3.7-flash` and `gemini-3.1-pro-preview`. The two Flash models list `global`, `us` and `eu`, matching the regions they serve; 3.1 Pro stays global-only. `scripts/validate_config_models.py` therefore accepts `GEMINI_REGION=us` and `eu`.
- `config.template.txt`, README and the workflow examples point at the new default. Existing deployments keep whatever `GEMINI_MODEL` they configured.

## Testing

- Unit: the serialized generation config carries no sampling keys for all three Gemini 3 models, the storyboard config likewise; model/location pair tests; a full submission for each text action at `us` and at `eu`; the deploy-time config check. Python suite on this branch: 460 tests.
- Live: all three text actions ran against `gemini-3.8-flash` at `global` with the real response schemas; the Flash models were confirmed to answer at `us` and `eu` and to return 404 at `us-central1`.

This change is independent of the Omni video PRs.


## Review follow-up (2026-09-07)

Addressed all four review comments in `4d03491`: typed defaults, unused unpacking cleanup, and both Flash models covered across text actions and deploy regions. Verification on this head: **150 focused tests, 469 full backend tests, action-signature check and diff whitespace check passed**. No new live/billable calls in this follow-up. Fresh CI and reviewer approval remain the merge gates.
