### PR TITLE
Download original candidates from Storyboard

### DIFF
--- a/ui/src/app/storyboard/storyboard-download.spec.ts
+++ b/ui/src/app/storyboard/storyboard-download.spec.ts
@@ -1,0 +1,372 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {provideHttpClient} from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import {signal} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {NavigationStart, Router} from '@angular/router';
+import {Subject} from 'rxjs';
+import {beforeEach, afterEach, describe, expect, it, vi} from 'vitest';
+import {
+  Candidate,
+  ConfigService,
+  GeneratedScene,
+  ProjectConfig,
+} from '../services/config/config';
+import {RemixEngineService} from '../services/remix-engine/remix-engine';
+import {Storyboard} from './storyboard';
+
+describe('Storyboard original download', () => {
+  let component: Storyboard;
+  let fixture: ComponentFixture<Storyboard>;
+  let http: HttpTestingController;
+  let routerEvents: Subject<unknown>;
+  let projectConfig: ReturnType<typeof signal<ProjectConfig>>;
+  let snackBar: {open: ReturnType<typeof vi.fn>};
+  let createObjectUrl: ReturnType<typeof vi.spyOn>;
+  let revokeObjectUrl: ReturnType<typeof vi.spyOn>;
+  let createElement: ReturnType<typeof vi.spyOn>;
+  let anchor: HTMLAnchorElement;
+
+  const candidate = (path: string, runNumber = 1, url = ''): Candidate => ({
+    runNumber,
+    durationSeconds: 4,
+    model: 'veo-1',
+    prompt: 'prompt',
+    generateAudio: false,
+    resolution: '1080p',
+    video: {path, url},
+  });
+
+  function sceneWithCandidates(
+    candidates: Candidate[],
+    selectedCandidateIndex = 0,
+  ): GeneratedScene {
+    return {
+      id: 'scene-1',
+      type: 'generated',
+      name: 'Scene / One',
+      prompt: 'prompt',
+      selectedCandidateIndex,
+      candidates,
+    };
+  }
+
+  function setProject(storyboard: GeneratedScene[], id = 'project-1') {
+    projectConfig.set({
+      id,
+      name: 'Project / One',
+      storyboard,
+      aspectRatio: '16:9',
+      resolution: '1080p',
+      candidateDurationSeconds: 4,
+      generateAudio: false,
+      numberOfCandidates: 1,
+      model: 'veo-1',
+      inputConfig: {products: [], composition: ''},
+      audioTracks: [],
+      visualOverlays: [],
+    });
+    fixture.detectChanges();
+  }
+
+  async function flushMicrotasks() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await Promise.resolve();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await Promise.resolve();
+  }
+
+  beforeEach(async () => {
+    projectConfig = signal<ProjectConfig>({
+      id: 'project-1',
+      name: 'Project / One',
+      storyboard: [],
+      aspectRatio: '16:9',
+      resolution: '1080p',
+      candidateDurationSeconds: 4,
+      generateAudio: false,
+      numberOfCandidates: 1,
+      model: 'veo-1',
+      inputConfig: {products: [], composition: ''},
+      audioTracks: [],
+      visualOverlays: [],
+    });
+    routerEvents = new Subject<unknown>();
+    snackBar = {open: vi.fn()};
+    const config = {
+      projectConfig: {
+        value: projectConfig,
+        isLoading: () => false,
+        error: () => null,
+      },
+      globalConfig: {
+        value: () => ({
+          duration: 5,
+          veoModel: 'veo-model',
+          numberOfCandidates: 1,
+          generateAudio: false,
+        }),
+      },
+      updateProjectConfig: (partial: Partial<ProjectConfig>) =>
+        projectConfig.update(p => ({...p, ...partial})),
+      videoModels: () => [],
+      canEditCandidates: signal(false),
+      audioLocked: () => false,
+      durationSlider: signal({min: 4, max: 8, step: 2}),
+      selectVideoModel: vi.fn(),
+      sceneIdCounter: signal(0),
+      primaryColor: signal('theme-green'),
+      isGeneratedScene: (scene: unknown): scene is GeneratedScene =>
+        (scene as GeneratedScene)?.type === 'generated',
+      isProvidedVideoScene: () => false,
+    };
+    await TestBed.configureTestingModule({
+      imports: [Storyboard],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {provide: ConfigService, useValue: config},
+        {
+          provide: RemixEngineService,
+          useValue: {generatingSceneIds: signal(new Set())},
+        },
+        {provide: MatSnackBar, useValue: snackBar},
+        {provide: Router, useValue: {events: routerEvents}},
+      ],
+    })
+      .overrideComponent(Storyboard, {
+        set: {
+          template: '<button (click)="downloadOriginal()">Download</button>',
+          providers: [{provide: MatSnackBar, useValue: snackBar}],
+        },
+      })
+      .compileComponents();
+    fixture = TestBed.createComponent(Storyboard);
+    component = fixture.componentInstance;
+    http = TestBed.inject(HttpTestingController);
+    setProject([sceneWithCandidates([candidate('videos/original.webm')])]);
+    createObjectUrl = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:test');
+    revokeObjectUrl = vi
+      .spyOn(URL, 'revokeObjectURL')
+      .mockImplementation(() => {});
+    const nativeCreateElement = document.createElement.bind(document);
+    anchor = nativeCreateElement('a');
+    createElement = vi
+      .spyOn(document, 'createElement')
+      .mockImplementation(tag =>
+        tag === 'a' ? anchor : nativeCreateElement(tag),
+      );
+    vi.spyOn(anchor, 'click').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    http.verify({ignoreCancelled: true});
+    createObjectUrl.mockRestore();
+    revokeObjectUrl.mockRestore();
+    createElement.mockRestore();
+    fixture.destroy();
+    TestBed.resetTestingModule();
+  });
+
+  function sign(path: string, url = 'https://signed.test/video') {
+    const request = http.expectOne(
+      `/api/signUrl?path=${encodeURIComponent(path)}`,
+    );
+    request.flush({
+      urls: {[path]: url},
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    });
+  }
+
+  function blob(url = 'https://signed.test/video', type = 'video/webm') {
+    const request = http.expectOne(url);
+    request.flush(new Blob(['video'], {type}));
+  }
+
+  it('signs then fetches the original and downloads the captured filename', async () => {
+    fixture.nativeElement.querySelector('button').click();
+    sign('videos/original.webm');
+    await flushMicrotasks();
+    blob();
+    await flushMicrotasks();
+    expect(createObjectUrl).toHaveBeenCalledWith(expect.any(Blob));
+    expect(anchor.download).toBe('Project_One_Scene_One_1A_original.webm');
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:test');
+  });
+
+  it('shows an error for signing failure and retries successfully', async () => {
+    component.downloadOriginal();
+    http
+      .expectOne('/api/signUrl?path=videos%2Foriginal.webm')
+      .flush(null, {status: 500, statusText: 'Server Error'});
+    await flushMicrotasks();
+    await vi.waitFor(() =>
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'Failed to download original video.',
+        'Dismiss',
+      ),
+    );
+    component.downloadOriginal();
+    sign('videos/original.webm');
+    await flushMicrotasks();
+    blob();
+    await flushMicrotasks();
+    expect(createObjectUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an error for blob failure and retries using the signed URL', async () => {
+    component.downloadOriginal();
+    sign('videos/original.webm');
+    await flushMicrotasks();
+    http
+      .expectOne('https://signed.test/video')
+      .error(new ProgressEvent('error'), {
+        status: 502,
+        statusText: 'Bad Gateway',
+      });
+    await flushMicrotasks();
+    await vi.waitFor(() =>
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'Failed to download original video.',
+        'Dismiss',
+      ),
+    );
+    expect(component.downloadInProgress()).toBe(false);
+    component.downloadOriginal();
+    await flushMicrotasks();
+    blob();
+    await flushMicrotasks();
+    expect(createObjectUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores duplicate clicks while a download is in progress', async () => {
+    component.downloadOriginal();
+    await Promise.resolve();
+    component.downloadOriginal();
+    const requests = http.match(request =>
+      request.url.includes('/api/signUrl'),
+    );
+    expect(requests).toHaveLength(1);
+    requests[0].flush({
+      urls: {'videos/original.webm': 'https://signed.test/video'},
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    });
+    await flushMicrotasks();
+    blob();
+    await flushMicrotasks();
+  });
+
+  it('keeps the captured candidate path and extension when selection changes', async () => {
+    const scene = sceneWithCandidates([
+      candidate('videos/first.webm'),
+      candidate('videos/second.mp4', 2),
+    ]);
+    setProject([scene]);
+    component.downloadOriginal();
+    component.selectCandidate(scene, 1);
+    sign('videos/first.webm');
+    await flushMicrotasks();
+    blob();
+    await flushMicrotasks();
+    expect(anchor.download).toContain('1A_original.webm');
+  });
+
+  it('ignores URL queries for extensions and falls back to bin for unknown MIME', async () => {
+    const scene = sceneWithCandidates([
+      candidate('videos/original?token=1.mp4'),
+    ]);
+    setProject([scene]);
+    component.downloadOriginal();
+    sign('videos/original?token=1.mp4');
+    await flushMicrotasks();
+    blob('https://signed.test/video', 'video/x-custom');
+    await flushMicrotasks();
+    expect(anchor.download).toContain('_original.bin');
+  });
+
+  it('uses a pathless legacy URL without its query string for the filename', async () => {
+    const scene = sceneWithCandidates([
+      candidate('', 1, 'https://legacy.test/original.mp4?token=abc'),
+    ]);
+    setProject([scene]);
+    component.downloadOriginal();
+    await flushMicrotasks();
+    blob('https://legacy.test/original.mp4?token=abc', 'video/mp4');
+    await flushMicrotasks();
+    expect(anchor.download).toContain('_original.mp4');
+  });
+
+  it('keeps the captured names while an extensionless download is pending', async () => {
+    const scene = sceneWithCandidates([candidate('videos/original')]);
+    setProject([scene]);
+    component.downloadOriginal();
+    sign('videos/original');
+    await flushMicrotasks();
+    // Existing two-way-bound controls can mutate these objects before saving.
+    projectConfig().name = 'Changed Project';
+    component.selectedScene()!.name = 'Changed Scene';
+    const expectedBlob = new Blob(['video'], {type: 'video/mp4'});
+    http.expectOne('https://signed.test/video').flush(expectedBlob);
+    await flushMicrotasks();
+    expect(anchor.download).toBe('Project_One_Scene_One_1A_original.mp4');
+    expect(createObjectUrl).toHaveBeenCalledWith(expectedBlob);
+  });
+
+  it('suppresses a stale A download across NavigationStart A-B-A and permits the new one', async () => {
+    component.downloadOriginal();
+    routerEvents.next(new NavigationStart(1, '/b'));
+    routerEvents.next(new NavigationStart(2, '/a'));
+    component.downloadOriginal();
+    sign('videos/original.webm');
+    await flushMicrotasks();
+    blob();
+    await flushMicrotasks();
+    expect(createObjectUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the blob request on navigation without showing an error', async () => {
+    component.downloadOriginal();
+    sign('videos/original.webm');
+    await flushMicrotasks();
+    const request = http.expectOne('https://signed.test/video');
+    routerEvents.next(new NavigationStart(1, '/other'));
+    await flushMicrotasks();
+    expect(request.cancelled).toBe(true);
+    expect(snackBar.open).not.toHaveBeenCalled();
+  });
+
+  it('cancels the blob request on destroy without showing an error', async () => {
+    component.downloadOriginal();
+    sign('videos/original.webm');
+    await flushMicrotasks();
+    const request = http.expectOne('https://signed.test/video');
+    fixture.destroy();
+    await flushMicrotasks();
+    expect(request.cancelled).toBe(true);
+    expect(snackBar.open).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/storyboard/storyboard.html
+++ b/ui/src/app/storyboard/storyboard.html
@@ -511,7 +511,7 @@
 
                     <div class="video-overlay" (click)="toggleVideoPlay()">
                       <div class="video-controls" (click)="$event.stopPropagation()">
-                        <div class="controls-row">
+                        <div class="controls-row generated-controls-row">
                           <button mat-icon-button (click)="toggleVideoPlay()">
                             <mat-icon>{{ isVideoPlaying() ? 'pause' : 'play_arrow' }}</mat-icon>
                           </button>
@@ -585,6 +585,19 @@
                               </mat-slider>
                             </div>
                           </div>
+                          <button
+                            type="button"
+                            mat-icon-button
+                            aria-label="Download original"
+                            matTooltip="Download original"
+                            [disabled]="
+                              downloadInProgress() ||
+                              (!candidate.video?.path && !candidate.video?.url)
+                            "
+                            (click)="$event.stopPropagation(); downloadOriginal()"
+                          >
+                            <mat-icon>download</mat-icon>
+                          </button>
                         </div>
                       </div>
                     </div>

--- a/ui/src/app/storyboard/storyboard.scss
+++ b/ui/src/app/storyboard/storyboard.scss
@@ -1016,10 +1016,8 @@
               }
 
               &.generated-controls-row {
-                flex-wrap: wrap;
-
                 .timeline-container {
-                  flex: 1 1 80px;
+                  flex: 1 1 40px;
                   min-width: 0;
                 }
               }

--- a/ui/src/app/storyboard/storyboard.scss
+++ b/ui/src/app/storyboard/storyboard.scss
@@ -1014,6 +1014,15 @@
                   pointer-events: auto;
                 }
               }
+
+              &.generated-controls-row {
+                flex-wrap: wrap;
+
+                .timeline-container {
+                  flex: 1 1 80px;
+                  min-width: 0;
+                }
+              }
             }
 
             mat-icon {

--- a/ui/src/app/storyboard/storyboard.scss
+++ b/ui/src/app/storyboard/storyboard.scss
@@ -898,6 +898,7 @@
         border-radius: 8px;
         width: 100%;
         height: 100%;
+        container-type: inline-size;
         position: relative;
         display: flex;
         align-items: center;
@@ -1016,9 +1017,41 @@
               }
 
               &.generated-controls-row {
+                position: relative;
+
                 .timeline-container {
                   flex: 1 1 40px;
                   min-width: 0;
+                }
+
+                .volume-controls {
+                  position: static;
+
+                  .slider-popup {
+                    right: 4px;
+                    width: min(140px, calc(100% - 8px));
+                    box-sizing: border-box;
+                    padding: 0 8px;
+                  }
+                }
+              }
+            }
+
+            @container (max-width: 320px) {
+              .generated-controls-row {
+                gap: 4px;
+
+                .time-group {
+                  display: none;
+                }
+
+                .timeline-container {
+                  flex: 1 1 0;
+                  min-width: 0;
+                }
+
+                .volume-controls .slider-popup {
+                  width: min(140px, calc(100cqw - 8px));
                 }
               }
             }

--- a/ui/src/app/storyboard/storyboard.scss
+++ b/ui/src/app/storyboard/storyboard.scss
@@ -1039,14 +1039,32 @@
 
             @container (max-width: 320px) {
               .generated-controls-row {
+                display: grid;
+                grid-template-columns: 40px minmax(0, 1fr) 40px 40px;
                 gap: 4px;
+
+                > button:first-child {
+                  grid-column: 1;
+                  grid-row: 2;
+                }
+
+                > .volume-controls {
+                  grid-column: 3;
+                  grid-row: 2;
+                }
+
+                > button:last-child {
+                  grid-column: 4;
+                  grid-row: 2;
+                }
 
                 .time-group {
                   display: none;
                 }
 
                 .timeline-container {
-                  flex: 1 1 0;
+                  grid-column: 1 / -1;
+                  grid-row: 1;
                   min-width: 0;
                 }
 

--- a/ui/src/app/storyboard/storyboard.spec.ts
+++ b/ui/src/app/storyboard/storyboard.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import {CdkDragDrop} from '@angular/cdk/drag-drop';
+import {HttpClient} from '@angular/common/http';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {signal} from '@angular/core';
@@ -23,6 +24,7 @@ import {MatDialog} from '@angular/material/dialog';
 import {MatSelectHarness} from '@angular/material/select/testing';
 import {MatSlideToggle} from '@angular/material/slide-toggle';
 import {MatSlider} from '@angular/material/slider';
+import {provideRouter} from '@angular/router';
 import {By} from '@angular/platform-browser';
 import {of} from 'rxjs';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
@@ -35,6 +37,7 @@ import {
   resolveSceneRenderClip,
 } from '../services/config/config';
 import {RemixEngineService} from '../services/remix-engine/remix-engine';
+import {MediaService} from '../services/media/media';
 import {EditCandidateDialog} from './edit-candidate-dialog';
 import {Storyboard} from './storyboard';
 
@@ -57,6 +60,7 @@ describe('Storyboard', () => {
     audioTracks: [],
     visualOverlays: [],
   });
+
   const canEditCandidatesSignal = signal(false);
   const durationSliderSignal = signal({min: 4, max: 8, step: 2});
   let mockConfigService = {
@@ -100,6 +104,11 @@ describe('Storyboard', () => {
       afterClosed: () => of({type: 'generate'}),
     }),
   };
+  const mockMediaService = {
+    resolve: vi.fn().mockResolvedValue(''),
+    getCachedUrl: vi.fn().mockReturnValue(undefined),
+  };
+  const mockHttpClient = {get: vi.fn()};
 
   beforeEach(async () => {
     sceneIdCounterSignal.set(0);
@@ -148,12 +157,20 @@ describe('Storyboard', () => {
         afterClosed: () => of({type: 'generate'}),
       }),
     };
+    mockMediaService.resolve.mockReset();
+    mockMediaService.resolve.mockResolvedValue('');
+    mockMediaService.getCachedUrl.mockReset();
+    mockMediaService.getCachedUrl.mockReturnValue(undefined);
+    mockHttpClient.get.mockReset();
 
     await TestBed.configureTestingModule({
       imports: [Storyboard],
       providers: [
         {provide: ConfigService, useValue: mockConfigService},
         {provide: RemixEngineService, useValue: mockRemixEngineService},
+        {provide: MediaService, useValue: mockMediaService},
+        {provide: HttpClient, useValue: mockHttpClient},
+        provideRouter([]),
       ],
     })
       .overrideComponent(Storyboard, {
@@ -997,5 +1014,140 @@ describe('Storyboard', () => {
         expect(mockRemixEngineService.editCandidate).not.toHaveBeenCalled();
       });
     }
+  });
+  it('downloads the selected candidate original through the media boundary', async () => {
+    const candidate: Candidate = {
+      runNumber: 2,
+      durationSeconds: 4,
+      model: 'veo-1',
+      prompt: 'test prompt',
+      generateAudio: false,
+      resolution: '1080p',
+      video: {path: 'video/original.mp4', url: 'https://video/original.mp4'},
+    };
+    const scene: GeneratedScene = {
+      id: 'download-scene',
+      type: 'generated',
+      name: 'Scene / One',
+      prompt: 'test',
+      selectedCandidateIndex: 0,
+      candidates: [candidate],
+    };
+    projectConfigSignal.update(config => ({...config, storyboard: [scene]}));
+    component.selectScene(scene.id);
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector(
+      '[aria-label="Download original"]',
+    ) as HTMLButtonElement;
+    expect(button).toBeTruthy();
+    const objectUrl = 'blob:original';
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue(objectUrl);
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    mockMediaService.resolve.mockResolvedValue('https://signed/original.mp4');
+    mockHttpClient.get.mockReturnValue(
+      of(new Blob(['video'], {type: 'video/mp4'})),
+    );
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+
+    button.click();
+    await fixture.whenStable();
+
+    expect(mockMediaService.resolve).toHaveBeenCalledWith(candidate.video);
+    expect(mockHttpClient.get).toHaveBeenCalledWith(
+      'https://signed/original.mp4',
+      {
+        responseType: 'blob',
+      },
+    );
+    expect(click).toHaveBeenCalled();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(objectUrl);
+  });
+
+  it('disables original download when the selected candidate has no media', () => {
+    const scene: GeneratedScene = {
+      id: 'missing-media-scene',
+      type: 'generated',
+      name: 'Scene',
+      prompt: 'test',
+      selectedCandidateIndex: 0,
+      candidates: [
+        {
+          runNumber: 1,
+          durationSeconds: 4,
+          model: 'veo-1',
+          prompt: 'test',
+          generateAudio: true,
+          resolution: '1080p',
+        },
+      ],
+    };
+    projectConfigSignal.update(config => ({...config, storyboard: [scene]}));
+    component.selectScene(scene.id);
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector(
+      '[aria-label="Download original"]',
+    ) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(mockMediaService.resolve).not.toHaveBeenCalled();
+  });
+
+  it('keeps the click-time candidate and filename while media resolution is pending', async () => {
+    let resolveMedia!: (url: string) => void;
+    mockMediaService.resolve.mockImplementation(
+      () => new Promise<string>(resolve => (resolveMedia = resolve)),
+    );
+    mockHttpClient.get.mockReturnValue(
+      of(new Blob(['video'], {type: 'video/mp4'})),
+    );
+    const candidate: Candidate = {
+      runNumber: 1,
+      durationSeconds: 4,
+      model: 'veo-1',
+      prompt: 'original',
+      generateAudio: true,
+      resolution: '1080p',
+      video: {path: 'video/original.mp4', url: 'https://video/original.mp4'},
+    };
+    const scene: GeneratedScene = {
+      id: 'snapshot-scene',
+      type: 'generated',
+      name: 'Original Scene',
+      prompt: 'test',
+      selectedCandidateIndex: 0,
+      candidates: [candidate],
+    };
+    projectConfigSignal.update(config => ({...config, storyboard: [scene]}));
+    component.selectScene(scene.id);
+    fixture.detectChanges();
+    const button = fixture.nativeElement.querySelector(
+      '[aria-label="Download original"]',
+    ) as HTMLButtonElement;
+    const anchor = document.createElement('a');
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:snapshot');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    vi.spyOn(anchor, 'click').mockImplementation(() => undefined);
+
+    const resolveCallsBeforeDownload =
+      mockMediaService.resolve.mock.calls.length;
+    button.click();
+    button.click();
+    expect(mockMediaService.resolve).toHaveBeenCalledTimes(
+      resolveCallsBeforeDownload + 1,
+    );
+    candidate.video = {
+      path: 'video/renamed.webm',
+      url: 'https://video/renamed.webm',
+    };
+    projectConfigSignal.update(config => ({...config, name: 'Renamed'}));
+    resolveMedia('https://signed/original.mp4');
+    await fixture.whenStable();
+
+    expect(anchor.download).toBe('Test_Project_Original_Scene_1A_original.mp4');
   });
 });

--- a/ui/src/app/storyboard/storyboard.spec.ts
+++ b/ui/src/app/storyboard/storyboard.spec.ts
@@ -1015,139 +1015,166 @@ describe('Storyboard', () => {
       });
     }
   });
-  it('downloads the selected candidate original through the media boundary', async () => {
-    const candidate: Candidate = {
-      runNumber: 2,
-      durationSeconds: 4,
-      model: 'veo-1',
-      prompt: 'test prompt',
-      generateAudio: false,
-      resolution: '1080p',
-      video: {path: 'video/original.mp4', url: 'https://video/original.mp4'},
-    };
-    const scene: GeneratedScene = {
-      id: 'download-scene',
-      type: 'generated',
-      name: 'Scene / One',
-      prompt: 'test',
-      selectedCandidateIndex: 0,
-      candidates: [candidate],
-    };
-    projectConfigSignal.update(config => ({...config, storyboard: [scene]}));
-    component.selectScene(scene.id);
-    fixture.detectChanges();
+  describe('original candidate download', () => {
+    let anchor: HTMLAnchorElement;
+    let nativeCreateElement: typeof document.createElement;
+    let createElementSpy: ReturnType<typeof vi.spyOn>;
+    let createObjectUrlSpy: ReturnType<typeof vi.spyOn>;
+    let revokeObjectUrlSpy: ReturnType<typeof vi.spyOn>;
+    let clickSpy: ReturnType<typeof vi.spyOn>;
 
-    const button = fixture.nativeElement.querySelector(
-      '[aria-label="Download original"]',
-    ) as HTMLButtonElement;
-    expect(button).toBeTruthy();
-    const objectUrl = 'blob:original';
-    vi.spyOn(URL, 'createObjectURL').mockReturnValue(objectUrl);
-    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
-    mockMediaService.resolve.mockResolvedValue('https://signed/original.mp4');
-    mockHttpClient.get.mockReturnValue(
-      of(new Blob(['video'], {type: 'video/mp4'})),
-    );
-    const click = vi
-      .spyOn(HTMLAnchorElement.prototype, 'click')
-      .mockImplementation(() => undefined);
+    beforeEach(() => {
+      nativeCreateElement = document.createElement.bind(document);
+      anchor = nativeCreateElement('a');
+      createElementSpy = vi
+        .spyOn(document, 'createElement')
+        .mockImplementation(tag =>
+          tag === 'a' ? anchor : nativeCreateElement(tag),
+        );
+      createObjectUrlSpy = vi
+        .spyOn(URL, 'createObjectURL')
+        .mockReturnValue('blob:original');
+      revokeObjectUrlSpy = vi
+        .spyOn(URL, 'revokeObjectURL')
+        .mockImplementation(() => undefined);
+      clickSpy = vi
+        .spyOn(HTMLAnchorElement.prototype, 'click')
+        .mockImplementation(() => undefined);
+    });
 
-    button.click();
-    await fixture.whenStable();
+    afterEach(() => {
+      createElementSpy.mockRestore();
+      createObjectUrlSpy.mockRestore();
+      revokeObjectUrlSpy.mockRestore();
+      clickSpy.mockRestore();
+    });
 
-    expect(mockMediaService.resolve).toHaveBeenCalledWith(candidate.video);
-    expect(mockHttpClient.get).toHaveBeenCalledWith(
-      'https://signed/original.mp4',
-      {
-        responseType: 'blob',
-      },
-    );
-    expect(click).toHaveBeenCalled();
-    await new Promise(resolve => setTimeout(resolve, 0));
-    expect(URL.revokeObjectURL).toHaveBeenCalledWith(objectUrl);
-  });
+    it('downloads the selected candidate original through the media boundary', async () => {
+      const candidate: Candidate = {
+        runNumber: 2,
+        durationSeconds: 4,
+        model: 'veo-1',
+        prompt: 'test prompt',
+        generateAudio: false,
+        resolution: '1080p',
+        video: {path: 'video/original.mp4', url: 'https://video/original.mp4'},
+      };
+      const scene: GeneratedScene = {
+        id: 'download-scene',
+        type: 'generated',
+        name: 'Scene / One',
+        prompt: 'test',
+        selectedCandidateIndex: 0,
+        candidates: [candidate],
+      };
+      projectConfigSignal.update(config => ({...config, storyboard: [scene]}));
+      component.selectScene(scene.id);
+      fixture.detectChanges();
 
-  it('disables original download when the selected candidate has no media', () => {
-    const scene: GeneratedScene = {
-      id: 'missing-media-scene',
-      type: 'generated',
-      name: 'Scene',
-      prompt: 'test',
-      selectedCandidateIndex: 0,
-      candidates: [
+      const button = fixture.nativeElement.querySelector(
+        '[aria-label="Download original"]',
+      ) as HTMLButtonElement;
+      expect(button).toBeTruthy();
+      mockMediaService.resolve.mockResolvedValue('https://signed/original.mp4');
+      mockHttpClient.get.mockReturnValue(
+        of(new Blob(['video'], {type: 'video/mp4'})),
+      );
+      button.click();
+      await fixture.whenStable();
+
+      expect(mockMediaService.resolve).toHaveBeenCalledWith(candidate.video);
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'https://signed/original.mp4',
         {
-          runNumber: 1,
-          durationSeconds: 4,
-          model: 'veo-1',
-          prompt: 'test',
-          generateAudio: true,
-          resolution: '1080p',
+          responseType: 'blob',
         },
-      ],
-    };
-    projectConfigSignal.update(config => ({...config, storyboard: [scene]}));
-    component.selectScene(scene.id);
-    fixture.detectChanges();
+      );
+      expect(clickSpy).toHaveBeenCalled();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:original');
+    });
 
-    const button = fixture.nativeElement.querySelector(
-      '[aria-label="Download original"]',
-    ) as HTMLButtonElement;
-    expect(button.disabled).toBe(true);
-    expect(mockMediaService.resolve).not.toHaveBeenCalled();
-  });
+    it('disables original download when the selected candidate has no media', () => {
+      const scene: GeneratedScene = {
+        id: 'missing-media-scene',
+        type: 'generated',
+        name: 'Scene',
+        prompt: 'test',
+        selectedCandidateIndex: 0,
+        candidates: [
+          {
+            runNumber: 1,
+            durationSeconds: 4,
+            model: 'veo-1',
+            prompt: 'test',
+            generateAudio: true,
+            resolution: '1080p',
+          },
+        ],
+      };
+      projectConfigSignal.update(config => ({...config, storyboard: [scene]}));
+      component.selectScene(scene.id);
+      fixture.detectChanges();
 
-  it('keeps the click-time candidate and filename while media resolution is pending', async () => {
-    let resolveMedia!: (url: string) => void;
-    mockMediaService.resolve.mockImplementation(
-      () => new Promise<string>(resolve => (resolveMedia = resolve)),
-    );
-    mockHttpClient.get.mockReturnValue(
-      of(new Blob(['video'], {type: 'video/mp4'})),
-    );
-    const candidate: Candidate = {
-      runNumber: 1,
-      durationSeconds: 4,
-      model: 'veo-1',
-      prompt: 'original',
-      generateAudio: true,
-      resolution: '1080p',
-      video: {path: 'video/original.mp4', url: 'https://video/original.mp4'},
-    };
-    const scene: GeneratedScene = {
-      id: 'snapshot-scene',
-      type: 'generated',
-      name: 'Original Scene',
-      prompt: 'test',
-      selectedCandidateIndex: 0,
-      candidates: [candidate],
-    };
-    projectConfigSignal.update(config => ({...config, storyboard: [scene]}));
-    component.selectScene(scene.id);
-    fixture.detectChanges();
-    const button = fixture.nativeElement.querySelector(
-      '[aria-label="Download original"]',
-    ) as HTMLButtonElement;
-    const anchor = document.createElement('a');
-    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
-    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:snapshot');
-    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
-    vi.spyOn(anchor, 'click').mockImplementation(() => undefined);
+      const button = fixture.nativeElement.querySelector(
+        '[aria-label="Download original"]',
+      ) as HTMLButtonElement;
+      expect(button.disabled).toBe(true);
+      expect(mockMediaService.resolve).not.toHaveBeenCalled();
+    });
 
-    const resolveCallsBeforeDownload =
-      mockMediaService.resolve.mock.calls.length;
-    button.click();
-    button.click();
-    expect(mockMediaService.resolve).toHaveBeenCalledTimes(
-      resolveCallsBeforeDownload + 1,
-    );
-    candidate.video = {
-      path: 'video/renamed.webm',
-      url: 'https://video/renamed.webm',
-    };
-    projectConfigSignal.update(config => ({...config, name: 'Renamed'}));
-    resolveMedia('https://signed/original.mp4');
-    await fixture.whenStable();
+    it('keeps the click-time candidate and filename while media resolution is pending', async () => {
+      let resolveMedia!: (url: string) => void;
+      mockMediaService.resolve.mockImplementation(
+        () => new Promise<string>(resolve => (resolveMedia = resolve)),
+      );
+      mockHttpClient.get.mockReturnValue(
+        of(new Blob(['video'], {type: 'video/mp4'})),
+      );
+      const candidate: Candidate = {
+        runNumber: 1,
+        durationSeconds: 4,
+        model: 'veo-1',
+        prompt: 'original',
+        generateAudio: true,
+        resolution: '1080p',
+        video: {path: 'video/original.mp4', url: 'https://video/original.mp4'},
+      };
+      const scene: GeneratedScene = {
+        id: 'snapshot-scene',
+        type: 'generated',
+        name: 'Original Scene',
+        prompt: 'test',
+        selectedCandidateIndex: 0,
+        candidates: [candidate],
+      };
+      projectConfigSignal.update(config => ({...config, storyboard: [scene]}));
+      component.selectScene(scene.id);
+      fixture.detectChanges();
+      const button = fixture.nativeElement.querySelector(
+        '[aria-label="Download original"]',
+      ) as HTMLButtonElement;
+      expect(document.createElement('div')).toBeInstanceOf(HTMLDivElement);
 
-    expect(anchor.download).toBe('Test_Project_Original_Scene_1A_original.mp4');
+      const resolveCallsBeforeDownload =
+        mockMediaService.resolve.mock.calls.length;
+      button.click();
+      button.click();
+      expect(mockMediaService.resolve).toHaveBeenCalledTimes(
+        resolveCallsBeforeDownload + 1,
+      );
+      candidate.video = {
+        path: 'video/renamed.webm',
+        url: 'https://video/renamed.webm',
+      };
+      projectConfigSignal.update(config => ({...config, name: 'Renamed'}));
+      resolveMedia('https://signed/original.mp4');
+      await fixture.whenStable();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(anchor.download).toBe(
+        'Test_Project_Original_Scene_1A_original.mp4',
+      );
+    });
   });
 });

--- a/ui/src/app/storyboard/storyboard.ts
+++ b/ui/src/app/storyboard/storyboard.ts
@@ -19,18 +19,24 @@ import {
   DragDropModule,
   moveItemInArray,
 } from '@angular/cdk/drag-drop';
+import {HttpClient} from '@angular/common/http';
 import {DatePipe, DecimalPipe} from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   ElementRef,
   HostListener,
   inject,
+  DestroyRef,
   signal,
   viewChild,
 } from '@angular/core';
 import {FormsModule} from '@angular/forms';
+import {NavigationStart, Router} from '@angular/router';
+import {filter, firstValueFrom, Subject, takeUntil} from 'rxjs';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {MatButtonModule} from '@angular/material/button';
 import {MatChipsModule} from '@angular/material/chips';
 import {MatDialog, MatDialogModule} from '@angular/material/dialog';
@@ -55,6 +61,7 @@ import {
 } from '../services/config/config';
 import {ImageImportService} from '../services/image-import/image-import';
 import {MediaSrcPipe} from '../services/media/media-src.pipe';
+import {MediaService} from '../services/media/media';
 import {RemixEngineService} from '../services/remix-engine/remix-engine';
 import {EditableProjectTitle} from '../shared/editable-project-title/editable-project-title';
 import {
@@ -102,6 +109,50 @@ export class Storyboard {
   private clientMediaService = inject(ClientMediaService);
   private imageImport = inject(ImageImportService);
   private snackBar = inject(MatSnackBar);
+  private httpClient = inject(HttpClient);
+  private mediaService = inject(MediaService);
+  private destroyRef = inject(DestroyRef);
+  private router = inject(Router);
+  private downloadCancel$ = new Subject<void>();
+  private pendingObjectUrlCleanups = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+  private downloadEpoch = 0;
+  private lastProjectId: string | undefined;
+  readonly downloadInProgress = signal(false);
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      this.downloadEpoch++;
+      this.cancelDownload();
+      for (const [objectUrl, timer] of this.pendingObjectUrlCleanups) {
+        clearTimeout(timer);
+        URL.revokeObjectURL(objectUrl);
+      }
+      this.pendingObjectUrlCleanups.clear();
+    });
+    this.router.events
+      .pipe(filter(event => event instanceof NavigationStart))
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.downloadEpoch++;
+        this.cancelDownload();
+        this.downloadInProgress.set(false);
+      });
+    effect(() => {
+      const projectId = this.config.projectConfig.value().id;
+      if (
+        this.lastProjectId !== undefined &&
+        projectId !== this.lastProjectId
+      ) {
+        this.downloadEpoch++;
+        this.cancelDownload();
+        this.downloadInProgress.set(false);
+      }
+      this.lastProjectId = projectId;
+    });
+  }
 
   videoElement = viewChild<ElementRef<HTMLVideoElement>>('mainVideo');
   timelineTrack = viewChild<ElementRef<HTMLElement>>('timelineTrack');
@@ -819,6 +870,139 @@ export class Storyboard {
     scene.referenceImage = scene.candidates![index].referenceImage;
     this.updateScenes();
     this.isVideoPlaying.set(false);
+  }
+
+  downloadOriginal() {
+    const scene = this.selectedScene();
+    const candidate = this.selectedCandidate();
+    const video = candidate?.video;
+    if (
+      this.downloadInProgress() ||
+      !scene ||
+      !candidate ||
+      !video ||
+      (!video.path && !video.url)
+    ) {
+      return;
+    }
+
+    const epoch = ++this.downloadEpoch;
+    const project = this.config.projectConfig.value();
+    const projectId = project.id;
+    const projectName = project.name;
+    const sceneName = scene.name;
+    const source = {...video};
+    const label =
+      this.runLabels().get(candidate) ?? `run${candidate.runNumber}`;
+    const sourceExtension = this.mediaExtension(source);
+    const filenameBase = this.originalFilename(
+      projectName,
+      sceneName,
+      label,
+      sourceExtension ?? 'mp4',
+    );
+    this.downloadInProgress.set(true);
+    this.downloadCancel$ = new Subject<void>();
+    const cancel$ = this.downloadCancel$;
+
+    void (async () => {
+      try {
+        const url = await this.mediaService.resolve(source);
+        if (!url) {
+          throw new Error('Original media URL is unavailable.');
+        }
+        if (
+          epoch !== this.downloadEpoch ||
+          this.config.projectConfig.value().id !== projectId
+        ) {
+          return;
+        }
+        const blob = await firstValueFrom(
+          this.httpClient
+            .get(url, {responseType: 'blob'})
+            .pipe(takeUntil(cancel$)),
+        );
+        if (
+          epoch !== this.downloadEpoch ||
+          this.config.projectConfig.value().id !== projectId
+        ) {
+          return;
+        }
+        const filename =
+          sourceExtension === undefined
+            ? this.originalFilename(
+                projectName,
+                sceneName,
+                label,
+                this.mimeExtension(blob.type),
+              )
+            : filenameBase;
+        const objectUrl = URL.createObjectURL(blob);
+        const cleanupTimer = setTimeout(() => {
+          URL.revokeObjectURL(objectUrl);
+          this.pendingObjectUrlCleanups.delete(objectUrl);
+        }, 0);
+        this.pendingObjectUrlCleanups.set(objectUrl, cleanupTimer);
+        const anchor = document.createElement('a');
+        anchor.href = objectUrl;
+        anchor.download = filename;
+        anchor.click();
+      } catch {
+        if (epoch === this.downloadEpoch) {
+          this.snackBar.open('Failed to download original video.', 'Dismiss');
+        }
+      } finally {
+        if (epoch === this.downloadEpoch) {
+          this.downloadInProgress.set(false);
+        }
+      }
+    })();
+  }
+
+  private cancelDownload() {
+    this.downloadCancel$.next();
+    this.downloadCancel$.complete();
+    this.downloadCancel$ = new Subject<void>();
+    this.downloadInProgress.set(false);
+  }
+
+  private originalFilename(
+    projectName: string,
+    sceneName: string,
+    label: string,
+    extension: string,
+  ): string {
+    const sanitize = (value: string) =>
+      value.replace(/[^a-zA-Z0-9._-]+/g, '_').replace(/^_+|_+$/g, '') ||
+      'untitled';
+    return `${sanitize(projectName)}_${sanitize(sceneName)}_${sanitize(label)}_original.${extension}`;
+  }
+
+  private mediaExtension(media: {
+    path?: string;
+    url?: string;
+  }): string | undefined {
+    const source = media.path || media.url;
+    if (!source) {
+      return undefined;
+    }
+    try {
+      const pathname = new URL(source, window.location.href).pathname;
+      return pathname.match(/\.([a-z0-9]+)$/i)?.[1];
+    } catch {
+      return source.match(/\.([a-z0-9]+)$/i)?.[1];
+    }
+  }
+
+  private mimeExtension(mimeType: string): string {
+    const subtype = mimeType.split('/')[1]?.split(';')[0];
+    const knownExtensions: Record<string, string> = {
+      mp4: 'mp4',
+      webm: 'webm',
+      quicktime: 'mov',
+      'x-msvideo': 'avi',
+    };
+    return (subtype && knownExtensions[subtype]) || 'bin';
   }
 
   updateScenes(scene?: GeneratedScene | ProvidedVideoScene) {

--- a/ui/src/app/storyboard/storyboard.ts
+++ b/ui/src/app/storyboard/storyboard.ts
@@ -113,7 +113,7 @@ export class Storyboard {
   private mediaService = inject(MediaService);
   private destroyRef = inject(DestroyRef);
   private router = inject(Router);
-  private downloadCancel$ = new Subject<void>();
+  private downloadCancel = new Subject<void>();
   private pendingObjectUrlCleanups = new Map<
     string,
     ReturnType<typeof setTimeout>
@@ -902,8 +902,8 @@ export class Storyboard {
       sourceExtension ?? 'mp4',
     );
     this.downloadInProgress.set(true);
-    this.downloadCancel$ = new Subject<void>();
-    const cancel$ = this.downloadCancel$;
+    this.downloadCancel = new Subject<void>();
+    const cancel = this.downloadCancel;
 
     void (async () => {
       try {
@@ -920,7 +920,7 @@ export class Storyboard {
         const blob = await firstValueFrom(
           this.httpClient
             .get(url, {responseType: 'blob'})
-            .pipe(takeUntil(cancel$)),
+            .pipe(takeUntil(cancel)),
         );
         if (
           epoch !== this.downloadEpoch ||
@@ -960,9 +960,9 @@ export class Storyboard {
   }
 
   private cancelDownload() {
-    this.downloadCancel$.next();
-    this.downloadCancel$.complete();
-    this.downloadCancel$ = new Subject<void>();
+    this.downloadCancel.next();
+    this.downloadCancel.complete();
+    this.downloadCancel = new Subject<void>();
     this.downloadInProgress.set(false);
   }
 


### PR DESCRIPTION
## Summary

Add an explicit original-video download control to the Storyboard player.

The download delivers that candidate's original provider/uploaded file without applying saved trims or the audio-use preference. Existing processed scene downloads on the Output page are unchanged. Missing media and download failures are handled without changing the selected candidate.

## Victor review follow-up

Removed Observable `$` suffixes and isolated/restored the download tests' global DOM mocks. Controls stay within the player; narrow/portrait players give the trim timeline its own row, and the volume popup is bounded by the player instead of clipping outside it.

## Validation

Node 22.22.3/npm 10.9.3. The final #180–#184 source tree (combined head `a0b1753`, byte-identical verification tree `ce14111`) passes all 507 UI tests in 34 files, compile, spec typecheck, lint and production build. Production dependency audit reports zero vulnerabilities.

The combined stack also passes 644 backend tests plus 15 subtests, action-signature validation, Bash syntax and ShellCheck. Existing SDK deprecation/signature warnings remain non-failing.

Chrome checks at 375, 768, 1024 and 1440px verify landscape and portrait control bounds, a usable trim timeline, and keyboard-accessible volume adjustment. Original-download delivery retains the earlier controlled-media regression coverage.

No live Firestore changes, provider generation, deployment or reviewer messages were made for this update.

## Stack

PR #179 is merged. This PR is rebased onto `main` and targets `main`; #181 remains stacked on this branch.

## Review follow-up — 13 September

Release dependency: the original-file blob download needs the deployment CORS correction carried by #182. Include that correction in the minimum deployable release (or deploy these slices together); do not release #180 alone against a bucket that lacks its app origin. Verify original download from every supported deployed app origin during the release smoke test. No new deployment or origin-by-origin smoke was performed for this review. No download proxy is introduced.


## Current publication validation

PR head: `23f5095 (unchanged)`. Fresh integrated stack at #192 `f454c25`: **645 UI tests in 42 files**, compile, lint and spec typecheck pass on Node22.22.3/npm10.9.3. Production build passes on the identical runtime tree before the final test-only addition. The final backend tree passes **678 tests plus15 subtests** on Python3.13; action signatures, status-viewer tests, ShellCheck, Bash syntax and whitespace checks pass. The separate Python3.11/3.12 CI matrix was not run locally.

#191 independently passes **636 UI tests in41files** at its own final head `31a5be8`. This is local QA, not a new deployment or a claim of fresh application CI on stacked bases. Full upstream application CI remains required after parent merge/rebase/retarget to `main`.

